### PR TITLE
refactor(store): use dynamic `import()` to load the TypeScript module

### DIFF
--- a/src/store/StoreService.ts
+++ b/src/store/StoreService.ts
@@ -68,9 +68,9 @@ export class StoreService {
 
     if (modulePath != null) {
       const moduleSpecifier = pathToFileURL(modulePath).toString();
-      const { default: module } = (await import(moduleSpecifier)) as { default: typeof ts };
+      const { default: compilerModule } = (await import(moduleSpecifier)) as { default: typeof ts };
 
-      return module;
+      return compilerModule;
     }
 
     return;

--- a/src/store/StoreService.ts
+++ b/src/store/StoreService.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import type ts from "typescript";
 import { Diagnostic } from "#diagnostic";
 import { Environment } from "#environment";
@@ -66,7 +67,10 @@ export class StoreService {
     }
 
     if (modulePath != null) {
-      return this.#nodeRequire(modulePath) as typeof ts;
+      const moduleSpecifier = pathToFileURL(modulePath).toString();
+      const { default: module } = (await import(moduleSpecifier)) as { default: typeof ts };
+
+      return module;
     }
 
     return;


### PR DESCRIPTION
Let’s use dynamic `import()` to load the TypeScript module.