### PR TITLE
fix(expect, store): use strict subtyping check

### DIFF
--- a/examples/Options.tst.ts
+++ b/examples/Options.tst.ts
@@ -15,14 +15,14 @@ test("is assignable?", () => {
 });
 
 interface Options {
-  environment?: string;
+  readonly environment?: string;
   timers?: "fake" | "real";
 }
 
 const options: Options = {};
 
 test("is a match?", () => {
-  expect(options).type.toMatch<{ environment?: string }>();
+  expect(options).type.toMatch<{ readonly environment?: string }>();
   expect(options).type.toMatch<{ timers?: "fake" | "real" }>();
 });
 

--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -59,7 +59,9 @@ export class Expect {
 
   static assertTypeChecker(typeChecker: ts.TypeChecker): typeChecker is TypeChecker {
     return (
-      "isTypeAssignableTo" in typeChecker && "isTypeIdenticalTo" in typeChecker && "isTypeSubtypeOf" in typeChecker
+      "isTypeAssignableTo" in typeChecker
+      && "isTypeIdenticalTo" in typeChecker
+      && "isTypeSubtypeOf" in typeChecker
     );
   }
 

--- a/source/expect/ToMatch.ts
+++ b/source/expect/ToMatch.ts
@@ -15,7 +15,8 @@ export class ToMatch {
   }
 
   match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
-    const isMatch = this.typeChecker.isTypeSubtypeOf(sourceType, targetType);
+    const isMatch = this.typeChecker.isTypeStrictSubtypeOf?.(sourceType, targetType)
+      ?? this.typeChecker.isTypeSubtypeOf(sourceType, targetType);
 
     return {
       explain: () => this.#explain(sourceType, targetType, isNot),

--- a/source/expect/types.ts
+++ b/source/expect/types.ts
@@ -9,5 +9,6 @@ export interface MatchResult {
 export interface TypeChecker extends ts.TypeChecker {
   isTypeAssignableTo: (source: ts.Type, target: ts.Type) => boolean;
   isTypeIdenticalTo: (source: ts.Type, target: ts.Type) => boolean;
+  isTypeStrictSubtypeOf?: (source: ts.Type, target: ts.Type) => boolean;
   isTypeSubtypeOf: (source: ts.Type, target: ts.Type) => boolean;
 }

--- a/tests/__fixtures__/api-toMatch/__typetests__/toMatch.tst.ts
+++ b/tests/__fixtures__/api-toMatch/__typetests__/toMatch.tst.ts
@@ -32,6 +32,11 @@ test("difference from '.toBeAssignable()'", () => {
   // But an object type with an optional property is not a subtype
   // of the same object type without that particular property
   expect<{ a: string }>().type.not.toMatch<{ a: string; b?: number }>();
+
+  expect<{ a: string }>().type.toBeAssignable<{ readonly a: string }>();
+  // But an object type with a particular property is not a subtype
+  // of the same object type with that property marked 'readonly'
+  expect<{ readonly a: string }>().type.not.toMatch<{ a: string }>();
 });
 
 describe("received type", () => {

--- a/tests/__snapshots__/api-toMatch.test.js.snap
+++ b/tests/__snapshots__/api-toMatch.test.js.snap
@@ -3,99 +3,99 @@
 exports[`toMatch: stderr 1`] = `
 "Error: Type '{ b: number; }' is not a subtype of type '{ a: string; b?: number | undefined; }'.
 
-  44 |     expect<{ a: string; b?: number }>().type.toMatch<{ b?: number }>();
-  45 | 
-> 46 |     expect<{ a: string; b?: number }>().type.toMatch<{ b: number }>();
+  49 |     expect<{ a: string; b?: number }>().type.toMatch<{ b?: number }>();
+  50 | 
+> 51 |     expect<{ a: string; b?: number }>().type.toMatch<{ b: number }>();
      |                                              ^
-  47 |   });
-  48 | 
-  49 |   test("does NOT match expected type", () => {
+  52 |   });
+  53 | 
+  54 |   test("does NOT match expected type", () => {
 
-       at ./__typetests__/toMatch.tst.ts:46:46 ❭ received type ❭ matches expected type
+       at ./__typetests__/toMatch.tst.ts:51:46 ❭ received type ❭ matches expected type
 
 Error: Type '{ a: string; b?: number | undefined; }' is not a subtype of type '{ a: string; }'.
 
-  53 |     expect<{ a: string }>().type.not.toMatch<{ a: string; b?: number }>();
-  54 | 
-> 55 |     expect<{ a: string }>().type.toMatch<{ a: string; b?: number }>();
+  58 |     expect<{ a: string }>().type.not.toMatch<{ a: string; b?: number }>();
+  59 | 
+> 60 |     expect<{ a: string }>().type.toMatch<{ a: string; b?: number }>();
      |                                  ^
-  56 |   });
-  57 | 
-  58 |   test("matches expected value", () => {
+  61 |   });
+  62 | 
+  63 |   test("matches expected value", () => {
 
-       at ./__typetests__/toMatch.tst.ts:55:34 ❭ received type ❭ does NOT match expected type
+       at ./__typetests__/toMatch.tst.ts:60:34 ❭ received type ❭ does NOT match expected type
 
 Error: Type 'Names' is not a subtype of type '{ first: string; }'.
 
-  60 |     expect<{ first: string; last?: string }>().type.toMatch(getNames());
-  61 | 
-> 62 |     expect<{ first: string }>().type.toMatch(getNames());
+  65 |     expect<{ first: string; last?: string }>().type.toMatch(getNames());
+  66 | 
+> 67 |     expect<{ first: string }>().type.toMatch(getNames());
      |                                      ^
-  63 |   });
-  64 | 
-  65 |   test("does NOT match expected value", () => {
+  68 |   });
+  69 | 
+  70 |   test("does NOT match expected value", () => {
 
-       at ./__typetests__/toMatch.tst.ts:62:38 ❭ received type ❭ matches expected value
+       at ./__typetests__/toMatch.tst.ts:67:38 ❭ received type ❭ matches expected value
 
 Error: Type 'Names' is not a subtype of type '{ first?: string | undefined; }'.
 
-  66 |     expect<{ first?: string }>().type.not.toMatch(getNames());
-  67 | 
-> 68 |     expect<{ first?: string }>().type.toMatch(getNames());
+  71 |     expect<{ first?: string }>().type.not.toMatch(getNames());
+  72 | 
+> 73 |     expect<{ first?: string }>().type.toMatch(getNames());
      |                                       ^
-  69 |   });
-  70 | });
-  71 | 
+  74 |   });
+  75 | });
+  76 | 
 
-       at ./__typetests__/toMatch.tst.ts:68:39 ❭ received type ❭ does NOT match expected value
-
-Error: Type '{ last: string; }' is not a subtype of type 'Names'.
-
-  79 |     expect(getNames()).type.toMatch<{ last?: string }>();
-  80 | 
-> 81 |     expect(getNames()).type.toMatch<{ last: string }>();
-     |                             ^
-  82 |   });
-  83 | 
-  84 |   test("does NOT match expected type", () => {
-
-       at ./__typetests__/toMatch.tst.ts:81:29 ❭ received value ❭ matches expected type
+       at ./__typetests__/toMatch.tst.ts:73:39 ❭ received type ❭ does NOT match expected value
 
 Error: Type '{ last: string; }' is not a subtype of type 'Names'.
 
-  86 | 
-  87 |     expect(getNames()).type.not.toMatch<{ last: string }>();
-> 88 |     expect(getNames()).type.toMatch<{ last: string }>();
+  84 |     expect(getNames()).type.toMatch<{ last?: string }>();
+  85 | 
+> 86 |     expect(getNames()).type.toMatch<{ last: string }>();
      |                             ^
-  89 |   });
-  90 | 
-  91 |   test("matches expected value", () => {
+  87 |   });
+  88 | 
+  89 |   test("does NOT match expected type", () => {
 
-       at ./__typetests__/toMatch.tst.ts:88:29 ❭ received value ❭ does NOT match expected type
+       at ./__typetests__/toMatch.tst.ts:86:29 ❭ received value ❭ matches expected type
+
+Error: Type '{ last: string; }' is not a subtype of type 'Names'.
+
+  91 | 
+  92 |     expect(getNames()).type.not.toMatch<{ last: string }>();
+> 93 |     expect(getNames()).type.toMatch<{ last: string }>();
+     |                             ^
+  94 |   });
+  95 | 
+  96 |   test("matches expected value", () => {
+
+       at ./__typetests__/toMatch.tst.ts:93:29 ❭ received value ❭ does NOT match expected type
 
 Error: Type 'Names' is not a subtype of type '{ last: string; }'.
 
-   95 |     expect({ first: "One", last: "Two" }).type.toMatch(getNames());
-   96 | 
->  97 |     expect({ last: "Two" }).type.toMatch(getNames());
+  100 |     expect({ first: "One", last: "Two" }).type.toMatch(getNames());
+  101 | 
+> 102 |     expect({ last: "Two" }).type.toMatch(getNames());
       |                                  ^
-   98 |   });
-   99 | 
-  100 |   test("does NOT match expected value", () => {
+  103 |   });
+  104 | 
+  105 |   test("does NOT match expected value", () => {
 
-        at ./__typetests__/toMatch.tst.ts:97:34 ❭ received value ❭ matches expected value
+        at ./__typetests__/toMatch.tst.ts:102:34 ❭ received value ❭ matches expected value
 
 Error: Type 'Names' is a subtype of type '{ first: string; }'.
 
-  101 |     expect({ last: "Two" }).type.not.toMatch(getNames());
-  102 | 
-> 103 |     expect({ first: "One" }).type.not.toMatch(getNames());
+  106 |     expect({ last: "Two" }).type.not.toMatch(getNames());
+  107 | 
+> 108 |     expect({ first: "One" }).type.not.toMatch(getNames());
       |                                       ^
-  104 |   });
-  105 | });
-  106 | 
+  109 |   });
+  110 | });
+  111 | 
 
-        at ./__typetests__/toMatch.tst.ts:103:39 ❭ received value ❭ does NOT match expected value
+        at ./__typetests__/toMatch.tst.ts:108:39 ❭ received value ❭ does NOT match expected value
 
 "
 `;
@@ -119,7 +119,7 @@ fail ./__typetests__/toMatch.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      8 failed, 1 passed, 9 total
-Assertions: 8 failed, 28 passed, 36 total
+Assertions: 8 failed, 30 passed, 38 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -4,8 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
 import { clearFixture, getFixtureUrl, writeFixture } from "./__utils__/fixtureFactory.js";
 import { spawnTyche } from "./__utils__/spawnTyche.js";
 
-const toBeAssignableTestText = `
-import { expect, test } from "tstyche";
+const toBeAssignableTestText = `import { expect, test } from "tstyche";
 
 interface Sample {
   locale?: Array<"en" | "de">;
@@ -21,8 +20,7 @@ test("is assignable?", () => {
   });
 });`;
 
-const toEqualTestText = `
-import { expect, test } from "tstyche";
+const toEqualTestText = `import { expect, test } from "tstyche";
 
 interface Sample {
   getLength: () => number;
@@ -35,8 +33,7 @@ test("is equal?", () => {
 
 `;
 
-const toHavePropertyTestText = `
-import { expect } from "tstyche";
+const toHavePropertyTestText = `import { expect } from "tstyche";
 
 interface Sample {
   description: string;
@@ -51,24 +48,22 @@ expect<Sample>().type.not.toHaveProperty("setup");
 expect<Sample>().type.not.toHaveProperty("teardown");
 `;
 
-const toMatchTestText = `
-import { expect, test } from "tstyche";
+const toMatchTestText = `import { expect, test } from "tstyche";
 
 interface Options {
-  environment?: string;
+  readonly environment?: string;
   timers?: "fake" | "real";
 }
 
 const options: Options = {};
 
 test("is a match?", () => {
-  expect(options).type.toMatch<{ environment?: string }>();
+  expect(options).type.toMatch<{ readonly environment?: string }>();
   expect(options).type.toMatch<{ timers?: "fake" | "real" }>();
 });
 `;
 
-const toRaiseErrorTestText = `
-import { expect, test } from "tstyche";
+const toRaiseErrorTestText = `import { expect, test } from "tstyche";
 
 interface Matchers<R, T = unknown> {
   [key: string]: (expected: T) => R;
@@ -106,11 +101,11 @@ describe("TypeScript 4.x", () => {
   beforeAll(async () => {
     await writeFixture(fixtureUrl, {
       // 'moduleResolution: "node"' does not support self-referencing, but TSTyche needs 'import from "tstyche"' to be able to collect test nodes
-      ["__typetests__/toBeAssignable.test.ts"]: `// @ts-expect-error${toBeAssignableTestText}`,
-      ["__typetests__/toEqual.test.ts"]: `// @ts-expect-error${toEqualTestText}`,
-      ["__typetests__/toHaveProperty.test.ts"]: `// @ts-expect-error${toHavePropertyTestText}`,
-      ["__typetests__/toMatch.test.ts"]: `// @ts-expect-error${toMatchTestText}`,
-      ["__typetests__/toRaiseError.test.ts"]: `// @ts-expect-error${toRaiseErrorTestText}`,
+      ["__typetests__/toBeAssignable.test.ts"]: `// @ts-expect-error\n${toBeAssignableTestText}`,
+      ["__typetests__/toEqual.test.ts"]: `// @ts-expect-error\n${toEqualTestText}`,
+      ["__typetests__/toHaveProperty.test.ts"]: `// @ts-expect-error\n${toHavePropertyTestText}`,
+      ["__typetests__/toMatch.test.ts"]: `// @ts-expect-error\n${toMatchTestText}`,
+      ["__typetests__/toRaiseError.test.ts"]: `// @ts-expect-error\n${toRaiseErrorTestText}`,
     });
   });
 


### PR DESCRIPTION
Use strict subtyping check when possible (since TS 5.x). For example, the following example only passes with `readonly` modifier:

```ts
import { expect, test } from "tstyche";

interface Options {
  readonly environment?: string;
  timers?: "fake" | "real";
}

const options: Options = {};

test("is a match?", () => {
  expect(options).type.toMatch<{ readonly environment?: string }>();
  expect(options).type.toMatch<{ timers?: "fake" | "real" }>();
});
```