### PR TITLE
chore: add test for the `--only` command line option

### DIFF
--- a/tests/__snapshots__/command-line-options.test.ts.snap
+++ b/tests/__snapshots__/command-line-options.test.ts.snap
@@ -1,5 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`command line options '--only' option does not override the '.skip' run mode flag: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + external is string?
+  - skip external is number?
+  - skip internal is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests matching 'external' in all test files.
+"
+`;
+
+exports[`command line options '--only' option selects test group to run: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  external
+    + is string?
+  + external is number?
+  - skip internal is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 skipped, 2 passed, 3 total
+Assertions: 1 skipped, 2 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests matching 'external' in all test files.
+"
+`;
+
+exports[`command line options '--only' option selects tests to run: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + external is string?
+  + external is number?
+  - skip internal is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 skipped, 2 passed, 3 total
+Assertions: 1 skipped, 2 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests matching 'external' in all test files.
+"
+`;
+
+exports[`command line options '--only' option with '--skip' command line options: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + external is string?
+  - skip external is number?
+  - skip internal is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests matching 'external' and not matching 'number' in all test files.
+"
+`;
+
 exports[`command line options '--target' option handles multiple targets: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 

--- a/tests/command-line-options.test.ts
+++ b/tests/command-line-options.test.ts
@@ -81,6 +81,122 @@ describe("command line options", () => {
     });
   });
 
+  describe("'--only' option", () => {
+    test("selects tests to run", async () => {
+      const testText = `import { expect, test } from "tstyche";
+test("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+
+test("external is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--only external"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("selects test group to run", async () => {
+      const testText = `import { describe, expect, test } from "tstyche";
+describe("external", () => {
+  test("is string?", () => {
+    expect<string>().type.toBeString();
+  });
+});
+
+test("external is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--only external"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("does not override the '.skip' run mode flag", async () => {
+      const testText = `import { expect, test } from "tstyche";
+test("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+
+test.skip("external is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--only external"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("with '--skip' command line options", async () => {
+      const testText = `import { expect, test } from "tstyche";
+test("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+
+test("external is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--only external", "--skip number"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+  });
+
   describe("'--target' option", () => {
     test("handles single target", async () => {
       await writeFixture(fixture, {


### PR DESCRIPTION
The `--only` command line option had no tests. Time to add these.