### PR TITLE
chore: setup smoke test on TypeScript's nightly builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: checks
+name: Checks
 
 on:
   push:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,21 @@
+name: TypeScript's Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  test-types:
+    name: Test Types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
+        with:
+          node-version: lts/*
+      - run: corepack enable
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test:types --target next
+      - run: yarn test:examples --target next


### PR DESCRIPTION
Let's run daily smoke test on TypeScript's nightly builds.