### PR TITLE
feat: load local language service plugins

### DIFF
--- a/src/project/ProjectService.ts
+++ b/src/project/ProjectService.ts
@@ -43,6 +43,7 @@ export class ProjectService {
     };
 
     this.#service = new this.compiler.server.ProjectService({
+      allowLocalPluginLoads: true,
       cancellationToken: this.compiler.server.nullCancellationToken,
       host,
       logger: noopLogger,


### PR DESCRIPTION
Resolves #55

This change makes sure that language service plugins specified in `tsconfig.json` will be loaded for type testing.

For example, to make TypeScript recognize imports of `.vue` files, a user has to install the `typescript-vue-plugin` package and add it to the [`plugins`](https://typescriptlang.org/tsconfig#plugins) list of the `tsconfig.json` nearest to type test files:

```json
{
  "compilerOptions": {
    "plugins": [{ "name": "typescript-vue-plugin" }]
  }
}
```