### PR TITLE
fix(store): normalize `installationPath` path output

### DIFF
--- a/src/store/CompilerModuleWorker.ts
+++ b/src/store/CompilerModuleWorker.ts
@@ -41,7 +41,7 @@ export class CompilerModuleWorker {
       return tsserverFilePath;
     }
 
-    EventEmitter.dispatch(["store:info", { compilerVersion, installationPath }]);
+    EventEmitter.dispatch(["store:info", { compilerVersion, installationPath: this.#normalizePath(installationPath) }]);
 
     await fs.mkdir(installationPath, { recursive: true });
 
@@ -125,5 +125,13 @@ export class CompilerModuleWorker {
         reject(new Error(`Process exited with code ${String(code)}.`));
       });
     });
+  }
+
+  #normalizePath(filePath: string) {
+    if (path.sep === "/") {
+      return filePath;
+    }
+
+    return filePath.replace(/\\/g, "/");
   }
 }

--- a/tests/__utils__/spawnTyche.ts
+++ b/tests/__utils__/spawnTyche.ts
@@ -11,12 +11,14 @@ function normalizeOutput(output: string) {
 export function spawnTyche(
   fixture: string,
   args?: Array<string>,
+  env?: Record<string, string>,
 ): { status: number | null; stderr: string; stdout: string } {
   const { error, status, stderr, stdout } = spawnSync("tstyche", args, {
     cwd: getFixtureUrl(fixture),
     env: {
       ...process.env,
       ["TSTYCHE_NO_COLOR"]: "on",
+      ...env,
     },
     shell: true,
     windowsVerbatimArguments: true,

--- a/tests/command-line-options.test.ts
+++ b/tests/command-line-options.test.ts
@@ -20,6 +20,67 @@ afterEach(async () => {
 });
 
 describe("command line options", () => {
+  describe("'--install' option", () => {
+    test("default", async () => {
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--install"], { ["TSTYCHE_STORE_PATH"]: "./.store" });
+
+      expect(stdout).toMatch(
+        /^adds TypeScript \d\.\d\.\d to <<cwd>>\/tests\/__fixtures__\/command-line-options\/\.store\/\d\.\d\.\d/,
+      );
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("with 'target' configuration option", async () => {
+      const config = { target: ["4.8", "5.0"] };
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--install"], { ["TSTYCHE_STORE_PATH"]: "./.store" });
+
+      expect(stdout).toMatchInlineSnapshot(`
+        "adds TypeScript 4.8.4 to <<cwd>>/tests/__fixtures__/command-line-options/.store/4.8.4
+        adds TypeScript 5.0.4 to <<cwd>>/tests/__fixtures__/command-line-options/.store/5.0.4
+        "
+      `);
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("with '--target' command line options", async () => {
+      const config = { target: ["5.0", "latest"] };
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--install --target 4.9"], {
+        ["TSTYCHE_STORE_PATH"]: "./.store",
+      });
+
+      expect(stdout).toMatchInlineSnapshot(`
+        "adds TypeScript 4.9.5 to <<cwd>>/tests/__fixtures__/command-line-options/.store/4.9.5
+        "
+      `);
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+  });
+
   test("'--target' option", async () => {
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: isStringTestText,


### PR DESCRIPTION
Adding end-to-end test for the `--target` command line option.