### PR TITLE
fix(checker): clean up error messages of primitive type matchers

### DIFF
--- a/src/checker/Checker.ts
+++ b/src/checker/Checker.ts
@@ -262,7 +262,9 @@ export class Checker {
 
     return [
       Diagnostic.error(
-        assertion.isNot ? `Type '${sourceText}' is '${targetText}'.` : `Type '${sourceText}' is not '${targetText}'.`,
+        assertion.isNot
+          ? `Type '${targetText}' is identical to type '${sourceText}'.`
+          : `Type '${targetText}' is not identical to type '${sourceText}'.`,
         origin,
       ),
     ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ interface Test {
 
 interface Matchers {
   /**
-   * Checks if the source type is `any`.
+   * Checks if the `any` type is identical to the source type.
    */
   toBeAny: () => void;
   /**
@@ -79,47 +79,47 @@ interface Matchers {
     (target: unknown): void;
   };
   /**
-   * Checks if the source type is `bigint`.
+   * Checks if the `bigint` type is identical to the source type.
    */
   toBeBigInt: () => void;
   /**
-   * Checks if the source type is `boolean`.
+   * Checks if the `boolean` type is identical to the source type.
    */
   toBeBoolean: () => void;
   /**
-   * Checks if the source type is `never`.
+   * Checks if the `never` type is identical to the source type.
    */
   toBeNever: () => void;
   /**
-   * Checks if the source type is `null`.
+   * Checks if the `null` type is identical to the source type.
    */
   toBeNull: () => void;
   /**
-   * Checks if the source type is `number`.
+   * Checks if the `number` type is identical to the source type.
    */
   toBeNumber: () => void;
   /**
-   * Checks if the source type is `string`.
+   * Checks if the `string` type is identical to the source type.
    */
   toBeString: () => void;
   /**
-   * Checks if the source type is `symbol`.
+   * Checks if the `symbol` type is identical to the source type.
    */
   toBeSymbol: () => void;
   /**
-   * Checks if the source type is `undefined`.
+   * Checks if the `undefined` type is identical to the source type.
    */
   toBeUndefined: () => void;
   /**
-   * Checks if the source type is `unique symbol`.
+   * Checks if the `unique symbol` type is identical to the source type.
    */
   toBeUniqueSymbol: () => void;
   /**
-   * Checks if the source type is `unknown`.
+   * Checks if the `unknown` type is identical to the source type.
    */
   toBeUnknown: () => void;
   /**
-   * Checks if the source type is `void`.
+   * Checks if the `void` type is identical to the source type.
    */
   toBeVoid: () => void;
   /**

--- a/tests/__snapshots__/api-expect.test.ts.snap
+++ b/tests/__snapshots__/api-expect.test.ts.snap
@@ -240,7 +240,7 @@ Ran test files matching 'expect-skip.test.ts'.
 `;
 
 exports[`expect: stderr 1`] = `
-"Error: Type 'void' is not 'undefined'.
+"Error: Type 'undefined' is not identical to type 'void'.
 
    5 | });
    6 | 
@@ -252,7 +252,7 @@ exports[`expect: stderr 1`] = `
 
        at ./__typetests__/top-level-expect.tst.ts:7:21
 
-Error: Type 'number' is not 'void'.
+Error: Type 'void' is not identical to type 'number'.
 
   10 |   test("is number?", () => {
   11 |     expect<number>().type.toBeNumber();
@@ -264,7 +264,7 @@ Error: Type 'number' is not 'void'.
 
        at ./__typetests__/top-level-expect.tst.ts:12:27 ❭ is describe? ❭ is number?
 
-Error: Type 'number' is not 'void'.
+Error: Type 'void' is not identical to type 'number'.
 
   15 | 
   16 | expect<null>().type.toBeNull();
@@ -296,7 +296,7 @@ Ran test files matching 'top-level-expect.tst.ts'.
 `;
 
 exports[`handles '--failFast' option: stderr 1`] = `
-"Error: Type 'void' is not 'undefined'.
+"Error: Type 'undefined' is not identical to type 'void'.
 
    5 | });
    6 | 

--- a/tests/__snapshots__/api-toBeAny.test.ts.snap
+++ b/tests/__snapshots__/api-toBeAny.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeAny: stderr 1`] = `
-"Error: Type 'string' is not 'any'.
+"Error: Type 'any' is not identical to type 'string'.
 
   13 |   expect(returnsAny()).type.toBeAny();
   14 | 
@@ -13,7 +13,7 @@ exports[`toBeAny: stderr 1`] = `
 
        at ./__typetests__/toBeAny.test.ts:15:32 ❭ is any?
 
-Error: Type 'any' is 'any'.
+Error: Type 'any' is identical to type 'any'.
 
   19 |   expect(returnsString()).type.not.toBeAny();
   20 | 

--- a/tests/__snapshots__/api-toBeBigInt.test.ts.snap
+++ b/tests/__snapshots__/api-toBeBigInt.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeBigInt: stderr 1`] = `
-"Error: Type 'void' is not 'bigint'.
+"Error: Type 'bigint' is not identical to type 'void'.
 
   12 |   expect(returnsBigInt()).type.toBeBigInt();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeBigInt: stderr 1`] = `
 
        at ./__typetests__/toBeBigInt.test.ts:14:30 ❭ is bigint?
 
-Error: Type 'bigint' is 'bigint'.
+Error: Type 'bigint' is identical to type 'bigint'.
 
   18 |   expect(returnsVoid()).type.not.toBeBigInt();
   19 | 

--- a/tests/__snapshots__/api-toBeBoolean.test.ts.snap
+++ b/tests/__snapshots__/api-toBeBoolean.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeBoolean: stderr 1`] = `
-"Error: Type 'string' is not 'boolean'.
+"Error: Type 'boolean' is not identical to type 'string'.
 
   12 |   expect(returnsBoolean()).type.toBeBoolean();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeBoolean: stderr 1`] = `
 
        at ./__typetests__/toBeBoolean.test.ts:14:32 ❭ is boolean?
 
-Error: Type 'boolean' is 'boolean'.
+Error: Type 'boolean' is identical to type 'boolean'.
 
   18 |   expect(returnsString()).type.not.toBeBoolean();
   19 | 

--- a/tests/__snapshots__/api-toBeNever.test.ts.snap
+++ b/tests/__snapshots__/api-toBeNever.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeNever: stderr 1`] = `
-"Error: Type 'string' is not 'never'.
+"Error: Type 'never' is not identical to type 'string'.
 
   12 |   expect(returnsNever()).type.toBeNever();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeNever: stderr 1`] = `
 
        at ./__typetests__/toBeNever.test.ts:14:32 ❭ is never?
 
-Error: Type 'never' is 'never'.
+Error: Type 'never' is identical to type 'never'.
 
   18 |   expect(returnsString()).type.not.toBeNever();
   19 | 

--- a/tests/__snapshots__/api-toBeNull.test.ts.snap
+++ b/tests/__snapshots__/api-toBeNull.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeNull: stderr 1`] = `
-"Error: Type 'void' is not 'null'.
+"Error: Type 'null' is not identical to type 'void'.
 
   12 |   expect(returnsNull()).type.toBeNull();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeNull: stderr 1`] = `
 
        at ./__typetests__/toBeNull.test.ts:14:30 ❭ is null?
 
-Error: Type 'null' is 'null'.
+Error: Type 'null' is identical to type 'null'.
 
   18 |   expect(returnsVoid()).type.not.toBeNull();
   19 | 

--- a/tests/__snapshots__/api-toBeNumber.test.ts.snap
+++ b/tests/__snapshots__/api-toBeNumber.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeNumber: stderr 1`] = `
-"Error: Type 'void' is not 'number'.
+"Error: Type 'number' is not identical to type 'void'.
 
   12 |   expect(returnsNumber()).type.toBeNumber();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeNumber: stderr 1`] = `
 
        at ./__typetests__/toBeNumber.test.ts:14:30 ❭ is number?
 
-Error: Type 'number' is 'number'.
+Error: Type 'number' is identical to type 'number'.
 
   18 |   expect(returnsVoid()).type.not.toBeNumber();
   19 | 

--- a/tests/__snapshots__/api-toBeString.test.ts.snap
+++ b/tests/__snapshots__/api-toBeString.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeString: stderr 1`] = `
-"Error: Type 'void' is not 'string'.
+"Error: Type 'string' is not identical to type 'void'.
 
   12 |   expect(returnsString()).type.toBeString();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeString: stderr 1`] = `
 
        at ./__typetests__/toBeString.test.ts:14:30 ❭ is string?
 
-Error: Type 'string' is 'string'.
+Error: Type 'string' is identical to type 'string'.
 
   18 |   expect(returnsVoid()).type.not.toBeString();
   19 | 

--- a/tests/__snapshots__/api-toBeSymbol.test.ts.snap
+++ b/tests/__snapshots__/api-toBeSymbol.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeSymbol: stderr 1`] = `
-"Error: Type 'void' is not 'symbol'.
+"Error: Type 'symbol' is not identical to type 'void'.
 
   12 |   expect(returnsSymbol()).type.toBeSymbol();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeSymbol: stderr 1`] = `
 
        at ./__typetests__/toBeSymbol.test.ts:14:30 ❭ is symbol?
 
-Error: Type 'symbol' is 'symbol'.
+Error: Type 'symbol' is identical to type 'symbol'.
 
   18 |   expect(returnsVoid()).type.not.toBeSymbol();
   19 | 

--- a/tests/__snapshots__/api-toBeUndefined.test.ts.snap
+++ b/tests/__snapshots__/api-toBeUndefined.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeUndefined: stderr 1`] = `
-"Error: Type 'string' is not 'undefined'.
+"Error: Type 'undefined' is not identical to type 'string'.
 
   12 |   expect(returnsUndefined()).type.toBeUndefined();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeUndefined: stderr 1`] = `
 
        at ./__typetests__/toBeUndefined.test.ts:14:32 ❭ is undefined?
 
-Error: Type 'undefined' is 'undefined'.
+Error: Type 'undefined' is identical to type 'undefined'.
 
   18 |   expect(returnsString()).type.not.toBeUndefined();
   19 | 

--- a/tests/__snapshots__/api-toBeUniqueSymbol.test.ts.snap
+++ b/tests/__snapshots__/api-toBeUniqueSymbol.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeUniqueSymbol: stderr 1`] = `
-"Error: Type 'void' is not 'unique symbol'.
+"Error: Type 'unique symbol' is not identical to type 'void'.
 
   14 |   expect(returnsUniqueSymbol()).type.toBeUniqueSymbol();
   15 | 
@@ -13,7 +13,7 @@ exports[`toBeUniqueSymbol: stderr 1`] = `
 
        at ./__typetests__/toBeUniqueSymbol.test.ts:16:30 ❭ is unique symbol?
 
-Error: Type 'unique symbol' is 'unique symbol'.
+Error: Type 'unique symbol' is identical to type 'unique symbol'.
 
   20 |   expect(returnsVoid()).type.not.toBeUniqueSymbol();
   21 | 

--- a/tests/__snapshots__/api-toBeUnknown.test.ts.snap
+++ b/tests/__snapshots__/api-toBeUnknown.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeUnknown: stderr 1`] = `
-"Error: Type 'string' is not 'unknown'.
+"Error: Type 'unknown' is not identical to type 'string'.
 
   12 |   expect(returnsUnknown()).type.toBeUnknown();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeUnknown: stderr 1`] = `
 
        at ./__typetests__/toBeUnknown.test.ts:14:32 ❭ is unknown?
 
-Error: Type 'unknown' is 'unknown'.
+Error: Type 'unknown' is identical to type 'unknown'.
 
   18 |   expect(returnsString()).type.not.toBeUnknown();
   19 | 

--- a/tests/__snapshots__/api-toBeVoid.test.ts.snap
+++ b/tests/__snapshots__/api-toBeVoid.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toBeVoid: stderr 1`] = `
-"Error: Type 'string' is not 'void'.
+"Error: Type 'void' is not identical to type 'string'.
 
   12 |   expect(returnsVoid()).type.toBeVoid();
   13 | 
@@ -13,7 +13,7 @@ exports[`toBeVoid: stderr 1`] = `
 
        at ./__typetests__/toBeVoid.test.ts:14:32 ❭ is void?
 
-Error: Type 'void' is 'void'.
+Error: Type 'void' is identical to type 'void'.
 
   18 |   expect(returnsString()).type.not.toBeVoid();
   19 | 


### PR DESCRIPTION
The behaviour of primitive type matchers and the `.toEqual()` matcher is the same. Their error messages should be the same too.