### PR TITLE
chore: add test for the `$schema` key of configuration file

### DIFF
--- a/tests/__snapshots__/config-file-options.test.ts.snap
+++ b/tests/__snapshots__/config-file-options.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tstyche.config.json '$schema' key is allowed: stdout 1`] = `
+"uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/dummy.test.ts
+  + is string?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
 exports[`tstyche.config.json 'allowNoTestFiles: false' option errors when no test files are selected: stderr 1`] = `
 "Error: No test files were selected using current configuration.
 

--- a/tests/config-file-options.test.ts
+++ b/tests/config-file-options.test.ts
@@ -26,6 +26,25 @@ afterEach(async () => {
 });
 
 describe("tstyche.config.json", () => {
+  describe("'$schema' key", () => {
+    test("is allowed", async () => {
+      const config = { $schema: "https://tstyche.org/schemas/config.json" };
+
+      await writeFixture(fixture, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+      });
+
+      const { status, stderr, stdout } = spawnTyche(fixture);
+
+      expect(stdout).toMatchSnapshot("stdout");
+      expect(stderr).toBe("");
+
+      expect(status).toBe(0);
+    });
+  });
+
   describe("'allowNoTestFiles: false' option", () => {
     test("errors when no test files are selected", async () => {
       const config = { allowNoTestFiles: false };


### PR DESCRIPTION
Add test for the `$schema` key of configuration file.