### PR TITLE
refactor: import Node.js types explicitly

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "include": ["./"]
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "prettier": "3.1.1",
     "rollup": "4.9.4",
     "rollup-plugin-dts": "6.1.0",
-    "rollup-plugin-tsconfig-paths": "1.5.2",
     "ts-node": "10.9.2",
     "tslib": "2.6.2",
     "typescript": "5.3.3"

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "include": ["./"]
 }

--- a/src/api/TSTyche.ts
+++ b/src/api/TSTyche.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { pathToFileURL } from "node:url";
 import type { ResolvedConfig } from "#config";
 import { DiagnosticCategory } from "#diagnostic";

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import process from "node:process";
 import { Cli } from "./tstyche.js";
 
-const cli = new Cli(process);
+const cli = new Cli();
 
 await cli.run(process.argv.slice(2));

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { TSTyche } from "#api";
 import { ConfigService, OptionDefinitionsMap, OptionGroup } from "#config";
 import { DiagnosticCategory } from "#diagnostic";
@@ -10,12 +11,9 @@ import { StoreService } from "#store";
 export class Cli {
   #abortController = new AbortController();
   #logger: Logger;
-  #process: NodeJS.Process;
   #storeService: StoreService;
 
-  constructor(process: NodeJS.Process) {
-    this.#process = process;
-
+  constructor() {
     this.#logger = new Logger();
     this.#storeService = new StoreService();
   }
@@ -32,7 +30,7 @@ export class Cli {
           switch (diagnostic.category) {
             case DiagnosticCategory.Error:
               this.#abortController.abort();
-              this.#process.exitCode = 1;
+              process.exitCode = 1;
 
               this.#logger.writeError(diagnosticText(diagnostic));
               break;
@@ -78,7 +76,7 @@ export class Cli {
       return;
     }
 
-    if (this.#process.exitCode === 1) {
+    if (process.exitCode === 1) {
       return;
     }
 
@@ -95,13 +93,13 @@ export class Cli {
 
     await configService.parseCommandLine(commandLineArguments);
 
-    if (this.#process.exitCode === 1) {
+    if (process.exitCode === 1) {
       return;
     }
 
     await configService.readConfigFile();
 
-    if (this.#process.exitCode === 1) {
+    if (process.exitCode === 1) {
       return;
     }
 
@@ -132,7 +130,7 @@ export class Cli {
 
     const testFiles = configService.selectTestFiles();
 
-    if (this.#process.exitCode === 1) {
+    if (process.exitCode === 1) {
       return;
     }
 

--- a/src/environment/Environment.ts
+++ b/src/environment/Environment.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import os from "node:os";
+import process from "node:process";
 import { Path } from "#path";
 
 export class Environment {

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+import type { Writable } from "node:stream";
 import { Environment } from "#environment";
 import { Scribbler } from "#scribbler";
 
@@ -12,11 +14,11 @@ export interface LoggerOptions {
   /**
    * A stream to write warnings and errors. Default: `process.stdout`.
    */
-  stderr?: NodeJS.WritableStream;
+  stderr?: Writable;
   /**
    * A stream to write informational messages. Default: `process.stderr`.
    */
-  stdout?: NodeJS.WritableStream;
+  stdout?: Writable;
 }
 
 /**
@@ -25,8 +27,8 @@ export interface LoggerOptions {
 export class Logger {
   #noColor: boolean;
   #scribbler: Scribbler;
-  #stderr: NodeJS.WritableStream;
-  #stdout: NodeJS.WritableStream;
+  #stderr: Writable;
+  #stdout: Writable;
 
   /**
    * @param options - {@link LoggerOptions | Options} to configure an instance of the Logger.
@@ -46,7 +48,7 @@ export class Logger {
     this.#stdout.write("\u001B[1A\u001B[0K");
   }
 
-  #write(stream: NodeJS.WritableStream, body: JSX.Element | Array<JSX.Element>): void {
+  #write(stream: Writable, body: JSX.Element | Array<JSX.Element>): void {
     const elements = Array.isArray(body) ? body : [body];
 
     for (const element of elements) {

--- a/src/store/Lock.ts
+++ b/src/store/Lock.ts
@@ -1,4 +1,5 @@
 import { existsSync, rmSync, writeFileSync } from "node:fs";
+import process from "node:process";
 
 export interface IsLockedOptions {
   onDiagnostic?: (diagnostic: string) => void;

--- a/tests/__fixtures__/tsconfig.json
+++ b/tests/__fixtures__/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "include": ["./"],
   "exclude": []

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "include": ["./"],
   "exclude": ["./__fixtures__/"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "#*": ["./src/*/index.ts"]
     },
     "rootDir": "./",
-    "types": ["node"],
+    "types": [],
 
     "noEmit": true,
     "preserveConstEnums": true,

--- a/typetests/tsconfig.json
+++ b/typetests/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "include": ["./"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5678,17 +5678,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-tsconfig-paths@npm:1.5.2":
-  version: 1.5.2
-  resolution: "rollup-plugin-tsconfig-paths@npm:1.5.2"
-  dependencies:
-    typescript-paths: ^1.5.1
-  peerDependencies:
-    rollup: ^2 || ^3 || ^4
-  checksum: 6940959c1f411044a2eff9912d7d263833e80ea577c04c10e708fba83d46e0518d439e6659eb61bd7e233f835897092460e6ac541eea580bb74d00765814379d
-  languageName: node
-  linkType: hard
-
 "rollup@npm:4.9.4":
   version: 4.9.4
   resolution: "rollup@npm:4.9.4"
@@ -6255,7 +6244,6 @@ __metadata:
     prettier: 3.1.1
     rollup: 4.9.4
     rollup-plugin-dts: 6.1.0
-    rollup-plugin-tsconfig-paths: 1.5.2
     ts-node: 10.9.2
     tslib: 2.6.2
     typescript: 5.3.3
@@ -6370,15 +6358,6 @@ __metadata:
   dependencies:
     is-typedarray: ^1.0.0
   checksum: 99c11aaa8f45189fcfba6b8a4825fd684a321caa9bd7a76a27cf0c7732c174d198b99f449c52c3818107430b5f41c0ccbbfb75cb2ee3ca4a9451710986d61a60
-  languageName: node
-  linkType: hard
-
-"typescript-paths@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "typescript-paths@npm:1.5.1"
-  peerDependencies:
-    typescript: ^4.7.2 || ^5
-  checksum: e77571f979c1ac5a5bee749c69ac77089ab24ed3749286856787a6a75a67c440880469e44fe0ae36662fa498e8a7b2508cb30407444feb014d0945dea4fef6c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Importing Node.js types explicitly instead of relying on `types: ["node"]` magic. Somehow feels cleaner. At least this makes the output files cleaner.