### PR TITLE
fix: Allow `.raiseError()` to take template literals as arguments

### DIFF
--- a/src/checker/Checker.ts
+++ b/src/checker/Checker.ts
@@ -31,9 +31,12 @@ export class Checker {
 
   #assertStringsOrNumbers(
     nodes: ts.NodeArray<ts.Expression>,
-  ): nodes is ts.NodeArray<ts.StringLiteral | ts.NumericLiteral> {
+  ): nodes is ts.NodeArray<ts.StringLiteral | ts.NumericLiteral | ts.NoSubstitutionTemplateLiteral> {
     return nodes.every(
-      (expression) => this.compiler.isStringLiteral(expression) || this.compiler.isNumericLiteral(expression),
+      (expression) =>
+        this.compiler.isStringLiteral(expression) ||
+        this.compiler.isNumericLiteral(expression) ||
+        this.compiler.isNoSubstitutionTemplateLiteral(expression),
     );
   }
 
@@ -390,7 +393,10 @@ export class Checker {
     }
   }
 
-  #matchExpectedError(diagnostic: ts.Diagnostic, argument: ts.StringLiteral | ts.NumericLiteral) {
+  #matchExpectedError(
+    diagnostic: ts.Diagnostic,
+    argument: ts.StringLiteral | ts.NumericLiteral | ts.NoSubstitutionTemplateLiteral,
+  ) {
     if (this.compiler.isStringLiteral(argument)) {
       return this.compiler.flattenDiagnosticMessageText(diagnostic.messageText, " ", 0).includes(argument.text); // TODO sanitize 'text' by removing '\r\n', '\n', and leading/trailing spaces
     }

--- a/tests/__fixtures__/api-toRaiseError/__typetests__/toRaiseError.test.ts
+++ b/tests/__fixtures__/api-toRaiseError/__typetests__/toRaiseError.test.ts
@@ -162,7 +162,7 @@ test("expression raises more type errors than expected messages", () => {
   expect(() => {
     two(1111);
     two<string>("pass");
-  }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
+  }).type.toRaiseError(`Argument of type 'number' is not assignable to parameter of type 'string'`);
 });
 
 test("expression raises more type errors than expected codes", () => {
@@ -177,7 +177,7 @@ test("expression raises less type errors than expected messages", () => {
     two(1111);
     two<string>("pass");
   }).type.toRaiseError(
-    "Argument of type 'number' is not assignable to parameter of type 'string'",
+    `Argument of type 'number' is not assignable to parameter of type 'string'`,
     "Expected 0 arguments",
     "Expected 2 arguments",
   );

--- a/tests/__snapshots__/api-toRaiseError.test.ts.snap
+++ b/tests/__snapshots__/api-toRaiseError.test.ts.snap
@@ -599,7 +599,7 @@ Error: Expected only 1 type error, but 2 were raised.
 
   163 |     two(1111);
   164 |     two<string>("pass");
-> 165 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
+> 165 |   }).type.toRaiseError(\`Argument of type 'number' is not assignable to parameter of type 'string'\`);
       |           ^
   166 | });
   167 | 
@@ -616,7 +616,7 @@ Error: Expected only 1 type error, but 2 were raised.
     > 163 |     two(1111);
           |         ^
       164 |     two<string>("pass");
-      165 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
+      165 |   }).type.toRaiseError(\`Argument of type 'number' is not assignable to parameter of type 'string'\`);
       166 | });
 
             at ./__typetests__/toRaiseError.test.ts:163:9
@@ -627,7 +627,7 @@ Error: Expected only 1 type error, but 2 were raised.
       163 |     two(1111);
     > 164 |     two<string>("pass");
           |                 ^
-      165 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
+      165 |   }).type.toRaiseError(\`Argument of type 'number' is not assignable to parameter of type 'string'\`);
       166 | });
       167 | 
 
@@ -677,7 +677,7 @@ Error: Expected 3 type errors, but only 2 were raised.
   178 |     two<string>("pass");
 > 179 |   }).type.toRaiseError(
       |           ^
-  180 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
+  180 |     \`Argument of type 'number' is not assignable to parameter of type 'string'\`,
   181 |     "Expected 0 arguments",
   182 |     "Expected 2 arguments",
 
@@ -693,7 +693,7 @@ Error: Expected 3 type errors, but only 2 were raised.
           |         ^
       178 |     two<string>("pass");
       179 |   }).type.toRaiseError(
-      180 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
+      180 |     \`Argument of type 'number' is not assignable to parameter of type 'string'\`,
 
             at ./__typetests__/toRaiseError.test.ts:177:9
 
@@ -704,7 +704,7 @@ Error: Expected 3 type errors, but only 2 were raised.
     > 178 |     two<string>("pass");
           |                 ^
       179 |   }).type.toRaiseError(
-      180 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
+      180 |     \`Argument of type 'number' is not assignable to parameter of type 'string'\`,
       181 |     "Expected 0 arguments",
 
             at ./__typetests__/toRaiseError.test.ts:178:17


### PR DESCRIPTION
Fixes #34

The `.raiseError()` must be allowed to take template literals without substitution. Only substitution does not work, because TSTyche test runner does not executed the code.