### PR TITLE
feat(config): only select test files with supported extensions

### DIFF
--- a/source/config/ConfigService.ts
+++ b/source/config/ConfigService.ts
@@ -111,7 +111,7 @@ export class ConfigService {
 
     let testFilePaths = this.compiler.sys.readDirectory(
       rootPath,
-      /* extensions */ undefined,
+      ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
       /* exclude */ undefined,
       /* include */ testFileMatch,
     );

--- a/tests/__snapshots__/feature-runner.test.js.snap
+++ b/tests/__snapshots__/feature-runner.test.js.snap
@@ -18,8 +18,119 @@ Ran all test files.
 "
 `;
 
+exports[`search strings only the files matched by the 'testFileMatch' patterns are selected: stdout 1`] = `
+"uses TypeScript <<version>> with ./feature/__tests__/tsconfig.json
+
+pass ./feature/__tests__/isNumber.test.ts
+  + is number?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran test files matching 'number'.
+"
+`;
+
+exports[`search strings when multiple search strings are provided, selects matching files: stdout 1`] = `
+"uses TypeScript <<version>>
+
+pass ./feature/__tests__/isNumber.tst.ts
+pass ./feature/__tests__/isString.tst.ts
+pass ./__typetests__/isString.test.ts
+
+Targets:    1 passed, 1 total
+Test files: 3 passed, 3 total
+Tests:      3 passed, 3 total
+Assertions: 3 passed, 3 total
+Duration:   <<timestamp>>
+
+Ran test files matching 'string' or 'feature'.
+"
+`;
+
+exports[`search strings when relative search string is provided, selects matching files: stdout 1`] = `
+"uses TypeScript <<version>>
+
+pass ./feature/__tests__/isNumber.tst.ts
+  + is number?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran test files matching './feature/__tests__/isNumber'.
+"
+`;
+
+exports[`search strings when search string is not provided, selects files in 'typetests' directories: stdout 1`] = `
+"uses TypeScript <<version>>
+
+pass ./__typetests__/isNumber.test.ts
+pass ./__typetests__/isString.test.ts
+pass ./feature/__typetests__/isNumber.test.ts
+pass ./feature/__typetests__/isString.test.ts
+pass ./feature/typetests/isNumber.test.ts
+pass ./feature/typetests/isString.test.ts
+pass ./typetests/isNumber.test.ts
+pass ./typetests/isString.test.ts
+
+Targets:    1 passed, 1 total
+Test files: 8 passed, 8 total
+Tests:      8 passed, 8 total
+Assertions: 8 passed, 8 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
+exports[`search strings when search string is not provided, selects files with '.tst.' suffix: stdout 1`] = `
+"uses TypeScript <<version>>
+
+pass ./isNumber.tst.ts
+pass ./isString.tst.ts
+pass ./__tests__/isNumber.tst.ts
+pass ./__tests__/isString.tst.ts
+pass ./feature/__tests__/isNumber.tst.ts
+pass ./feature/__tests__/isString.tst.ts
+pass ./feature/tests/isNumber.tst.ts
+pass ./feature/tests/isString.tst.ts
+pass ./tests/isNumber.tst.ts
+pass ./tests/isString.tst.ts
+
+Targets:    1 passed, 1 total
+Test files: 10 passed, 10 total
+Tests:      10 passed, 10 total
+Assertions: 10 passed, 10 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
+exports[`search strings when single search string is provided, selects matching files: stdout 1`] = `
+"uses TypeScript <<version>>
+
+pass ./feature/__tests__/isNumber.tst.ts
+pass ./__typetests__/isNumber.test.ts
+
+Targets:    1 passed, 1 total
+Test files: 2 passed, 2 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>
+
+Ran test files matching 'number'.
+"
+`;
+
 exports[`test files allows a file to be empty: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
 
@@ -32,7 +143,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only an empty describe: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
   parent
@@ -47,7 +158,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only empty tests: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
   + empty test
@@ -62,7 +173,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only expect: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
 
@@ -76,7 +187,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only skipped describe: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
   skipped describe
@@ -90,7 +201,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only skipped tests: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
   - skip is skipped?
@@ -106,7 +217,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only todo describe: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
   have todo this
@@ -121,7 +232,7 @@ Ran all test files.
 `;
 
 exports[`test files allows a file to have only todo tests: stdout 1`] = `
-"uses TypeScript <<version>> with ./tsconfig.json
+"uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts
   - todo have todo this

--- a/tests/feature-runner.test.js
+++ b/tests/feature-runner.test.js
@@ -3,10 +3,17 @@ import { clearFixture, writeFixture } from "./__utils__/fixtureFactory.js";
 import { normalizeOutput } from "./__utils__/normalizeOutput.js";
 import { spawnTyche } from "./__utils__/spawnTyche.js";
 
-const tsconfig = {
-  extends: "../tsconfig.json",
-  include: ["**/*"],
-};
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+const isNumberTestText = `import { expect, test } from "tstyche";
+test("is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+`;
 
 const fixture = "feature-runner";
 
@@ -14,11 +21,127 @@ afterEach(async () => {
   await clearFixture(fixture);
 });
 
+describe("search strings", () => {
+  test("when search string is not provided, selects files in 'typetests' directories", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["feature/__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["feature/__typetests__/isString.test.ts"]: isStringTestText,
+      ["feature/typetests/isNumber.test.ts"]: isNumberTestText,
+      ["feature/typetests/isString.test.ts"]: isStringTestText,
+      ["typetests/isNumber.test.ts"]: isNumberTestText,
+      ["typetests/isString.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when search string is not provided, selects files with '.tst.' suffix", async () => {
+    await writeFixture(fixture, {
+      ["__tests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__tests__/isString.tst.ts"]: isStringTestText,
+      ["feature/__tests__/isNumber.tst.ts"]: isNumberTestText,
+      ["feature/__tests__/isString.tst.ts"]: isStringTestText,
+      ["feature/tests/isNumber.tst.ts"]: isNumberTestText,
+      ["feature/tests/isString.tst.ts"]: isStringTestText,
+      ["isNumber.tst.ts"]: isNumberTestText,
+      ["isString.tst.ts"]: isStringTestText,
+      ["tests/isNumber.tst.ts"]: isNumberTestText,
+      ["tests/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when single search string is provided, selects matching files", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["feature/__tests__/isNumber.tst.ts"]: isNumberTestText,
+      ["feature/__tests__/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["number"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when multiple search strings are provided, selects matching files", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["feature/__tests__/isNumber.tst.ts"]: isNumberTestText,
+      ["feature/__tests__/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["string", "feature"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("when relative search string is provided, selects matching files", async () => {
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["feature/__tests__/isNumber.tst.ts"]: isNumberTestText,
+      ["feature/__tests__/isString.tst.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["./feature/__tests__/isNumber"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("only the files matched by the 'testFileMatch' patterns are selected", async () => {
+    const config = {
+      testFileMatch: ["**/feature/__tests__/**.*"],
+    };
+    const tsconfig = { extends: "../../../tsconfig.json", include: ["**/*"] };
+
+    await writeFixture(fixture, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["feature/__tests__/__snapshot__/isNumber.test.ts.snap"]: "isNumberSnap",
+      ["feature/__tests__/__snapshot__/isString.test.ts.snap"]: "isStringSnap",
+      ["feature/__tests__/isNumber.test.ts"]: isNumberTestText,
+      ["feature/__tests__/isString.test.ts"]: isStringTestText,
+      ["feature/__tests__/tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture, ["number"]);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("test files", () => {
   test("allows a file to be empty", async () => {
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: "",
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -40,7 +163,6 @@ describe("parent", () => {
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -62,7 +184,6 @@ describe.skip("skipped describe", function () {
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -81,7 +202,6 @@ describe.todo("and this one");
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -101,7 +221,6 @@ test("empty test", () => {
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -121,7 +240,6 @@ test.skip("is skipped?", () => {
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -140,7 +258,6 @@ test.todo("and this one");
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);
@@ -158,7 +275,6 @@ expect<number>().type.toBeNumber();
 
     await writeFixture(fixture, {
       ["__typetests__/dummy.test.ts"]: testText,
-      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixture);

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./models/config-schema.json",
-  "testFileMatch": ["examples/*.tst.ts", "models/__typetests__/*.tst.ts", "tests/*.test.js"]
+  "testFileMatch": ["examples/*", "models/__typetests__/*", "tests/*"]
 }


### PR DESCRIPTION
Adding a list of file extensions. Currently `.json` or `.snap` files get selected, but this does not make sense. This change makes it easier to write `testFileMatch` patterns as well.