### PR TITLE
chore: add test for the `--version` command line option

### DIFF
--- a/tests/command-line-options.test.ts
+++ b/tests/command-line-options.test.ts
@@ -376,4 +376,17 @@ test.only("external is string?", () => {
       expect(status).toBe(1);
     });
   });
+
+  test("'--version' option", async () => {
+    await writeFixture(fixture, {
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { status, stderr, stdout } = spawnTyche(fixture, ["--version"]);
+
+    expect(stdout).toMatch(/^\d+\.\d+\.\d+/);
+    expect(stderr).toBe("");
+
+    expect(status).toBe(0);
+  });
 });


### PR DESCRIPTION
Adding a test for the `--version` command line option.