### PR TITLE
refactor: move retry logic to the `Lock` class

### DIFF
--- a/src/store/Lock.ts
+++ b/src/store/Lock.ts
@@ -1,11 +1,17 @@
 import { existsSync, rmSync, writeFileSync } from "node:fs";
 
+export interface IsLockedOptions {
+  onDiagnostic?: (diagnostic: string) => void;
+  signal?: AbortSignal | undefined;
+  timeout?: number;
+}
+
 export class Lock {
   #lockFilePath: string;
   static #lockSuffix = "__lock__";
 
   constructor(targetPath: string) {
-    this.#lockFilePath = Lock.getLockFilePath(targetPath);
+    this.#lockFilePath = Lock.#getLockFilePath(targetPath);
 
     writeFileSync(this.#lockFilePath, "");
 
@@ -14,15 +20,47 @@ export class Lock {
     });
   }
 
-  static getLockFilePath(targetPath: string): string {
+  static #getLockFilePath(targetPath: string): string {
     return `${targetPath}${Lock.#lockSuffix}`;
   }
 
-  static isLocked(targetPath: string): boolean {
-    return existsSync(Lock.getLockFilePath(targetPath));
+  static async isLocked(targetPath: string, options?: IsLockedOptions): Promise<boolean> {
+    let isLocked = existsSync(Lock.#getLockFilePath(targetPath));
+
+    if (!isLocked) {
+      return isLocked;
+    }
+
+    if (options?.timeout == null) {
+      return isLocked;
+    }
+
+    const waitStartTime = Date.now();
+
+    while (isLocked) {
+      if (options.signal?.aborted === true) {
+        break;
+      }
+
+      if (Date.now() - waitStartTime > options.timeout) {
+        options.onDiagnostic?.(`Lock wait timeout of ${options.timeout / 1000}s was exceeded.`);
+
+        break;
+      }
+
+      await Lock.#sleep(1000);
+
+      isLocked = existsSync(Lock.#getLockFilePath(targetPath));
+    }
+
+    return isLocked;
   }
 
   release(): void {
     rmSync(this.#lockFilePath, { force: true });
+  }
+
+  static async #sleep(time: number) {
+    return new Promise((resolve) => setTimeout(resolve, time));
   }
 }


### PR DESCRIPTION
Moving retry logic to the `Lock` class:

- this allows using `onDiagnostic()` instead of throwing an error;
- and does not need `node:timers/promises` anymore.