### PR TITLE
fix(config): correctly handle command line options that do not take a value

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -98,6 +98,7 @@ function createInterfaceDeclaration(identifierText, commentText, optionDefinitio
   for (const [key, optionDefinition] of optionDefinitions) {
     switch (optionDefinition.brand) {
       case tstyche.OptionBrand.Boolean:
+      case tstyche.OptionBrand.True:
         members.push(
           createPrimitivePropertySignature(
             key,

--- a/src/config/CommandLineOptionsWorker.ts
+++ b/src/config/CommandLineOptionsWorker.ts
@@ -86,6 +86,10 @@ export class CommandLineOptionsWorker {
     let optionValue = this.#resolveOptionValue(commandLineArgs[index]);
 
     switch (optionDefinition.brand) {
+      case OptionBrand.True:
+        this.#commandLineOptions[optionDefinition.name] = true;
+        break;
+
       case OptionBrand.Boolean:
         this.#commandLineOptions[optionDefinition.name] = optionValue !== "false";
 

--- a/src/config/OptionBrand.ts
+++ b/src/config/OptionBrand.ts
@@ -2,6 +2,7 @@ export const enum OptionBrand {
   String = "string",
   Number = "number",
   Boolean = "boolean",
+  True = "true", // an option which does not take a value
   List = "list",
   Object = "object",
 }

--- a/src/config/OptionDefinitionsMap.ts
+++ b/src/config/OptionDefinitionsMap.ts
@@ -31,7 +31,7 @@ interface BaseOptionDefinition {
 }
 
 interface PrimitiveTypeOptionDefinition extends BaseOptionDefinition {
-  brand: OptionBrand.String | OptionBrand.Number | OptionBrand.Boolean;
+  brand: OptionBrand.String | OptionBrand.Number | OptionBrand.Boolean | OptionBrand.True;
 }
 
 interface ListTypeOptionDefinition extends BaseOptionDefinition {
@@ -69,21 +69,21 @@ export class OptionDefinitionsMap {
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Print the list of command line options with brief descriptions and exit.",
       group: OptionGroup.CommandLine,
       name: "help",
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Install specified versions of the 'typescript' package and exit.",
       group: OptionGroup.CommandLine,
       name: "install",
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Print the list of the selected test files and exit.",
       group: OptionGroup.CommandLine,
       name: "listFiles",
@@ -97,7 +97,7 @@ export class OptionDefinitionsMap {
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Remove all installed versions of the 'typescript' package and exit.",
       group: OptionGroup.CommandLine,
       name: "prune",
@@ -111,7 +111,7 @@ export class OptionDefinitionsMap {
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Print the resolved configuration and exit.",
       group: OptionGroup.CommandLine,
       name: "showConfig",
@@ -148,14 +148,14 @@ export class OptionDefinitionsMap {
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Fetch the 'typescript' package metadata from the registry and exit.",
       group: OptionGroup.CommandLine,
       name: "update",
     },
 
     {
-      brand: OptionBrand.Boolean,
+      brand: OptionBrand.True,
       description: "Print the version number and exit.",
       group: OptionGroup.CommandLine,
       name: "version",

--- a/src/config/OptionGroup.ts
+++ b/src/config/OptionGroup.ts
@@ -1,5 +1,4 @@
 export const enum OptionGroup {
-  // TODO add PreTask group to filter out options like --help
   CommandLine = 1 << 1,
   ConfigFile = 1 << 2,
 }


### PR DESCRIPTION
Command line options that do not take any value, must always be `true` and ignore any provided value.