### PR TITLE
fest(store): make the TypeScript module loading more version aware

### DIFF
--- a/eslint.config.json
+++ b/eslint.config.json
@@ -142,7 +142,7 @@
       }
     },
     {
-      "files": ["src/result/ResultManager.ts"],
+      "files": ["src/result/ResultManager.ts", "src/store/Version.ts"],
       "rules": {
         "@typescript-eslint/no-non-null-assertion": "off"
       }

--- a/src/store/StoreService.ts
+++ b/src/store/StoreService.ts
@@ -66,7 +66,9 @@ export class StoreService {
     }
 
     if (modulePath != null) {
-      return this.#nodeRequire(modulePath) as typeof ts;
+      const { default: module } = (await import(modulePath)) as { default: typeof ts };
+
+      return module;
     }
 
     return;

--- a/src/store/StoreService.ts
+++ b/src/store/StoreService.ts
@@ -54,7 +54,7 @@ export class StoreService {
 
     if (tag === "local") {
       try {
-        modulePath = this.#nodeRequire.resolve("typescript/lib/tsserverlibrary.js");
+        modulePath = this.#nodeRequire.resolve("typescript");
       } catch {
         // TypeScript is not installed locally, let's load "latest" from the store
         tag = "latest";

--- a/src/store/StoreService.ts
+++ b/src/store/StoreService.ts
@@ -66,9 +66,7 @@ export class StoreService {
     }
 
     if (modulePath != null) {
-      const { default: module } = (await import(modulePath)) as { default: typeof ts };
-
-      return module;
+      return this.#nodeRequire(modulePath) as typeof ts;
     }
 
     return;

--- a/src/store/Version.ts
+++ b/src/store/Version.ts
@@ -4,12 +4,8 @@ export class Version {
     const targetElements = target.split(/\.|-/);
 
     function compare(index = 0): boolean {
-      const sourceElement = sourceElements[index];
-      const targetElement = targetElements[index];
-
-      if (sourceElement == null || targetElement == null) {
-        return false;
-      }
+      const sourceElement = sourceElements[index]!;
+      const targetElement = targetElements[index]!;
 
       if (sourceElement > targetElement) {
         return true;

--- a/src/store/Version.ts
+++ b/src/store/Version.ts
@@ -1,0 +1,31 @@
+export class Version {
+  static satisfies(source: string, target: string): boolean {
+    const sourceVersions = source.split(/\.|-/);
+    const targetVersions = target.split(/\.|-/);
+
+    function compare(index = 0): boolean {
+      const sourceElement = sourceVersions[index];
+      const targetElement = targetVersions[index];
+
+      if (sourceElement == null || targetElement == null) {
+        return false;
+      }
+
+      if (sourceElement > targetElement) {
+        return true;
+      }
+
+      if (sourceElement === targetElement) {
+        if (index === targetVersions.length - 1) {
+          return true;
+        }
+
+        return compare(index + 1);
+      }
+
+      return false;
+    }
+
+    return compare();
+  }
+}

--- a/src/store/Version.ts
+++ b/src/store/Version.ts
@@ -1,11 +1,11 @@
 export class Version {
   static satisfies(source: string, target: string): boolean {
-    const sourceVersions = source.split(/\.|-/);
-    const targetVersions = target.split(/\.|-/);
+    const sourceElements = source.split(/\.|-/);
+    const targetElements = target.split(/\.|-/);
 
     function compare(index = 0): boolean {
-      const sourceElement = sourceVersions[index];
-      const targetElement = targetVersions[index];
+      const sourceElement = sourceElements[index];
+      const targetElement = targetElements[index];
 
       if (sourceElement == null || targetElement == null) {
         return false;
@@ -16,7 +16,7 @@ export class Version {
       }
 
       if (sourceElement === targetElement) {
-        if (index === targetVersions.length - 1) {
+        if (index === targetElements.length - 1) {
           return true;
         }
 

--- a/src/store/__tests__/Version.test.ts
+++ b/src/store/__tests__/Version.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "@jest/globals";
+import { Version } from "../Version.js";
+
+describe("Version", () => {
+  describe("'satisfies' method", () => {
+    test.each([
+      {
+        expected: true,
+        source: "5.3.2",
+        target: "5.3",
+        testCase: "when target is provided in 'x.y' form and source minor is equal",
+      },
+      {
+        expected: false,
+        source: "5.2.4",
+        target: "5.3",
+        testCase: "when target is provided in 'x.y' form and source minor is lower",
+      },
+      {
+        expected: true,
+        source: "5.4.2",
+        target: "5.3",
+        testCase: "when target is provided in 'x.y' form and source minor is higher",
+      },
+
+      {
+        expected: true,
+        source: "4.9.5",
+        target: "4.9.5",
+        testCase: "when target is provided in 'x.y.z' form and all source versions are equal",
+      },
+      {
+        expected: false,
+        source: "4.9.4",
+        target: "4.9.5",
+        testCase: "when target is provided in 'x.y.z' form and source patch is lower",
+      },
+      {
+        expected: true,
+        source: "4.9.5",
+        target: "4.9.4",
+        testCase: "when target is provided in 'x.y.z' form and source patch is higher",
+      },
+      {
+        expected: false,
+        source: "5.2.3",
+        target: "5.3.2",
+        testCase: "when target is provided in 'x.y.z' form and source minor is lower",
+      },
+      {
+        expected: true,
+        source: "5.4.2",
+        target: "5.3.3",
+        testCase: "when target is provided in 'x.y.z' form and source minor is higher",
+      },
+      {
+        expected: false,
+        source: "4.6.2",
+        target: "5.3.2",
+        testCase: "when target is provided in 'x.y.z' form and source major is lower",
+      },
+      {
+        expected: true,
+        source: "6.2.2",
+        target: "5.3.2",
+        testCase: "when target is provided in 'x.y.z' form and source major is higher",
+      },
+
+      {
+        expected: true,
+        source: "5.4.0-dev.20231129",
+        target: "5.3",
+        testCase: "when target is provided in 'x.y' form and source is a newer 'dev' release",
+      },
+      {
+        expected: false,
+        source: "5.3.0-dev.20230822",
+        target: "5.4",
+        testCase: "when target is provided in 'x.y' form and source is a older 'dev' release",
+      },
+      {
+        expected: true,
+        source: "5.4.0-dev.20231129",
+        target: "5.4",
+        testCase: "when target is provided in 'x.y' form and source is a 'dev' release of the same series",
+      },
+      {
+        expected: false,
+        source: "5.4.0-dev.20231129",
+        target: "5.4.0-dev.20231207",
+        testCase: "when target is provided in 'x.y' form and source older 'dev' release",
+      },
+      {
+        expected: true,
+        source: "5.4.0-dev.20231231",
+        target: "5.4.0-dev.20231207",
+        testCase: "when target is provided in 'x.y' form and source newer 'dev' release",
+      },
+    ])("$testCase", ({ expected, source, target }) => {
+      const result = Version.satisfies(source, target);
+
+      expect(result).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
Since TypeScript 5.3 it is recommended to load `typescript.js` instead of `tsserverlibrary.js`. This change makes the TypeScript module loading a bit more version aware.

Reference: https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-53
