### PR TITLE
chore: drop support for Node.js 16

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["16.14", "16.x", "18.x", "20.x", "21.x"]
+        node-version: ["18.12.0", "18.x", "20.x", "21.x"]
     runs-on: ubuntu-latest
 
     steps:
@@ -70,18 +70,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: corepack enable
       - run: yarn install
-        env:
-          YARN_IGNORE_NODE: true # TODO remove after dropping support for Node.js 16
       - run: yarn build
-        env:
-          YARN_IGNORE_NODE: true # TODO remove after dropping support for Node.js 16
       - run: yarn test
         env:
           FORCE_COLOR: true
-          YARN_IGNORE_NODE: true # TODO remove after dropping support for Node.js 16
 
   test-os:
-    name: Test Build on ${{ matrix.os }} using Node.js LTS
+    name: Test Build on ${{ matrix.os }}
     needs:
       - typecheck
     strategy:

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
   },
   "packageManager": "yarn@4.0.2",
   "engines": {
-    "node": "^16.14 || 18.x || >=20.x"
+    "node": "^18.12.0 || >=20.x"
   }
 }

--- a/src/collect/IdentifierLookup.ts
+++ b/src/collect/IdentifierLookup.ts
@@ -29,11 +29,7 @@ export class IdentifierLookup {
   }
 
   clone(): Identifiers {
-    // TODO use 'structuredClone()' after dropping support for Node.js 16
-    return {
-      namedImports: { ...this.#identifiers.namedImports },
-      namespace: this.#identifiers.namespace,
-    };
+    return structuredClone(this.#identifiers);
   }
 
   handleImportDeclaration(node: ts.ImportDeclaration): void {

--- a/src/store/ManifestWorker.ts
+++ b/src/store/ManifestWorker.ts
@@ -1,3 +1,5 @@
+/// <reference lib="es2023" />
+
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import https from "node:https";
@@ -92,7 +94,7 @@ export class ManifestWorker {
 
     let packageMetadata: PackageMetadata | undefined;
 
-    // TODO use 'AbortSignal.any()' after dropping support for Node.js 16
+    // TODO use 'AbortSignal.any()' after dropping support for Node.js 18
     const abortController = new AbortController();
 
     const timeoutSignal = AbortSignal.timeout(this.#timeout);
@@ -137,8 +139,7 @@ export class ManifestWorker {
     const minorVersions = [...new Set(manifest.versions.map((version) => version.slice(0, -2)))];
 
     for (const tag of minorVersions) {
-      // TODO use 'findLast()' after dropping support for Node.js 16
-      const resolvedVersion = manifest.versions.filter((version) => version.startsWith(tag)).pop();
+      const resolvedVersion = manifest.versions.findLast((version) => version.startsWith(tag));
 
       if (resolvedVersion != null) {
         manifest.resolutions[tag] = resolvedVersion;


### PR DESCRIPTION
Dropping support for Node.js 16, because it is an End-of-Life version already.