### PR TITLE
refactor: replace the `allowNoTestFiles` option with `disableTestFileLookup`

### DIFF
--- a/lib/CommandLineOptions.ts
+++ b/lib/CommandLineOptions.ts
@@ -5,10 +5,6 @@
  */
 export interface CommandLineOptions {
     /**
-     * Do not raise an error, if no test files are selected.
-     */
-    allowNoTestFiles?: boolean;
-    /**
      * The path to a TSTyche configuration file.
      */
     config?: string;

--- a/lib/ConfigFileOptions.ts
+++ b/lib/ConfigFileOptions.ts
@@ -5,9 +5,9 @@
  */
 export interface ConfigFileOptions {
     /**
-     * Do not raise an error, if no test files are selected.
+     * Do not search for the test files.
      */
-    allowNoTestFiles?: boolean;
+    disableTestFileLookup?: boolean;
     /**
      * Stop running tests after the first failed assertion.
      */

--- a/lib/__tests__/__fixtures__/invalid-disableTestFileLookup.json
+++ b/lib/__tests__/__fixtures__/invalid-disableTestFileLookup.json
@@ -1,4 +1,4 @@
 {
   "$schema": "../../schema.json",
-  "allowNoTestFiles": "all"
+  "disableTestFileLookup": "all"
 }

--- a/lib/__tests__/__fixtures__/valid-all-options.json
+++ b/lib/__tests__/__fixtures__/valid-all-options.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../schema.json",
-  "allowNoTestFiles": true,
+  "disableTestFileLookup": true,
   "failFast": true,
   "rootPath": "../",
   "target": ["4.9", "5.0.4", "beta", "latest", "next", "rc"],

--- a/lib/__tests__/__fixtures__/valid-disableTestFileLookup.json
+++ b/lib/__tests__/__fixtures__/valid-disableTestFileLookup.json
@@ -1,4 +1,4 @@
 {
   "$schema": "../../schema.json",
-  "allowNoTestFiles": true
+  "disableTestFileLookup": true
 }

--- a/lib/__tests__/__snapshots__/schema.test.js.snap
+++ b/lib/__tests__/__snapshots__/schema.test.js.snap
@@ -72,16 +72,16 @@ exports[`schema.json invalid items of 'testFileMatch' option must NOT be identic
 ]
 `;
 
-exports[`schema.json invalid value of 'allowNoTestFiles' option must be of type boolean 1`] = `
+exports[`schema.json invalid value of 'disableTestFileLookup' option must be of type boolean 1`] = `
 [
   {
-    "instancePath": "/allowNoTestFiles",
+    "instancePath": "/disableTestFileLookup",
     "keyword": "type",
     "message": "must be boolean",
     "params": {
       "type": "boolean",
     },
-    "schemaPath": "#/properties/allowNoTestFiles/type",
+    "schemaPath": "#/properties/disableTestFileLookup/type",
   },
 ]
 `;

--- a/lib/__tests__/schema.test.js
+++ b/lib/__tests__/schema.test.js
@@ -40,8 +40,8 @@ describe("schema.json", () => {
         testCase: "all options",
       },
       {
-        fixtureFileName: "valid-allowNoTestFiles.json",
-        testCase: "'allowNoTestFiles' option",
+        fixtureFileName: "valid-disableTestFileLookup.json",
+        testCase: "'disableTestFileLookup' option",
       },
       {
         fixtureFileName: "valid-failFast.json",
@@ -70,8 +70,8 @@ describe("schema.json", () => {
   describe("invalid", () => {
     test.each([
       {
-        fixtureFileName: "invalid-allowNoTestFiles.json",
-        testCase: "value of 'allowNoTestFiles' option must be of type boolean",
+        fixtureFileName: "invalid-disableTestFileLookup.json",
+        testCase: "value of 'disableTestFileLookup' option must be of type boolean",
       },
       {
         fixtureFileName: "invalid-failFast.json",

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -2,9 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {},
   "properties": {
-    "allowNoTestFiles": {
+    "disableTestFileLookup": {
       "default": false,
-      "description": "Do not raise an error, if no test files are selected.",
+      "description": "Do not search for the test files.",
       "type": "boolean"
     },
     "failFast": {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -124,16 +124,20 @@ export class Cli {
       return;
     }
 
-    const testFiles = configService.selectTestFiles();
+    let testFiles: Array<string> = [];
 
-    if (process.exitCode === 1) {
-      return;
-    }
+    if (!resolvedConfig.disableTestFileLookup) {
+      testFiles = configService.selectTestFiles();
 
-    if (configService.commandLineOptions.listFiles === true) {
-      this.#logger.writeMessage(formattedText(testFiles));
+      if (testFiles.length === 0) {
+        return;
+      }
 
-      return;
+      if (configService.commandLineOptions.listFiles === true) {
+        this.#logger.writeMessage(formattedText(testFiles));
+
+        return;
+      }
     }
 
     EventEmitter.removeHandler(this.#onStartupEvent);

--- a/src/config/ConfigService.ts
+++ b/src/config/ConfigService.ts
@@ -22,7 +22,7 @@ export class ConfigService {
   #configFileOptions: ConfigFileOptions = {};
 
   static #defaultOptions: Required<ConfigFileOptions> = {
-    allowNoTestFiles: false,
+    disableTestFileLookup: false,
     failFast: false,
     rootPath: Path.resolve("./"),
     target: [Environment.typescriptPath == null ? "latest" : "current"],
@@ -107,7 +107,7 @@ export class ConfigService {
   }
 
   selectTestFiles(): Array<string> {
-    const { allowNoTestFiles, pathMatch, rootPath, testFileMatch } = this.resolveConfig();
+    const { pathMatch, rootPath, testFileMatch } = this.resolveConfig();
 
     let testFilePaths = this.compiler.sys.readDirectory(
       rootPath,
@@ -126,7 +126,7 @@ export class ConfigService {
       );
     }
 
-    if (testFilePaths.length === 0 && !allowNoTestFiles) {
+    if (testFilePaths.length === 0) {
       const text = [
         "No test files were selected using current configuration.",
         `Root path:       ${rootPath}`,

--- a/src/config/OptionDefinitionsMap.ts
+++ b/src/config/OptionDefinitionsMap.ts
@@ -48,17 +48,17 @@ interface ObjectTypeOptionDefinition extends BaseOptionDefinition {
 export class OptionDefinitionsMap {
   static #definitions: Array<OptionDefinition> = [
     {
-      brand: OptionBrand.Boolean,
-      description: "Do not raise an error, if no test files are selected.",
-      group: OptionGroup.ConfigFile | OptionGroup.CommandLine,
-      name: "allowNoTestFiles",
-    },
-
-    {
       brand: OptionBrand.String,
       description: "The path to a TSTyche configuration file.",
       group: OptionGroup.CommandLine,
       name: "config",
+    },
+
+    {
+      brand: OptionBrand.Boolean,
+      description: "Do not search for the test files.",
+      group: OptionGroup.ConfigFile,
+      name: "disableTestFileLookup",
     },
 
     {

--- a/tests/__snapshots__/config-disableTestFileLookup.test.js.snap
+++ b/tests/__snapshots__/config-disableTestFileLookup.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`'disableTestFileLookup' configuration file option does not search for test files: stderr 1`] = `""`;
+
+exports[`'disableTestFileLookup' configuration file option does not search for test files: stdout 1`] = `
+"Targets:    1 passed, 1 total
+Test files: 0 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;

--- a/tests/__snapshots__/config-file-options.test.js.snap
+++ b/tests/__snapshots__/config-file-options.test.js.snap
@@ -16,24 +16,6 @@ Ran all test files.
 "
 `;
 
-exports[`tstyche.config.json 'allowNoTestFiles: false' option errors when no test files are selected: stderr 1`] = `
-"Error: No test files were selected using current configuration.
-
-Root path:       <<cwd>>/tests/__fixtures__/config-file-options
-Test file match: **/*.tst.*, **/__typetests__/*.test.*, **/typetests/*.test.*
-
-"
-`;
-
-exports[`tstyche.config.json 'allowNoTestFiles: true' option warns when no test files are selected: stdout 1`] = `
-"Targets:    1 passed, 1 total
-Test files: 0 total
-Duration:   <<timestamp>>
-
-Ran all test files.
-"
-`;
-
 exports[`tstyche.config.json 'target' option: stdout 1`] = `
 "adds TypeScript 4.8.4 to <<cwd>>/tests/__fixtures__/config-file-options/.store/4.8.4
 uses TypeScript <<version>> with ./tsconfig.json

--- a/tests/__snapshots__/config-help.test.js.snap
+++ b/tests/__snapshots__/config-help.test.js.snap
@@ -15,9 +15,6 @@ exports[`'--help' command line option prints the list of command line options: s
 
 Command Line Options
 
-  --allowNoTestFiles  boolean
-  Do not raise an error, if no test files are selected.
-
   --config  string
   The path to a TSTyche configuration file.
 

--- a/tests/__snapshots__/config-listFiles.test.js.snap
+++ b/tests/__snapshots__/config-listFiles.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`'--listFiles' command line option lists test files and exist: stdout 1`] = `
+"[
+  "<<cwd>>/tests/__fixtures__/config-listFiles/__typetests__/isNumber.tst.ts",
+  "<<cwd>>/tests/__fixtures__/config-listFiles/__typetests__/isString.tst.ts"
+]
+"
+`;
+
+exports[`'--listFiles' command line option when 'disableTestFileLookup: true' is set, does nothing: stderr 1`] = `""`;
+
+exports[`'--listFiles' command line option when 'disableTestFileLookup: true' is set, does nothing: stdout 1`] = `
+"Targets:    1 passed, 1 total
+Test files: 0 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
+exports[`'--listFiles' command line option when search string is provided after the option: stdout 1`] = `
+"[
+  "<<cwd>>/tests/__fixtures__/config-listFiles/__typetests__/isString.tst.ts"
+]
+"
+`;
+
+exports[`'--listFiles' command line option when search string is provided before the option: stdout 1`] = `
+"[
+  "<<cwd>>/tests/__fixtures__/config-listFiles/__typetests__/isNumber.tst.ts"
+]
+"
+`;

--- a/tests/__snapshots__/config-listFiles.test.js.snap
+++ b/tests/__snapshots__/config-listFiles.test.js.snap
@@ -8,8 +8,6 @@ exports[`'--listFiles' command line option lists test files and exist: stdout 1`
 "
 `;
 
-exports[`'--listFiles' command line option when 'disableTestFileLookup: true' is set, does nothing: stderr 1`] = `""`;
-
 exports[`'--listFiles' command line option when 'disableTestFileLookup: true' is set, does nothing: stdout 1`] = `
 "Targets:    1 passed, 1 total
 Test files: 0 total

--- a/tests/__snapshots__/validation-runner.test.js.snap
+++ b/tests/__snapshots__/validation-runner.test.js.snap
@@ -31,3 +31,26 @@ Duration:   <<timestamp>>
 Ran all test files.
 "
 `;
+
+exports[`compiler options when no test files are present: stderr 1`] = `
+"Error: No test files were selected using current configuration.
+
+Root path:       <<cwd>>/tests/__fixtures__/validation-runner
+Test file match: **/*.tst.*, **/__typetests__/*.test.*, **/typetests/*.test.*
+
+"
+`;
+
+exports[`compiler options when no test files are present: stdout 1`] = `""`;
+
+exports[`compiler options when search string does not select test files: stderr 1`] = `
+"Error: No test files were selected using current configuration.
+
+Root path:       <<cwd>>/tests/__fixtures__/validation-runner
+Test file match: **/*.tst.*, **/__typetests__/*.test.*, **/typetests/*.test.*
+Path match:      sample
+
+"
+`;
+
+exports[`compiler options when search string does not select test files: stdout 1`] = `""`;

--- a/tests/__snapshots__/validation-runner.test.js.snap
+++ b/tests/__snapshots__/validation-runner.test.js.snap
@@ -19,7 +19,7 @@ exports[`compiler options when TSConfig file has errors: stderr 1`] = `
 exports[`compiler options when TSConfig file has errors: stdout 1`] = `
 "uses TypeScript <<version>> with ./tsconfig.json
 
-pass ./__typetests__/dummy.test.ts
+pass ./__typetests__/dummy.tst.ts
   + is string?
 
 Targets:    1 failed, 1 total

--- a/tests/config-disableTestFileLookup.test.js
+++ b/tests/config-disableTestFileLookup.test.js
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { clearFixture, writeFixture } from "./__utils__/fixtureFactory.js";
+import { normalizeOutput } from "./__utils__/normalizeOutput.js";
+import { spawnTyche } from "./__utils__/spawnTyche.js";
+
+const fixture = "config-disableTestFileLookup";
+
+afterEach(async () => {
+  await clearFixture(fixture);
+});
+
+describe("'disableTestFileLookup' configuration file option", () => {
+  test("does not search for test files", async () => {
+    await writeFixture(fixture, {
+      ["tstyche.config.json"]: JSON.stringify({ disableTestFileLookup: true }, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toMatchSnapshot("stderr");
+
+    expect(exitCode).toBe(0);
+  });
+});

--- a/tests/config-file-options.test.js
+++ b/tests/config-file-options.test.js
@@ -46,42 +46,6 @@ describe("tstyche.config.json", () => {
     });
   });
 
-  describe("'allowNoTestFiles: false' option", () => {
-    test("errors when no test files are selected", async () => {
-      const config = { allowNoTestFiles: false };
-
-      await writeFixture(fixture, {
-        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
-        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
-      });
-
-      const { exitCode, stderr, stdout } = await spawnTyche(fixture);
-
-      expect(stdout).toBe("");
-      expect(normalizeOutput(stderr)).toMatchSnapshot("stderr");
-
-      expect(exitCode).toBe(1);
-    });
-  });
-
-  describe("'allowNoTestFiles: true' option", () => {
-    test("warns when no test files are selected", async () => {
-      const config = { allowNoTestFiles: true };
-
-      await writeFixture(fixture, {
-        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
-        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
-      });
-
-      const { exitCode, stderr, stdout } = await spawnTyche(fixture);
-
-      expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
-      expect(stderr).toBe("");
-
-      expect(exitCode).toBe(0);
-    });
-  });
-
   test("'rootPath' option", async () => {
     const config = {
       rootPath: "../",

--- a/tests/config-listFiles.test.js
+++ b/tests/config-listFiles.test.js
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { clearFixture, writeFixture } from "./__utils__/fixtureFactory.js";
+import { normalizeOutput } from "./__utils__/normalizeOutput.js";
+import { spawnTyche } from "./__utils__/spawnTyche.js";
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+const isNumberTestText = `import { expect, test } from "tstyche";
+test("is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+`;
+
+const fixture = "config-listFiles";
+
+afterEach(async () => {
+  await clearFixture(fixture);
+});
+
+describe("'--listFiles' command line option", () => {
+  test("lists test files and exist", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["--listFiles"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when search string is provided before the option", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["isNumber", "--listFiles"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when search string is provided after the option", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["--listFiles", "isString"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when 'disableTestFileLookup: true' is set, does nothing", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify({ disableTestFileLookup: true }, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["--listFiles"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toMatchSnapshot("stderr");
+
+    expect(exitCode).toBe(0);
+  });
+});

--- a/tests/config-listFiles.test.js
+++ b/tests/config-listFiles.test.js
@@ -74,7 +74,7 @@ describe("'--listFiles' command line option", () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["--listFiles"]);
 
     expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
-    expect(normalizeOutput(stderr)).toMatchSnapshot("stderr");
+    expect(normalizeOutput(stderr)).toBe("");
 
     expect(exitCode).toBe(0);
   });

--- a/tests/validation-runner.test.js
+++ b/tests/validation-runner.test.js
@@ -31,7 +31,7 @@ describe("compiler options", () => {
 
   test("when search string does not select test files", async () => {
     await writeFixture(fixture, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["__typetests__/dummy.tst.ts"]: isStringTestText,
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["sample"]);
@@ -54,7 +54,7 @@ describe("compiler options", () => {
     };
 
     await writeFixture(fixture, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["__typetests__/dummy.tst.ts"]: isStringTestText,
       ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 

--- a/tests/validation-runner.test.js
+++ b/tests/validation-runner.test.js
@@ -16,6 +16,32 @@ afterEach(async () => {
 });
 
 describe("compiler options", () => {
+  test("when no test files are present", async () => {
+    await writeFixture(fixture, {
+      ["tstyche.config.json"]: "{}",
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toMatchSnapshot("stderr");
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("when search string does not select test files", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["sample"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(normalizeOutput(stderr)).toMatchSnapshot("stderr");
+
+    expect(exitCode).toBe(1);
+  });
+
   test("when TSConfig file has errors", async () => {
     const tsconfig = {
       compilerOptions: {

--- a/typetests/CommandLineOptions.tst.ts
+++ b/typetests/CommandLineOptions.tst.ts
@@ -6,7 +6,6 @@ const options: tstyche.CommandLineOptions = {};
 describe("CommandLineOptions", () => {
   test("all options", () => {
     expect(options).type.toBeAssignable({
-      allowNoTestFiles: true,
       config: "./config/tstyche.json",
       failFast: true,
       help: true,
@@ -20,12 +19,6 @@ describe("CommandLineOptions", () => {
       update: true,
       version: true,
     });
-  });
-
-  test("'allowNoTestFiles' option", () => {
-    expect<tstyche.CommandLineOptions>().type.toMatch<{
-      allowNoTestFiles?: boolean;
-    }>();
   });
 
   test("'config' option", () => {

--- a/typetests/ConfigFileOptions.tst.ts
+++ b/typetests/ConfigFileOptions.tst.ts
@@ -6,7 +6,7 @@ const options: tstyche.ConfigFileOptions = {};
 describe("ConfigFileOptions", () => {
   test("all options", () => {
     expect(options).type.toBeAssignable({
-      allowNoTestFiles: true,
+      disableTestFileLookup: true,
       failFast: true,
       rootPath: "../",
       target: ["4.9.5" as const, "5.0" as const, "latest" as const],
@@ -14,9 +14,9 @@ describe("ConfigFileOptions", () => {
     });
   });
 
-  test("'allowNoTestFiles' option", () => {
+  test("'disableTestFileLookup' option", () => {
     expect<tstyche.ConfigFileOptions>().type.toMatch<{
-      allowNoTestFiles?: boolean;
+      disableTestFileLookup?: boolean;
     }>();
   });
 


### PR DESCRIPTION
Replace the `allowNoTestFiles` option with `disableTestFileLookup`. It does almost the same, but will work better with programmatic API (coming soon!).