### PR TITLE
refactor(collect, expect, runner): use `Set` to handle TypeScript diagnostic

### DIFF
--- a/src/collect/Assertion.ts
+++ b/src/collect/Assertion.ts
@@ -11,7 +11,6 @@ export interface MatcherNode extends ts.CallExpression {
 // TODO try not extending after implementing 'onDiagnostics'
 export class Assertion extends TestMember {
   isNot: boolean;
-  override name = "";
 
   constructor(
     brand: TestMemberBrand,
@@ -24,8 +23,23 @@ export class Assertion extends TestMember {
   ) {
     super(brand, node, parent, flags);
 
-    this.diagnostics = this.#mapDiagnostics();
     this.isNot = notNode ? true : false;
+
+    const argStart = this.source[0]?.getStart();
+    const argEnd = this.source[0]?.getEnd();
+
+    for (const diagnostic of parent.diagnostics) {
+      if (
+        diagnostic.start != null &&
+        argStart != null &&
+        argEnd != null &&
+        diagnostic.start >= argStart &&
+        diagnostic.start <= argEnd
+      ) {
+        this.diagnostics.add(diagnostic);
+        parent.diagnostics.delete(diagnostic);
+      }
+    }
   }
 
   override get ancestorNames(): Array<string> {
@@ -60,33 +74,5 @@ export class Assertion extends TestMember {
     }
 
     return this.matcherNode.arguments;
-  }
-
-  #mapDiagnostics() {
-    const mapped: Array<ts.Diagnostic> = [];
-    const unmapped: Array<ts.Diagnostic> = [];
-
-    let argStart: number;
-    let argEnd: number;
-
-    if (this.node.typeArguments?.[0]) {
-      argStart = this.node.typeArguments[0].getStart();
-      argEnd = this.node.typeArguments[0].getEnd();
-    } else if (this.node.arguments[0]) {
-      argStart = this.node.arguments[0].getStart();
-      argEnd = this.node.arguments[0].getEnd();
-    }
-
-    this.parent.diagnostics.forEach((diagnostic) => {
-      if (diagnostic.start != null && diagnostic.start >= argStart && diagnostic.start <= argEnd) {
-        mapped.push(diagnostic);
-      } else {
-        unmapped.push(diagnostic);
-      }
-    });
-
-    this.parent.diagnostics = unmapped;
-
-    return mapped;
   }
 }

--- a/src/collect/CollectService.ts
+++ b/src/collect/CollectService.ts
@@ -98,7 +98,7 @@ export class CollectService {
   }
 
   createTestTree(sourceFile: ts.SourceFile, semanticDiagnostics: Array<ts.Diagnostic> = []): TestTree {
-    const testTree = new TestTree(this.compiler, semanticDiagnostics, sourceFile);
+    const testTree = new TestTree(this.compiler, new Set(semanticDiagnostics), sourceFile);
 
     this.#collectTestMembers(sourceFile, new IdentifierLookup(this.compiler), testTree);
 

--- a/src/collect/TestTree.ts
+++ b/src/collect/TestTree.ts
@@ -8,7 +8,7 @@ export class TestTree {
 
   constructor(
     public compiler: typeof ts,
-    public diagnostics: Array<ts.Diagnostic>,
+    public diagnostics: Set<ts.Diagnostic>,
     public sourceFile: ts.SourceFile,
   ) {}
 

--- a/src/expect/Expect.ts
+++ b/src/expect/Expect.ts
@@ -184,7 +184,7 @@ export class Expect {
         }
 
         return this.toRaiseError.match(
-          { diagnostics: assertion.diagnostics, node: assertion.source[0] },
+          { diagnostics: [...assertion.diagnostics], node: assertion.source[0] },
           targetTypes,
           assertion.isNot,
         );

--- a/src/runner/TestFileRunner.ts
+++ b/src/runner/TestFileRunner.ts
@@ -80,11 +80,11 @@ export class TestFileRunner {
 
     const testTree = this.#collectService.createTestTree(sourceFile, semanticDiagnostics);
 
-    if (testTree.diagnostics.length > 0) {
+    if (testTree.diagnostics.size > 0) {
       EventEmitter.dispatch([
         "file:error",
         {
-          diagnostics: Diagnostic.fromDiagnostics(testTree.diagnostics, this.compiler),
+          diagnostics: Diagnostic.fromDiagnostics([...testTree.diagnostics], this.compiler),
           result: fileResult,
         },
       ]);

--- a/src/runner/TestTreeWorker.ts
+++ b/src/runner/TestTreeWorker.ts
@@ -115,11 +115,11 @@ export class TestTreeWorker {
       return;
     }
 
-    if (assertion.diagnostics.length > 0 && assertion.matcherName.getText() !== "toRaiseError") {
+    if (assertion.diagnostics.size > 0 && assertion.matcherName.getText() !== "toRaiseError") {
       EventEmitter.dispatch([
         "expect:error",
         {
-          diagnostics: Diagnostic.fromDiagnostics(assertion.diagnostics, this.compiler),
+          diagnostics: Diagnostic.fromDiagnostics([...assertion.diagnostics], this.compiler),
           result: expectResult,
         },
       ]);
@@ -186,12 +186,12 @@ export class TestTreeWorker {
 
     if (
       !(runMode & RunMode.Skip || (this.#hasOnly && !(runMode & RunMode.Only)) || runMode & RunMode.Todo) &&
-      describe.diagnostics.length > 0
+      describe.diagnostics.size > 0
     ) {
       EventEmitter.dispatch([
         "file:error",
         {
-          diagnostics: Diagnostic.fromDiagnostics(describe.diagnostics, this.compiler),
+          diagnostics: Diagnostic.fromDiagnostics([...describe.diagnostics], this.compiler),
           result: this.#fileResult,
         },
       ]);
@@ -215,11 +215,11 @@ export class TestTreeWorker {
       return;
     }
 
-    if (!(runMode & RunMode.Skip || (this.#hasOnly && !(runMode & RunMode.Only))) && test.diagnostics.length > 0) {
+    if (!(runMode & RunMode.Skip || (this.#hasOnly && !(runMode & RunMode.Only))) && test.diagnostics.size > 0) {
       EventEmitter.dispatch([
         "test:error",
         {
-          diagnostics: Diagnostic.fromDiagnostics(test.diagnostics, this.compiler),
+          diagnostics: Diagnostic.fromDiagnostics([...test.diagnostics], this.compiler),
           result: testResult,
         },
       ]);


### PR DESCRIPTION
Using `Set`s to handle TypeScript diagnostics, simplifies logic (and might improve performance as well).