### PR TITLE
refactor(api): inject the version string during the build step

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,11 +19,15 @@ function tidyJs() {
   return {
     name: "tidy-js",
 
-    renderChunk(code, chunkInfo) {
+    async renderChunk(code, chunkInfo) {
       if (chunkInfo.fileName === tstycheEntry) {
         const magicString = new MagicString(code);
 
-        magicString.replaceAll("../../package.json", "../package.json");
+        const packageConfig = await fs.readFile(new URL("./package.json", import.meta.url), { encoding: "utf8" });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const { version } = /** @type {{version: string}} */ (JSON.parse(packageConfig));
+
+        magicString.replaceAll("__version__", version);
 
         return {
           code: magicString.toString(),

--- a/src/api/TSTyche.ts
+++ b/src/api/TSTyche.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import type { ResolvedConfig } from "#config";
 import { DiagnosticCategory } from "#diagnostic";
@@ -11,6 +10,7 @@ export class TSTyche {
   #abortController = new AbortController();
   #storeService: StoreService;
   #taskRunner: TaskRunner;
+  static readonly version = "__version__";
 
   constructor(
     readonly resolvedConfig: ResolvedConfig,
@@ -19,13 +19,6 @@ export class TSTyche {
     this.#storeService = storeService;
     this.#taskRunner = new TaskRunner(this.resolvedConfig, this.#storeService);
     this.#addEventHandlers();
-  }
-
-  static get version(): string {
-    const packageConfig = readFileSync(new URL("../../package.json", import.meta.url), { encoding: "utf8" });
-    const { version } = JSON.parse(packageConfig) as { version: string };
-
-    return version;
   }
 
   #addEventHandlers(): void {


### PR DESCRIPTION
Let’s use Rollup to inject the version string during the build step. Less code to ship.