### PR TITLE
chore: use `json` coverage reporter

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,4 +120,4 @@ jobs:
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           directory: ./coverage
-          files: lcov.info
+          files: cobertura-coverage.xml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,4 +120,4 @@ jobs:
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           directory: ./coverage
-          files: cobertura-coverage.xml
+          files: coverage-final.json

--- a/c8.config.json
+++ b/c8.config.json
@@ -19,6 +19,6 @@
   ],
   "excludeAfterRemap": true,
   "mergeAsync": true,
-  "reporter": ["cobertura", "text"],
+  "reporter": ["json", "text"],
   "tempDirectory": "./coverage/temp"
 }

--- a/c8.config.json
+++ b/c8.config.json
@@ -14,6 +14,7 @@
     "jest.config.js",
     "rollup.config.js",
     "**/index.ts",
+    "**/main.ts",
     "**/tstyche.ts",
     "**/types.ts"
   ],

--- a/c8.config.json
+++ b/c8.config.json
@@ -19,6 +19,6 @@
   ],
   "excludeAfterRemap": true,
   "mergeAsync": true,
-  "reporter": ["lcov", "text"],
+  "reporter": ["cobertura", "text"],
   "tempDirectory": "./coverage/temp"
 }

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -13,5 +13,5 @@
   "ignorePaths": ["**/__snapshots__/**/*"],
   "language": "en-US",
   "useGitignore": true,
-  "words": ["cobertura", "packagephobia", "tsdoc", "tsserverlibrary", "tstyche", "typecheck", "typetests"]
+  "words": ["packagephobia", "tsdoc", "tsserverlibrary", "tstyche", "typecheck", "typetests"]
 }

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -13,5 +13,5 @@
   "ignorePaths": ["**/__snapshots__/**/*"],
   "language": "en-US",
   "useGitignore": true,
-  "words": ["lcov", "packagephobia", "tsdoc", "tsserverlibrary", "tstyche", "typecheck", "typetests"]
+  "words": ["cobertura", "packagephobia", "tsdoc", "tsserverlibrary", "tstyche", "typecheck", "typetests"]
 }


### PR DESCRIPTION
Right now the result of `text` reporter is more correct than `lcov`. Switching to `json` to have correct data on Codecov.