### PR TITLE
chore: add tests for the `--skip` command line option

### DIFF
--- a/tests/__snapshots__/command-line-options.test.ts.snap
+++ b/tests/__snapshots__/command-line-options.test.ts.snap
@@ -73,6 +73,79 @@ Ran tests matching 'external' and not matching 'number' in all test files.
 "
 `;
 
+exports[`command line options '--skip' option overrides the '.only' run mode flag: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  - skip internal is string?
+  - skip internal is number?
+  + external is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests not matching 'internal' in all test files.
+"
+`;
+
+exports[`command line options '--skip' option selects test group to run: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  internal
+    - skip is string?
+  - skip internal is number?
+  + external is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests not matching 'internal' in all test files.
+"
+`;
+
+exports[`command line options '--skip' option selects tests to run: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  - skip internal is string?
+  - skip internal is number?
+  + external is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests not matching 'internal' in all test files.
+"
+`;
+
+exports[`command line options '--skip' option with '--only' command line options: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  - skip internal is string?
+  - skip internal is number?
+  + external is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran tests matching 'number' and not matching 'internal' in all test files.
+"
+`;
+
 exports[`command line options '--target' option handles multiple targets: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 

--- a/tests/command-line-options.test.ts
+++ b/tests/command-line-options.test.ts
@@ -197,6 +197,122 @@ test("internal is string?", () => {
     });
   });
 
+  describe("'--skip' option", () => {
+    test("selects tests to run", async () => {
+      const testText = `import { expect, test } from "tstyche";
+test("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+
+test("internal is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--skip internal"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("selects test group to run", async () => {
+      const testText = `import { describe, expect, test } from "tstyche";
+describe("internal", () => {
+  test("is string?", () => {
+    expect<string>().type.toBeString();
+  });
+});
+
+test("internal is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--skip internal"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("overrides the '.only' run mode flag", async () => {
+      const testText = `import { expect, test } from "tstyche";
+test.only("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+
+test.only("internal is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test.only("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--skip internal"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+
+    test("with '--only' command line options", async () => {
+      const testText = `import { expect, test } from "tstyche";
+test("internal is string?", () => {
+  expect<string>().type.toBeString();
+});
+
+test("internal is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+
+test.only("external is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: testText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture, ["--only number", "--skip internal"]);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+  });
+
   describe("'--target' option", () => {
     test("handles single target", async () => {
       await writeFixture(fixture, {


### PR DESCRIPTION
The `--skip` command line option had no tests. Time to add these too.