### PR TITLE
refactor(diagnostic, scribbler): make the end of line sequence configurable

### DIFF
--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -43,7 +43,7 @@ export class Diagnostic {
       const category = DiagnosticCategory.Error;
       const code = `ts(${diagnostic.code})`;
       let origin: DiagnosticOrigin | undefined;
-      const text = compiler.flattenDiagnosticMessageText(diagnostic.messageText, "\r\n");
+      const text = compiler.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
 
       if (Diagnostic.isTsDiagnosticWithLocation(diagnostic)) {
         origin = {

--- a/source/scribbler/Line.tsx
+++ b/source/scribbler/Line.tsx
@@ -17,7 +17,7 @@ export class Line implements JSX.ElementClass {
         <Text color={this.props.color} indent={this.props.indent}>
           {this.props.children}
         </Text>
-        <newline />
+        <newLine />
       </text>
     );
   }

--- a/source/scribbler/Scribbler.ts
+++ b/source/scribbler/Scribbler.ts
@@ -27,7 +27,7 @@ declare global {
         children?: never;
         escapes: Color | Array<Color>;
       };
-      newline: {
+      newLine: {
         children?: never;
       };
       text: {
@@ -43,6 +43,10 @@ declare global {
  */
 export interface ScribblerOptions {
   /**
+   * The end of line sequence to be used in the output. Default: `"\n"`.
+   */
+  newLine?: string;
+  /**
    * Do not include ANSI color escape codes in the output. Default: `false`.
    */
   noColor?: boolean;
@@ -52,12 +56,14 @@ export interface ScribblerOptions {
  * Provides the JSX factory function and renderer.
  */
 export class Scribbler {
+  #newLine: string;
   #noColor: boolean;
 
   /**
    * @param options - {@link ScribblerOptions | Options} to configure an instance of the Scribbler.
    */
   constructor(options?: ScribblerOptions) {
+    this.#newLine = options?.newLine ?? "\n";
     this.#noColor = options?.noColor ?? false;
   }
 
@@ -112,8 +118,8 @@ export class Scribbler {
         }
       }
 
-      if (element.type === "newline") {
-        return "\r\n";
+      if (element.type === "newLine") {
+        return this.#newLine;
       }
 
       if (element.type === "text") {

--- a/source/scribbler/__tests__/Line.test.tsx
+++ b/source/scribbler/__tests__/Line.test.tsx
@@ -12,13 +12,13 @@ describe("Line", () => {
   test("renders text", () => {
     const text = scribbler.render(<Line>Sample text</Line>);
 
-    expect(text).toBe("Sample text\r\n");
+    expect(text).toBe("Sample text\n");
   });
 
   test("renders text with indent", () => {
     const text = scribbler.render(<Line indent={2}>Sample text</Line>);
 
-    expect(text).toBe("    Sample text\r\n");
+    expect(text).toBe("    Sample text\n");
   });
 
   test("renders text with color", () => {

--- a/tests/config-storePath.test.js
+++ b/tests/config-storePath.test.js
@@ -39,7 +39,7 @@ describe("'TSTYCHE_STORE_PATH' environment variable", () => {
     expect(existsSync(storeUrl)).toBe(true);
 
     expect(stdout).toMatch(/^adds TypeScript 5.2.2 to /);
-    expect(stdout).toMatch(/dummy-store\/5.2.2\r\n$/);
+    expect(stdout).toMatch(/dummy-store\/5.2.2\n$/);
     expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);

--- a/tests/feature-store.test.js
+++ b/tests/feature-store.test.js
@@ -33,7 +33,7 @@ describe("store manifest", () => {
 
     expect(existsSync(storeUrl)).toBe(false);
 
-    const { exitCode, stderr } = await spawnTyche(fixture, []);
+    const { exitCode, stderr } = await spawnTyche(fixture);
 
     expect(existsSync(storeUrl)).toBe(false);
 

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -137,7 +137,7 @@ describe("TypeScript 4.x", () => {
       env: { ["TSTYCHE_TYPESCRIPT_PATH"]: typescriptPath },
     });
 
-    expect(stdout).toMatch(RegExp(`^uses TypeScript ${version}\r\n`));
+    expect(stdout).toMatch(RegExp(`^uses TypeScript ${version}\n`));
     expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);
@@ -164,7 +164,7 @@ describe("TypeScript 5.x", () => {
       env: { ["TSTYCHE_TYPESCRIPT_PATH"]: typescriptPath },
     });
 
-    expect(stdout).toMatch(RegExp(`^uses TypeScript ${version}\r\n`));
+    expect(stdout).toMatch(RegExp(`^uses TypeScript ${version}\n`));
     expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -83,7 +83,7 @@ describe("warns if resolution of a tag may be outdated", () => {
       [
         "Warning: Failed to update metadata of the 'typescript' package from the registry.",
         `The resolution of the '${target}' tag may be outdated.`,
-      ].join("\r\n\r\n"),
+      ].join("\n\n"),
     );
   });
 });

--- a/tests/validation-target.test.js
+++ b/tests/validation-target.test.js
@@ -35,7 +35,7 @@ describe("'--target' command line option", () => {
         "",
         "Argument for the '--target' option must be a single tag or a comma separated list.",
         "Usage examples:",
-      ].join("\r\n"),
+      ].join("\n"),
     );
 
     expect(exitCode).toBe(1);
@@ -58,7 +58,7 @@ describe("'--target' command line option", () => {
         "",
         "Argument for the '--target' option must be a single tag or a comma separated list.",
         "Usage examples:",
-      ].join("\r\n"),
+      ].join("\n"),
     );
 
     expect(exitCode).toBe(1);
@@ -77,7 +77,7 @@ describe("'target' configuration file option", () => {
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixture, []);
+    const { exitCode, stderr, stdout } = await spawnTyche(fixture);
 
     expect(stdout).toBe("");
     expect(stderr).toMatch(
@@ -86,7 +86,7 @@ describe("'target' configuration file option", () => {
         "",
         "Item of the 'target' list must be a supported version tag.",
         "Supported tags:",
-      ].join("\r\n"),
+      ].join("\n"),
     );
 
     expect(exitCode).toBe(1);
@@ -114,7 +114,7 @@ describe("'target' configuration file option", () => {
         "",
         "Item of the 'target' list must be a supported version tag.",
         "Supported tags:",
-      ].join("\r\n"),
+      ].join("\n"),
     );
 
     expect(exitCode).toBe(1);


### PR DESCRIPTION
Makes the end of line sequence configurable and use `\n` as default. 

Currently `\r\n` is used to make VS Code's Testing API happy. I can use the option there.