### PR TITLE
feat(project): set `module: "preserve"` in the default compiler options

### DIFF
--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -74,7 +74,11 @@ export class ProjectService {
       target: "esnext" as ts.server.protocol.ScriptTarget,
     };
 
-    if (Version.isSatisfiedWith(this.compiler.version, "5")) {
+    if (Version.isSatisfiedWith(this.compiler.version, "5.4")) {
+      defaultCompilerOptions.module = "preserve" as ts.server.protocol.ModuleKind;
+    }
+
+    if (Version.isSatisfiedWith(this.compiler.version, "5.0")) {
       defaultCompilerOptions["allowImportingTsExtensions"] = true;
       defaultCompilerOptions.moduleResolution = "bundler" as ts.server.protocol.ModuleResolutionKind;
     }

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -123,7 +123,6 @@ describe("TypeScript 4.x", () => {
     "4.4.4",
     "4.5.5",
     "4.6.4",
-    "4.7.2",
     "4.7.4",
     "4.8.4",
     "4.9.5",
@@ -154,7 +153,10 @@ describe("TypeScript 5.x", () => {
     });
   });
 
-  test.each(["5.0.2", ...versionTags])("uses TypeScript %s as current target", async (version) => {
+  test.each([
+    "5.0.2",
+    ...versionTags,
+  ])("uses TypeScript %s as current target", async (version) => {
     await spawnTyche(fixtureUrl, ["--install", "--target", version]);
 
     const typescriptPath = fileURLToPath(new URL(`./${version}/node_modules/typescript/lib/typescript.js`, storeUrl));


### PR DESCRIPTION
Closes #109

Setting `module: "preserve"` in the default compiler options for inferred project that are using TypeScript 5.4 and up.

Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-5-4-beta/#support-for-require-calls-in-moduleresolution-bundler-and-module-preserve