### PR TITLE
fix(cli): do not select files, if `testFileMatch` is an empty list

### DIFF
--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -126,7 +126,7 @@ export class Cli {
 
     let testFiles: Array<string> = [];
 
-    if (!resolvedConfig.disableTestFileLookup) {
+    if (resolvedConfig.testFileMatch.length !== 0 && !resolvedConfig.disableTestFileLookup) {
       testFiles = configService.selectTestFiles();
 
       if (testFiles.length === 0) {

--- a/tests/__snapshots__/config-testFileMatch.test.js.snap
+++ b/tests/__snapshots__/config-testFileMatch.test.js.snap
@@ -46,6 +46,15 @@ Ran all test files.
 "
 `;
 
+exports[`'testFileMatch' configuration file option specified empty list, does not select files: stdout 1`] = `
+"Targets:    1 passed, 1 total
+Test files: 0 total
+Duration:   <<timestamp>>
+
+Ran all test files.
+"
+`;
+
 exports[`'testFileMatch' configuration file option specified pattern, selects only matching files: stdout 1`] = `
 "uses TypeScript <<version>>
 

--- a/tests/config-listFiles.test.js
+++ b/tests/config-listFiles.test.js
@@ -31,7 +31,7 @@ describe("'--listFiles' command line option", () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--listFiles"]);
 
     expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
-    expect(normalizeOutput(stderr)).toBe("");
+    expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);
   });
@@ -45,7 +45,7 @@ describe("'--listFiles' command line option", () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["isNumber", "--listFiles"]);
 
     expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
-    expect(normalizeOutput(stderr)).toBe("");
+    expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);
   });
@@ -59,7 +59,7 @@ describe("'--listFiles' command line option", () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--listFiles", "isString"]);
 
     expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
-    expect(normalizeOutput(stderr)).toBe("");
+    expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);
   });
@@ -74,7 +74,7 @@ describe("'--listFiles' command line option", () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--listFiles"]);
 
     expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
-    expect(normalizeOutput(stderr)).toBe("");
+    expect(stderr).toBe("");
 
     expect(exitCode).toBe(0);
   });

--- a/tests/config-testFileMatch.test.js
+++ b/tests/config-testFileMatch.test.js
@@ -84,4 +84,23 @@ describe("'testFileMatch' configuration file option", () => {
 
     expect(exitCode).toBe(0);
   });
+
+  test("specified empty list, does not select files", async () => {
+    const config = {
+      testFileMatch: [],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    expect(normalizeOutput(stdout)).toMatchSnapshot("stdout");
+    expect(stderr).toBe("");
+
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
When the `testFileMatch` option is specified as an empty list, no test files should be selected. This is similar how the `target` option works.