### PR TITLE
refactor(expect, runner, store): use the `isTypeRelatedTo()` method

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,8 +44,7 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn test:types --target 4.7,5.0,current
-      - run: yarn test:examples --skip Readonly --target 4.7
-      - run: yarn test:examples --target 5.0,current
+      - run: yarn test:examples --target 4.7,5.0,current
 
   test-node:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))

--- a/benchmarks/tstyche.bench.sh
+++ b/benchmarks/tstyche.bench.sh
@@ -10,7 +10,7 @@ hyperfine \
   'tstyche examples --target 5.2' \
   --command-name 'warm cache: tstyche examples --target 5.2' \
   --prepare '' \
-  'tstyche examples --skip Readonly --target 4.9' \
+  'tstyche examples --target 4.9' \
   --command-name 'warm cache: tstyche examples --target 4.9' \
   --prepare '' \
   'tstyche examples' \
@@ -19,6 +19,6 @@ hyperfine \
   'tstyche examples --target 5.2' \
   --command-name 'cold cache: tstyche examples --target 5.2' \
   --prepare 'tstyche --prune && npm cache clean --force' \
-  'tstyche examples --skip Readonly --target 4.9' \
+  'tstyche examples --target 4.9' \
   --command-name 'cold cache: tstyche examples --target 4.9' \
   --prepare 'tstyche --prune && npm cache clean --force'

--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -58,11 +58,7 @@ export class Expect {
   }
 
   static assertTypeChecker(typeChecker: ts.TypeChecker): typeChecker is TypeChecker {
-    return (
-      "isTypeAssignableTo" in typeChecker
-      && "isTypeIdenticalTo" in typeChecker
-      && "isTypeSubtypeOf" in typeChecker
-    );
+    return ("isTypeRelatedTo" in typeChecker && "relation" in typeChecker);
   }
 
   #getType(node: ts.Expression | ts.TypeNode) {
@@ -146,7 +142,7 @@ export class Expect {
 
         if (
           sourceType.flags & (this.compiler.TypeFlags.Any | this.compiler.TypeFlags.Never)
-          || !this.typeChecker.isTypeAssignableTo(sourceType, nonPrimitiveType)
+          || !this.typeChecker.isTypeRelatedTo(sourceType, nonPrimitiveType, this.typeChecker.relation.assignable)
         ) {
           this.#onSourceArgumentMustBeObjectType(assertion.source[0], expectResult);
 

--- a/source/expect/ToBeAssignable.ts
+++ b/source/expect/ToBeAssignable.ts
@@ -15,7 +15,7 @@ export class ToBeAssignable {
   }
 
   match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
-    const isMatch = this.typeChecker.isTypeAssignableTo(targetType, sourceType);
+    const isMatch = this.typeChecker.isTypeRelatedTo(targetType, sourceType, this.typeChecker.relation.assignable);
 
     return {
       explain: () => this.#explain(sourceType, targetType, isNot),

--- a/source/expect/ToEqual.ts
+++ b/source/expect/ToEqual.ts
@@ -15,7 +15,7 @@ export class ToEqual {
   }
 
   match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
-    const isMatch = this.typeChecker.isTypeIdenticalTo(sourceType, targetType);
+    const isMatch = this.typeChecker.isTypeRelatedTo(sourceType, targetType, this.typeChecker.relation.identity);
 
     return {
       explain: () => this.#explain(sourceType, targetType, isNot),

--- a/source/expect/ToMatch.ts
+++ b/source/expect/ToMatch.ts
@@ -15,8 +15,7 @@ export class ToMatch {
   }
 
   match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
-    const isMatch = this.typeChecker.isTypeStrictSubtypeOf?.(sourceType, targetType)
-      ?? this.typeChecker.isTypeSubtypeOf(sourceType, targetType);
+    const isMatch = this.typeChecker.isTypeRelatedTo(sourceType, targetType, this.typeChecker.relation.subtype);
 
     return {
       explain: () => this.#explain(sourceType, targetType, isNot),

--- a/source/expect/types.ts
+++ b/source/expect/types.ts
@@ -6,9 +6,9 @@ export interface MatchResult {
   isMatch: boolean;
 }
 
+type Relation = Map<string, unknown>;
+
 export interface TypeChecker extends ts.TypeChecker {
-  isTypeAssignableTo: (source: ts.Type, target: ts.Type) => boolean;
-  isTypeIdenticalTo: (source: ts.Type, target: ts.Type) => boolean;
-  isTypeStrictSubtypeOf?: (source: ts.Type, target: ts.Type) => boolean;
-  isTypeSubtypeOf: (source: ts.Type, target: ts.Type) => boolean;
+  isTypeRelatedTo: (source: ts.Type, target: ts.Type, relation: Relation) => boolean;
+  relation: { assignable: Relation; identity: Relation; subtype: Relation };
 }

--- a/source/runner/TestFileRunner.ts
+++ b/source/runner/TestFileRunner.ts
@@ -95,8 +95,7 @@ export class TestFileRunner {
     const typeChecker = program.getTypeChecker();
 
     if (!Expect.assertTypeChecker(typeChecker)) {
-      const text =
-        "The required 'isTypeAssignableTo()', 'isTypeIdenticalTo()' and 'isTypeSubtypeOf()' methods are missing in the provided type checker.";
+      const text = "The required 'isTypeRelatedTo()' method is missing in the provided type checker.";
 
       EventEmitter.dispatch(["file:error", { diagnostics: [Diagnostic.error(text)], result: fileResult }]);
 

--- a/source/store/StoreService.ts
+++ b/source/store/StoreService.ts
@@ -98,20 +98,18 @@ export class StoreService {
     for (const candidatePath of candidatePaths) {
       const sourceText = await fs.readFile(candidatePath, { encoding: "utf8" });
 
-      if (!sourceText.includes("isTypeAssignableTo")) {
+      if (!sourceText.includes("isTypeRelatedTo")) {
         continue;
       }
 
-      const exposedMethods = ["isTypeIdenticalTo", "isTypeSubtypeOf"];
-
-      if (sourceText.includes("isTypeStrictSubtypeOf")) {
-        // the 'isTypeStrictSubtypeOf()' method got added since TypeScript 5
-        exposedMethods.push("isTypeStrictSubtypeOf");
-      }
+      const toExpose = [
+        "isTypeRelatedTo",
+        "relation: { assignable: assignableRelation, identity: identityRelation, subtype: strictSubtypeRelation }",
+      ];
 
       const modifiedSourceText = sourceText.replace(
         "return checker;",
-        `return { ...checker, ${exposedMethods.join(", ")} };`,
+        `return { ...checker, ${toExpose.join(", ")} };`,
       );
 
       const compiledWrapper = vm.compileFunction(


### PR DESCRIPTION
Refactoring to use the `isTypeRelatedTo()` method for type relationship checks. Only difference: this makes possible to have strict subtype relationship checks in TypeScript 4.x.