### PR TITLE
refactor: use `String.prototype.replace()`

### DIFF
--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -24,7 +24,7 @@ export class CodeSpanText implements JSX.ElementClass {
         : this.props.file.getPositionOfLineAndCharacter(index + 1, 0);
 
       const lineNumberText = String(index + 1);
-      const lineText = this.props.file.text.slice(lineStart, lineEnd).trimEnd().replaceAll("\t", " ");
+      const lineText = this.props.file.text.slice(lineStart, lineEnd).trimEnd().replace(/\t/g, " ");
 
       if (index === markedLine) {
         codeSpan.push(

--- a/source/path/Path.ts
+++ b/source/path/Path.ts
@@ -14,7 +14,7 @@ export class Path {
       return filePath;
     }
 
-    return filePath.replaceAll("\\", "/");
+    return filePath.replace(/\\/g, "/");
   }
 
   static relative(from: string, to: string): string {

--- a/source/scribbler/Scribbler.ts
+++ b/source/scribbler/Scribbler.ts
@@ -91,7 +91,7 @@ export class Scribbler {
     const indentStep = "  ";
     const notEmptyLineRegExp = /^(?!$)/gm;
 
-    return lines.replaceAll(notEmptyLineRegExp, indentStep.repeat(level));
+    return lines.replace(notEmptyLineRegExp, indentStep.repeat(level));
   }
 
   /**

--- a/tests/__utils__/normalizeOutput.js
+++ b/tests/__utils__/normalizeOutput.js
@@ -1,9 +1,11 @@
+const rootPath = process.cwd().replace(/\\/g, "/");
+
 /**
  * @param {string} output
  */
 export function normalizeOutput(output) {
   return output
-    .replaceAll(process.cwd().replaceAll("\\", "/"), "<<cwd>>")
-    .replaceAll(/(Duration:\s{2})\s((?:\d\.?)+s)/g, "$1 <<timestamp>>")
-    .replaceAll(/(uses TypeScript)\s(\d\.?)+/g, "$1 <<version>>");
+    .replace(new RegExp(rootPath, "g"), "<<cwd>>")
+    .replace(/(Duration:\s{2})\s((?:\d\.?)+s)/g, "$1 <<timestamp>>")
+    .replace(/(uses TypeScript)\s(\d\.?)+/g, "$1 <<version>>");
 }


### PR DESCRIPTION
Part of #136

This PR replaces `String.prototype.replaceAll()` with `String.prototype.replace()`.