### PR TITLE
chore: try spawning a process with 'windowsVerbatimArguments: true'

### DIFF
--- a/tests/__utils__/spawnTyche.ts
+++ b/tests/__utils__/spawnTyche.ts
@@ -19,6 +19,7 @@ export function spawnTyche(
       ["TSTYCHE_NO_COLOR"]: "on",
     },
     shell: true,
+    windowsVerbatimArguments: true,
   });
 
   if (error) {


### PR DESCRIPTION
What happens on Windows if a process gets spawned with 'windowsVerbatimArguments: true'?