### PR TITLE
fix(config, store): do not validated tags if the store failed to open

### DIFF
--- a/source/config/OptionValidator.ts
+++ b/source/config/OptionValidator.ts
@@ -38,7 +38,7 @@ export class OptionValidator {
         break;
 
       case "target":
-        if (!(await this.#storeService.validateTag(optionValue))) {
+        if (await this.#storeService.validateTag(optionValue) === false) {
           this.#onDiagnostic(
             Diagnostic.error(
               [

--- a/source/store/StoreService.ts
+++ b/source/store/StoreService.ts
@@ -172,7 +172,7 @@ export class StoreService {
     await this.open(signal);
 
     if (!this.#manifest) {
-      return false;
+      return undefined;
     }
 
     if (

--- a/source/store/StoreService.ts
+++ b/source/store/StoreService.ts
@@ -164,7 +164,7 @@ export class StoreService {
     await this.#manifestWorker.open(signal, { refresh: true });
   }
 
-  async validateTag(tag: string, signal?: AbortSignal): Promise<boolean> {
+  async validateTag(tag: string, signal?: AbortSignal): Promise<boolean | undefined> {
     if (tag === "current") {
       return Environment.typescriptPath != null;
     }


### PR DESCRIPTION
If the store failed to open, the 'Supported tags..." message should be omitted. Currently it creates unnecessary noise.