### PR TITLE
feat(store): add `$version` field to store manifest

### DIFF
--- a/src/store/ManifestWorker.ts
+++ b/src/store/ManifestWorker.ts
@@ -39,11 +39,9 @@ export class ManifestWorker {
   async #create(signal?: AbortSignal) {
     const manifest = await this.#load(signal);
 
-    if (manifest == null) {
-      return;
+    if (manifest != null) {
+      await this.persist(manifest);
     }
-
-    await this.persist(manifest);
 
     return manifest;
   }
@@ -51,9 +49,9 @@ export class ManifestWorker {
   async #fetch(signal?: AbortSignal) {
     return new Promise<PackageMetadata>((resolve, reject) => {
       const request = https.get(
-        // reference: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
         new URL("typescript", this.#registryUrl),
         {
+          // reference: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
           headers: { accept: "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*" },
           signal,
         },

--- a/src/store/ManifestWorker.ts
+++ b/src/store/ManifestWorker.ts
@@ -13,6 +13,7 @@ interface PackageMetadata {
 }
 
 export interface Manifest {
+  $version?: string | undefined;
   lastUpdated: number;
   resolutions: Record<string, string>;
   versions: Array<string>;
@@ -26,12 +27,25 @@ export class ManifestWorker {
   #registryUrl = new URL("https://registry.npmjs.org");
   #storePath: string;
   #timeout = Environment.timeout * 1000;
+  readonly #version = "1";
 
   constructor(storePath: string, onDiagnostic: (diagnostic: Diagnostic) => void, prune: () => Promise<void>) {
     this.#storePath = storePath;
     this.#onDiagnostic = onDiagnostic;
     this.#manifestFilePath = Path.join(storePath, this.#manifestFileName);
     this.#prune = prune;
+  }
+
+  async #create(signal?: AbortSignal) {
+    const manifest = await this.#load(signal);
+
+    if (manifest == null) {
+      return;
+    }
+
+    await this.persist(manifest);
+
+    return manifest;
   }
 
   async #fetch(signal?: AbortSignal) {
@@ -85,6 +99,7 @@ export class ManifestWorker {
 
   async #load(signal?: AbortSignal, isUpdate = false) {
     const manifest: Manifest = {
+      $version: this.#version,
       lastUpdated: Date.now(),
       resolutions: {},
       versions: [],
@@ -160,15 +175,7 @@ export class ManifestWorker {
     let manifest: Manifest | undefined;
 
     if (!existsSync(this.#manifestFilePath)) {
-      manifest = await this.#load(signal);
-
-      if (manifest == null) {
-        return;
-      }
-
-      await this.persist(manifest);
-
-      return manifest;
+      return this.#create(signal);
     }
 
     let manifestText: string | undefined;
@@ -185,26 +192,18 @@ export class ManifestWorker {
 
     try {
       manifest = JSON.parse(manifestText) as Manifest;
-    } catch (error) {
-      this.#onDiagnostic(
-        Diagnostic.fromError(
-          [
-            `Failed to parse '${this.#manifestFilePath}'.`,
-            "Cached files appeared to be corrupt and got removed. Try running 'tstyche' again.",
-          ],
-          error,
-        ),
-      );
+    } catch {
+      // the manifest will be removed and recreated
     }
 
-    if (manifest == null) {
+    if (manifest == null || manifest.$version !== this.#version) {
       await this.#prune();
 
-      return;
+      return this.#create(signal);
     }
 
     if (this.isOutdated(manifest)) {
-      manifest = await this.update(manifest, signal);
+      return this.update(manifest, signal);
     }
 
     return manifest;

--- a/tests/validation-store-manifest.test.ts
+++ b/tests/validation-store-manifest.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { clearFixture, writeFixture } from "./__utils__/fixtureFactory.js";
+import { getFixtureUrl } from "./__utils__/getFixtureUrl.js";
+import { spawnTyche } from "./__utils__/spawnTyche.js";
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+const tsconfig = {
+  extends: "../tsconfig.json",
+  include: ["./"],
+};
+
+const fixture = "validation-store-manifest";
+
+afterEach(async () => {
+  await clearFixture(fixture);
+});
+
+describe("store-manifest", () => {
+  test("unparsable manifest file", async () => {
+    const storeManifest = '{"$version":"1","last';
+
+    await writeFixture(fixture, {
+      [".store/store-manifest.json"]: storeManifest,
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { status, stderr } = spawnTyche(fixture, /* args */ undefined, {
+      ["TSTYCHE_STORE_PATH"]: "./.store",
+    });
+
+    const result = await fs.readFile(new URL(".store/store-manifest.json", getFixtureUrl(fixture)), {
+      encoding: "utf8",
+    });
+
+    expect(JSON.parse(result)).toMatchObject({ $version: "1", lastUpdated: expect.any(Number) });
+
+    expect(stderr).toBe("");
+    expect(status).toBe(0);
+  });
+
+  test("manifest with not matching '$version'", async () => {
+    const storeManifest = '{"$version":"0"}';
+
+    await writeFixture(fixture, {
+      [".store/store-manifest.json"]: storeManifest,
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { status, stderr } = spawnTyche(fixture, /* args */ undefined, {
+      ["TSTYCHE_STORE_PATH"]: "./.store",
+    });
+
+    const result = await fs.readFile(new URL(".store/store-manifest.json", getFixtureUrl(fixture)), {
+      encoding: "utf8",
+    });
+
+    expect(JSON.parse(result)).toMatchObject({ $version: "1" });
+
+    expect(stderr).toBe("");
+    expect(status).toBe(0);
+  });
+});


### PR DESCRIPTION
Keeping store versioned allows newer versions of TSTyche to purge cache if it was created by older version. After #64 it is good idea to recreate files kept in the store. 