### PR TITLE
fix(runner): tune up behavior of run mode flags

### DIFF
--- a/tests/__fixtures__/api-describe/__typetests__/describe-only.test.ts
+++ b/tests/__fixtures__/api-describe/__typetests__/describe-only.test.ts
@@ -5,15 +5,19 @@ jest.test("'describe.only' implementation'", () => {
   jest.expect(describe.only).toBeInstanceOf(Function);
 });
 
-describe("is describe?", () => {
+describe("is skipped describe?", () => {
+  const a: string = 123;
+
   test("is skipped?", () => {
+    const b: number = "abc";
+
     expect<void>().type.toBeVoid();
   });
 });
 
 describe.only("is only describe?", () => {
-  test("is never?", () => {
-    expect<never>().type.toBeNever();
+  test("is number?", () => {
+    expect<number>().type.toBeNumber();
   });
 
   test.skip("is skipped?", () => {

--- a/tests/__fixtures__/api-describe/__typetests__/describe-skip.test.ts
+++ b/tests/__fixtures__/api-describe/__typetests__/describe-skip.test.ts
@@ -6,7 +6,11 @@ jest.test("'describe.skip' implementation'", () => {
 });
 
 describe.skip("is skipped describe?", () => {
+  const a: string = 123;
+
   test("is skipped?", () => {
+    const b: number = "abc";
+
     expect<string>().type.toBeString();
   });
 });

--- a/tests/__fixtures__/api-describe/__typetests__/describe-todo.test.ts
+++ b/tests/__fixtures__/api-describe/__typetests__/describe-todo.test.ts
@@ -11,6 +11,8 @@ describe.todo("is todo describe too?", () => {
   const a: string = 123;
 
   test("is todo?", () => {
+    const b: number = "abc";
+
     expect(a).type.toBeString();
   });
 });

--- a/tests/__fixtures__/api-expect/__typetests__/expect-only-fail.test.ts
+++ b/tests/__fixtures__/api-expect/__typetests__/expect-only-fail.test.ts
@@ -10,9 +10,9 @@ expect.only.fail<string>().type.toBeString();
 
 expect.only.fail<never>().type.toBeString();
 
-describe("is describe?", () => {
-  test("is string?", () => {
-    expect<string>().type.toBeString();
+describe("is skipped describe?", () => {
+  test("is skipped?", () => {
+    expect<never>().type.toBeVoid();
     expect.only.fail<string>().type.toBeString();
 
     expect.only.fail<never>().type.toBeVoid();
@@ -25,11 +25,11 @@ describe("is skipped describe?", () => {
   });
 });
 
-test("is number?", () => {
-  expect<number>().type.toBeNumber();
-  expect.only.fail<number>().type.toBeNumber();
+test.only("is number?", () => {
+  expect.skip<string>().type.toBeNumber();
+  expect.fail<number>().type.toBeNumber();
 
-  expect.only.fail<never>().type.toBeVoid();
+  expect.fail<never>().type.toBeVoid();
 });
 
 test("is skipped?", () => {

--- a/tests/__fixtures__/api-expect/__typetests__/expect-only.test.ts
+++ b/tests/__fixtures__/api-expect/__typetests__/expect-only.test.ts
@@ -9,9 +9,9 @@ expect.only<string>().type.toBeString();
 expect<never>().type.toBeString();
 
 describe("is describe?", () => {
-  test("is string?", () => {
-    expect.only<string>().type.toBeString();
+  test("is skipped?", () => {
     expect<never>().type.toBeVoid();
+    expect.only<string>().type.toBeString();
   });
 });
 
@@ -21,9 +21,9 @@ describe("is skipped describe?", () => {
   });
 });
 
-test("is number?", () => {
-  expect.only<number>().type.toBeNumber();
-  expect<never>().type.toBeVoid();
+test.only("is number?", () => {
+  expect<number>().type.toBeNumber();
+  expect.skip<never>().type.toBeVoid();
 });
 
 test("is skipped?", () => {

--- a/tests/__fixtures__/api-expect/__typetests__/expect-skip.test.ts
+++ b/tests/__fixtures__/api-expect/__typetests__/expect-skip.test.ts
@@ -26,6 +26,13 @@ test("is number?", () => {
   expect.skip<never>().type.toBeVoid();
 });
 
+test("is assignable?", () => {
+  let a: string | undefined = "abc";
+  a = undefined;
+
+  expect.skip(a).type.toBeVoid();
+});
+
 test.skip("is skipped?", () => {
   expect<never>().type.toBeString();
 });

--- a/tests/__fixtures__/api-it/__typetests__/it-only.test.ts
+++ b/tests/__fixtures__/api-it/__typetests__/it-only.test.ts
@@ -10,6 +10,8 @@ it.only("is only?", () => {
 });
 
 it("is skipped?", () => {
+  const a: string = 123;
+
   expect("abc" as string).type.toBeString();
 });
 

--- a/tests/__fixtures__/api-it/__typetests__/it-skip.test.ts
+++ b/tests/__fixtures__/api-it/__typetests__/it-skip.test.ts
@@ -6,6 +6,8 @@ jest.test("'it.skip' implementation'", () => {
 });
 
 it.skip("is skipped?", () => {
+  const a: string = 123;
+
   expect("abc" as string).type.toBeString();
 });
 

--- a/tests/__fixtures__/api-it/__typetests__/it-todo.test.ts
+++ b/tests/__fixtures__/api-it/__typetests__/it-todo.test.ts
@@ -15,5 +15,6 @@ it.todo("is todo too?");
 
 it.todo("and this one is todo?", () => {
   const a: string = 123;
+
   expect(a).type.toBeString();
 });

--- a/tests/__fixtures__/api-test/__typetests__/test-only.test.ts
+++ b/tests/__fixtures__/api-test/__typetests__/test-only.test.ts
@@ -10,6 +10,8 @@ test.only("is only?", () => {
 });
 
 test("is skipped?", () => {
+  const a: string = 123;
+
   expect("abc" as string).type.toBeString();
 });
 

--- a/tests/__fixtures__/api-test/__typetests__/test-skip.test.ts
+++ b/tests/__fixtures__/api-test/__typetests__/test-skip.test.ts
@@ -6,6 +6,8 @@ jest.test("'test.skip' implementation'", () => {
 });
 
 test.skip("is skipped?", () => {
+  const a: string = 123;
+
   expect("abc" as string).type.toBeString();
 });
 

--- a/tests/__fixtures__/api-test/__typetests__/test-todo.test.ts
+++ b/tests/__fixtures__/api-test/__typetests__/test-todo.test.ts
@@ -15,5 +15,6 @@ test.todo("is todo too?");
 
 test.todo("and this one is todo?", () => {
   const a: string = 123;
+
   expect(a).type.toBeString();
 });

--- a/tests/__snapshots__/api-describe.test.ts.snap
+++ b/tests/__snapshots__/api-describe.test.ts.snap
@@ -4,10 +4,10 @@ exports[`describe.only: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/describe-only.test.ts
-  is describe?
+  is skipped describe?
     - skip is skipped?
   is only describe?
-    + is never?
+    + is number?
     - skip is skipped?
     - todo is todo?
     + is string?
@@ -25,7 +25,7 @@ pass ./__typetests__/describe-only.test.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      6 skipped, 2 todo, 4 passed, 12 total
-Assertions: 2 skipped, 4 passed, 6 total
+Assertions: 6 skipped, 4 passed, 10 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'only'.
@@ -49,7 +49,7 @@ pass ./__typetests__/describe-skip.test.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      2 skipped, 2 todo, 2 passed, 6 total
-Assertions: 2 passed, 2 total
+Assertions: 2 skipped, 2 passed, 4 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'skip'.
@@ -76,7 +76,7 @@ pass ./__typetests__/describe-todo.test.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      1 skipped, 6 todo, 1 passed, 8 total
-Assertions: 1 passed, 1 total
+Assertions: 1 skipped, 1 passed, 2 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'todo'.

--- a/tests/__snapshots__/api-expect.test.ts.snap
+++ b/tests/__snapshots__/api-expect.test.ts.snap
@@ -83,8 +83,8 @@ Error: The assertion was supposed to fail, but it passed.
 
 Consider removing the '.fail' flag.
 
-  14 |   test("is string?", () => {
-  15 |     expect<string>().type.toBeString();
+  14 |   test("is skipped?", () => {
+  15 |     expect<never>().type.toBeVoid();
 > 16 |     expect.only.fail<string>().type.toBeString();
      |     ^
   17 | 
@@ -97,12 +97,12 @@ Error: The assertion was supposed to fail, but it passed.
 
 Consider removing the '.fail' flag.
 
-  28 | test("is number?", () => {
-  29 |   expect<number>().type.toBeNumber();
-> 30 |   expect.only.fail<number>().type.toBeNumber();
+  28 | test.only("is number?", () => {
+  29 |   expect.skip<string>().type.toBeNumber();
+> 30 |   expect.fail<number>().type.toBeNumber();
      |   ^
   31 | 
-  32 |   expect.only.fail<never>().type.toBeVoid();
+  32 |   expect.fail<never>().type.toBeVoid();
   33 | });
 
        at ./__typetests__/expect-only-fail.test.ts:30:3
@@ -114,8 +114,8 @@ exports[`expect.only.fail: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/expect-only-fail.test.ts
-  is describe?
-    × is string?
+  is skipped describe?
+    - skip is skipped?
   is skipped describe?
     - skip is skipped?
   × is number?
@@ -124,7 +124,7 @@ fail ./__typetests__/expect-only-fail.test.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      2 failed, 2 skipped, 1 todo, 5 total
+Tests:      1 failed, 3 skipped, 1 todo, 5 total
 Assertions: 3 failed, 5 skipped, 3 passed, 11 total
 Duration:   <<timestamp>>
 
@@ -200,7 +200,7 @@ exports[`expect.only: stdout 1`] = `
 
 pass ./__typetests__/expect-only.test.ts
   is describe?
-    + is string?
+    - skip is skipped?
   is skipped describe?
     - skip is skipped?
   + is number?
@@ -209,7 +209,7 @@ pass ./__typetests__/expect-only.test.ts
 
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
-Tests:      2 skipped, 1 todo, 2 passed, 5 total
+Tests:      3 skipped, 1 todo, 1 passed, 5 total
 Assertions: 5 skipped, 3 passed, 8 total
 Duration:   <<timestamp>>
 
@@ -226,13 +226,14 @@ pass ./__typetests__/expect-skip.test.ts
   is skipped describe?
     - skip is skipped?
   + is number?
+  + is assignable?
   - skip is skipped?
   - todo is todo?
 
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
-Tests:      2 skipped, 1 todo, 2 passed, 5 total
-Assertions: 3 skipped, 3 passed, 6 total
+Tests:      2 skipped, 1 todo, 3 passed, 6 total
+Assertions: 6 skipped, 3 passed, 9 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'expect-skip.test.ts'.

--- a/tests/__snapshots__/api-file.test.ts.snap
+++ b/tests/__snapshots__/api-file.test.ts.snap
@@ -55,6 +55,7 @@ pass ./__typetests__/skip-file.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      1 skipped, 1 total
+Assertions: 1 skipped, 1 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'skip-file'.

--- a/tests/__snapshots__/api-imports.test.ts.snap
+++ b/tests/__snapshots__/api-imports.test.ts.snap
@@ -15,7 +15,7 @@ pass ./__typetests__/aliased-import.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      3 skipped, 2 todo, 1 passed, 6 total
-Assertions: 2 skipped, 1 passed, 3 total
+Assertions: 3 skipped, 1 passed, 4 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'aliased'.
@@ -37,7 +37,7 @@ pass ./__typetests__/named-import.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      3 skipped, 2 todo, 1 passed, 6 total
-Assertions: 2 skipped, 1 passed, 3 total
+Assertions: 3 skipped, 1 passed, 4 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'named'.
@@ -59,7 +59,7 @@ pass ./__typetests__/namespace-import.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      3 skipped, 2 todo, 1 passed, 6 total
-Assertions: 2 skipped, 1 passed, 3 total
+Assertions: 3 skipped, 1 passed, 4 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'namespace'.

--- a/tests/__snapshots__/api-it.test.ts.snap
+++ b/tests/__snapshots__/api-it.test.ts.snap
@@ -72,7 +72,7 @@ pass ./__typetests__/it-skip.test.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      2 skipped, 1 passed, 3 total
-Assertions: 1 passed, 1 total
+Assertions: 2 skipped, 1 passed, 3 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'skip'.

--- a/tests/__snapshots__/api-test.test.ts.snap
+++ b/tests/__snapshots__/api-test.test.ts.snap
@@ -72,7 +72,7 @@ pass ./__typetests__/test-skip.test.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      2 skipped, 1 passed, 3 total
-Assertions: 1 passed, 1 total
+Assertions: 2 skipped, 1 passed, 3 total
 Duration:   <<timestamp>>
 
 Ran test files matching 'skip'.


### PR DESCRIPTION
Noticed some difference between explicit `.skip` and implicit skip caused by `.only`.