### PR TITLE
feat: add support for the `current` target tag

### DIFF
--- a/lib/__tests__/__fixtures__/valid-target.json
+++ b/lib/__tests__/__fixtures__/valid-target.json
@@ -1,4 +1,4 @@
 {
   "$schema": "../../schema.json",
-  "target": ["4.9", "5.0.4", "beta", "latest", "next", "rc"]
+  "target": ["4.9", "5.0.4", "beta", "current", "latest", "next", "rc"]
 }

--- a/lib/__tests__/__snapshots__/schema.test.ts.snap
+++ b/lib/__tests__/__snapshots__/schema.test.ts.snap
@@ -19,9 +19,9 @@ exports[`schema.json invalid item of 'target' option must be one of the allowed 
   {
     "instancePath": "/target/0",
     "keyword": "pattern",
-    "message": "must match pattern "^([45]\\.[0-9](\\.[0-9])?)|beta|latest|next|rc$"",
+    "message": "must match pattern "^([45]\\.[0-9](\\.[0-9])?)|beta|current|latest|next|rc$"",
     "params": {
-      "pattern": "^([45]\\.[0-9](\\.[0-9])?)|beta|latest|next|rc$",
+      "pattern": "^([45]\\.[0-9](\\.[0-9])?)|beta|current|latest|next|rc$",
     },
     "schemaPath": "#/properties/target/items/pattern",
   },

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -23,7 +23,7 @@
       ],
       "description": "The list of TypeScript versions to be tested on.",
       "items": {
-        "pattern": "^([45]\\.[0-9](\\.[0-9])?)|beta|latest|next|rc$",
+        "pattern": "^([45]\\.[0-9](\\.[0-9])?)|beta|current|latest|next|rc$",
         "type": "string"
       },
       "type": "array",

--- a/src/config/OptionDefinitionsMap.ts
+++ b/src/config/OptionDefinitionsMap.ts
@@ -131,7 +131,7 @@ export class OptionDefinitionsMap {
       items: {
         brand: OptionBrand.String,
         name: "target",
-        pattern: "^([45]\\.[0-9](\\.[0-9])?)|beta|latest|next|rc$",
+        pattern: "^([45]\\.[0-9](\\.[0-9])?)|beta|current|latest|next|rc$",
       },
       name: "target",
     },

--- a/src/config/OptionUsageText.ts
+++ b/src/config/OptionUsageText.ts
@@ -25,7 +25,7 @@ export class OptionUsageText {
         switch (this.#optionGroup) {
           case OptionGroup.CommandLine:
             usageText.push(
-              "Argument for the '--target' option must be a single tag or a comma separated list of versions.",
+              "Argument for the '--target' option must be a single tag or a comma separated list.",
               "Usage examples: '--target 4.9', '--target 5.0.4', '--target 4.7,4.8,latest'.",
               supportedTagsText,
             );

--- a/src/store/StoreService.ts
+++ b/src/store/StoreService.ts
@@ -28,7 +28,7 @@ export class StoreService {
       return [];
     }
 
-    return [...Object.keys(this.#manifest.resolutions), ...this.#manifest.versions].sort();
+    return [...Object.keys(this.#manifest.resolutions), ...this.#manifest.versions, "current"].sort();
   }
 
   async install(tag: string, signal?: AbortSignal): Promise<string | undefined> {
@@ -95,6 +95,19 @@ export class StoreService {
       return;
     }
 
+    if (tag === "current") {
+      try {
+        tag = (this.#nodeRequire("typescript") as typeof ts).version;
+      } catch (error) {
+        this.#onDiagnostic(
+          Diagnostic.fromError(
+            "Failed to resolve tag 'current'. The 'typescript' package might be not installed.",
+            error,
+          ),
+        );
+      }
+    }
+
     if (this.#manifest.versions.includes(tag)) {
       return tag;
     }
@@ -133,7 +146,7 @@ export class StoreService {
       return false;
     }
 
-    if (this.#manifest.versions.includes(tag) || tag in this.#manifest.resolutions) {
+    if (this.#manifest.versions.includes(tag) || tag in this.#manifest.resolutions || tag === "current") {
       return true;
     }
 

--- a/tests/__snapshots__/command-line-options.test.ts.snap
+++ b/tests/__snapshots__/command-line-options.test.ts.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`command line options '--target' option handles 'current' tag: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
-
-pass ./__typetests__/dummy.test.ts
-  + is string?
-
-Targets:    1 passed, 1 total
-Test files: 1 passed, 1 total
-Tests:      1 passed, 1 total
-Assertions: 1 passed, 1 total
-Duration:   <<timestamp>>
-
-Ran all test files.
-"
-`;
-
 exports[`command line options '--target' option handles multiple targets: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 

--- a/tests/__snapshots__/command-line-options.test.ts.snap
+++ b/tests/__snapshots__/command-line-options.test.ts.snap
@@ -1,6 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`command line options '--target' option: stdout 1`] = `
+exports[`command line options '--target' option handles 'current' tag: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
+exports[`command line options '--target' option handles multiple targets: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts
@@ -15,6 +31,22 @@ Targets:    2 passed, 2 total
 Test files: 2 passed, 2 total
 Tests:      2 passed, 2 total
 Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
+exports[`command line options '--target' option handles single target: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/__snapshots__/config-file-options.test.ts.snap
+++ b/tests/__snapshots__/config-file-options.test.ts.snap
@@ -55,6 +55,22 @@ Ran all test files.
 "
 `;
 
+exports[`tstyche.config.json handles 'current' as 'target' option value: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
 exports[`tstyche.config.json handles list item of wrong type: stderr 1`] = `
 "Error: Item of the 'testFileMatch' list must be of type string.
 

--- a/tests/__snapshots__/config-file-options.test.ts.snap
+++ b/tests/__snapshots__/config-file-options.test.ts.snap
@@ -55,22 +55,6 @@ Ran all test files.
 "
 `;
 
-exports[`tstyche.config.json handles 'current' as 'target' option value: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
-
-pass ./__typetests__/dummy.test.ts
-  + is string?
-
-Targets:    1 passed, 1 total
-Test files: 1 passed, 1 total
-Tests:      1 passed, 1 total
-Assertions: 1 passed, 1 total
-Duration:   <<timestamp>>
-
-Ran all test files.
-"
-`;
-
 exports[`tstyche.config.json handles list item of wrong type: stderr 1`] = `
 "Error: Item of the 'testFileMatch' list must be of type string.
 

--- a/tests/command-line-options.test.ts
+++ b/tests/command-line-options.test.ts
@@ -116,9 +116,8 @@ describe("command line options", () => {
         ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
       });
 
-      const { status, stderr, stdout } = spawnTyche(fixture, ["--target current"]);
+      const { status, stderr } = spawnTyche(fixture, ["--target current"]);
 
-      expect(stdout).toMatchSnapshot("stdout");
       expect(stderr).toBe("");
 
       expect(status).toBe(0);

--- a/tests/command-line-options.test.ts
+++ b/tests/command-line-options.test.ts
@@ -81,38 +81,68 @@ describe("command line options", () => {
     });
   });
 
-  test("'--target' option", async () => {
-    await writeFixture(fixture, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+  describe("'--target' option", () => {
+    test("handles single target", async () => {
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--target 4.8"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
     });
 
-    const { status, stderr, stdout } = spawnTyche(fixture, ["--target 4.8,latest"]);
+    test("handles multiple targets", async () => {
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
 
-    expect(stdout).toMatchSnapshot("stdout");
-    expect(stderr).toBe("");
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--target 4.8,latest"]);
 
-    expect(status).toBe(0);
-  });
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
 
-  test("handles not supported '--target' option value", async () => {
-    await writeFixture(fixture, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      expect(status).toBe(0);
     });
 
-    const { status, stderr, stdout } = spawnTyche(fixture, ["--target new"]);
+    test("handles 'current' tag", async () => {
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
 
-    expect(stdout).toBe("");
-    expect(stderr).toMatch(
-      [
-        "Error: TypeScript version 'new' is not supported.",
-        "",
-        "Argument for the '--target' option must be a single tag or a comma separated list of versions.",
-        "Usage examples:",
-      ].join("\r\n"),
-    );
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--target current"]);
 
-    expect(status).toBe(1);
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("handles not supported '--target' option value", async () => {
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--target new"]);
+
+      expect(stdout).toBe("");
+      expect(stderr).toMatch(
+        [
+          "Error: TypeScript version 'new' is not supported.",
+          "",
+          "Argument for the '--target' option must be a single tag or a comma separated list.",
+          "Usage examples:",
+        ].join("\r\n"),
+      );
+
+      expect(status).toBe(1);
+    });
   });
 });

--- a/tests/config-file-options.test.ts
+++ b/tests/config-file-options.test.ts
@@ -122,6 +122,25 @@ describe("tstyche.config.json", () => {
     expect(status).toBe(0);
   });
 
+  test("handles 'current' as 'target' option value", async () => {
+    const config = {
+      target: ["current"],
+    };
+
+    await writeFixture(fixture, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { status, stderr, stdout } = spawnTyche(fixture);
+
+    expect(stdout).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(status).toBe(0);
+  });
+
   test("handles not supported 'target' option value", async () => {
     const config = {
       target: ["new"],

--- a/tests/config-file-options.test.ts
+++ b/tests/config-file-options.test.ts
@@ -133,9 +133,8 @@ describe("tstyche.config.json", () => {
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 
-    const { status, stderr, stdout } = spawnTyche(fixture);
+    const { status, stderr } = spawnTyche(fixture);
 
-    expect(stdout).toMatchSnapshot("stdout");
     expect(stderr).toBe("");
 
     expect(status).toBe(0);


### PR DESCRIPTION
Two users asked for a possibility to run type test on the same version of TypeScript as the one currently installed in the repo. Having an option makes it easy to keep both versions in sync. Nice idea.

This PR is adding the `current` target tag, which makes this possible:

bash
```
tstyche --target current
```

Or via config file:

```json
{
  "target": ["4.9", "current"]
}
```

---

`latest` stays as the default. This is because TSTyche can be used without installing TypeScript. Using `current` as a default cannot work in repos with `typescript` installed. Would be possible to use `latest` as a fallback, but I am not sure if it is good idea to change the default just because a package is getting installed or uninstalled.