### PR TITLE
feat(collect, expect): add `.toBeAssignableTo()` and `.toBeAssignableWith()` matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ test("handles numbers", () => {
 
 Here is the list of all matchers:
 
-- `.toBeAssignable()`, `.toEqual()`, `.toMatch()` compares types or types of expression,
+- `.toBeAssignableTo()`, `.toBeAssignableWith()`, `.toEqual()`, `.toMatch()` compares types or types of expression,
 - `.toHaveProperty()` looks up keys on an object type,
 - `.toRaiseError()` captures the type error message or code,
 - `.toBeString()`, `.toBeNumber()`, `.toBeVoid()` and 9 more shorthand checks for primitive types.

--- a/examples/Awaitable.tst.ts
+++ b/examples/Awaitable.tst.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "tstyche";
+
+type Awaitable<T> = T | PromiseLike<T>;
+
+test("is assignable with?", () => {
+  expect<Awaitable<string>>().type.toBeAssignableWith("abc");
+  expect<Awaitable<string>>().type.toBeAssignableWith(Promise.resolve("abc"));
+
+  expect<Awaitable<string>>().type.not.toBeAssignableWith(123);
+  expect<Awaitable<string>>().type.not.toBeAssignableWith(Promise.resolve(123));
+});

--- a/examples/JsonObject.tst.ts
+++ b/examples/JsonObject.tst.ts
@@ -9,31 +9,31 @@ interface JsonObject {
 }
 
 test("JsonObject", () => {
-  expect<JsonObject>().type.toBeAssignable({
+  expect<JsonObject>().type.toBeAssignableWith({
     caption: "test",
   });
 
-  expect<JsonObject>().type.toBeAssignable({
+  expect<JsonObject>().type.toBeAssignableWith({
     count: 100,
   });
 
-  expect<JsonObject>().type.toBeAssignable({
+  expect<JsonObject>().type.toBeAssignableWith({
     isTest: true,
   });
 
-  expect<JsonObject>().type.toBeAssignable({
+  expect<JsonObject>().type.toBeAssignableWith({
     values: [10, 20, { x: 1, y: 2 }, true, "test", ["a", "b"]],
   });
 
-  expect<JsonObject>().type.toBeAssignable({
+  expect<JsonObject>().type.toBeAssignableWith({
     location: { name: "test", start: [1, 2], valid: false, x: 10, y: 20 },
   });
 
-  expect<JsonObject>().type.not.toBeAssignable({
+  expect<JsonObject>().type.not.toBeAssignableWith({
     isTrue: () => true,
   });
 
-  expect<JsonObject>().type.not.toBeAssignable({
+  expect<JsonObject>().type.not.toBeAssignableWith({
     kPlay: Symbol("play"),
   });
 });

--- a/examples/Options.tst.ts
+++ b/examples/Options.tst.ts
@@ -6,9 +6,9 @@ interface Options {
 }
 
 test("is assignable?", () => {
-  expect<Options>().type.toBeAssignable({});
+  expect<Options>().type.toBeAssignableWith({});
 
-  expect<Options>().type.toBeAssignable({
+  expect<Options>().type.toBeAssignableWith({
     locale: ["en" as const, "de" as const],
     root: "./",
   });
@@ -26,10 +26,10 @@ test("is a match?", () => {
   expect(options).type.toMatch<{ timers?: "fake" | "real" }>();
 });
 
-expect<"fake" | "real">().type.toBeAssignable<"fake">();
+expect<"fake" | "real">().type.toBeAssignableWith<"fake">();
 // But type '"fake" | "real"' is not assignable to type '"fake"'
 expect<"fake" | "real">().type.not.toMatch<"fake">();
 
-expect<string>().type.toBeAssignable<"node">();
+expect<string>().type.toBeAssignableWith<"node">();
 // But type 'string' is not assignable to type '"node"'
 expect<string>().type.not.toMatch<"node">();

--- a/examples/Set.tst.ts
+++ b/examples/Set.tst.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "tstyche";
+
+test("is assignable to?", () => {
+  expect(new Set(["abc"])).type.toBeAssignableTo<Set<string>>();
+  expect(new Set([123])).type.toBeAssignableTo<Set<number>>();
+
+  expect(new Set([123, "abc"])).type.not.toBeAssignableTo<Set<string>>();
+  expect(new Set([123, "abc"])).type.not.toBeAssignableTo<Set<number>>();
+});

--- a/source/collect/CollectService.ts
+++ b/source/collect/CollectService.ts
@@ -9,6 +9,8 @@ export class CollectService {
   readonly matcherIdentifiers = [
     "toBeAny",
     "toBeAssignable",
+    "toBeAssignableTo",
+    "toBeAssignableWith",
     "toBeBigInt",
     "toBeBoolean",
     "toBeNever",

--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -5,6 +5,8 @@ import { EventEmitter } from "#events";
 import type { ExpectResult } from "#result";
 import { PrimitiveTypeMatcher } from "./PrimitiveTypeMatcher.js";
 import { ToBeAssignable } from "./ToBeAssignable.js";
+import { ToBeAssignableTo } from "./ToBeAssignableTo.js";
+import { ToBeAssignableWith } from "./ToBeAssignableWith.js";
 import { ToEqual } from "./ToEqual.js";
 import { ToHaveProperty } from "./ToHaveProperty.js";
 import { ToMatch } from "./ToMatch.js";
@@ -14,6 +16,8 @@ import type { MatchResult, TypeChecker } from "./types.js";
 export class Expect {
   toBeAny: PrimitiveTypeMatcher;
   toBeAssignable: ToBeAssignable;
+  toBeAssignableTo: ToBeAssignableTo;
+  toBeAssignableWith: ToBeAssignableWith;
   toBeBigInt: PrimitiveTypeMatcher;
   toBeBoolean: PrimitiveTypeMatcher;
   toBeNever: PrimitiveTypeMatcher;
@@ -36,6 +40,8 @@ export class Expect {
   ) {
     this.toBeAny = new PrimitiveTypeMatcher(this.typeChecker, this.compiler.TypeFlags.Any);
     this.toBeAssignable = new ToBeAssignable(this.typeChecker);
+    this.toBeAssignableTo = new ToBeAssignableTo(this.typeChecker);
+    this.toBeAssignableWith = new ToBeAssignableWith(this.typeChecker);
     this.toBeBigInt = new PrimitiveTypeMatcher(this.typeChecker, this.compiler.TypeFlags.BigInt);
     this.toBeBoolean = new PrimitiveTypeMatcher(this.typeChecker, this.compiler.TypeFlags.Boolean);
     this.toBeNever = new PrimitiveTypeMatcher(this.typeChecker, this.compiler.TypeFlags.Never);
@@ -86,6 +92,8 @@ export class Expect {
 
     switch (matcherNameText) {
       case "toBeAssignable":
+      case "toBeAssignableTo":
+      case "toBeAssignableWith":
       case "toEqual":
       case "toMatch":
         if (assertion.source[0] == null) {

--- a/source/expect/RelationMatcherBaseNew.ts
+++ b/source/expect/RelationMatcherBaseNew.ts
@@ -1,0 +1,28 @@
+import type ts from "typescript";
+import { Diagnostic } from "#diagnostic";
+import type { MatchResult, Relation, TypeChecker } from "./types.js";
+
+export abstract class RelationMatcherBase {
+  abstract relation: Relation;
+  abstract relationExplanationText: string;
+
+  constructor(public typeChecker: TypeChecker) {}
+
+  protected explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic> {
+    const sourceTypeText = this.typeChecker.typeToString(sourceType);
+    const targetTypeText = this.typeChecker.typeToString(targetType);
+
+    return isNot
+      ? [Diagnostic.error(`Type '${sourceTypeText}' is ${this.relationExplanationText} type '${targetTypeText}'.`)]
+      : [Diagnostic.error(`Type '${sourceTypeText}' is not ${this.relationExplanationText} type '${targetTypeText}'.`)];
+  }
+
+  match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
+    const isMatch = this.typeChecker.isTypeRelatedTo(sourceType, targetType, this.relation);
+
+    return {
+      explain: () => this.explain(sourceType, targetType, isNot),
+      isMatch,
+    };
+  }
+}

--- a/source/expect/ToBeAssignableTo.ts
+++ b/source/expect/ToBeAssignableTo.ts
@@ -1,0 +1,6 @@
+import { RelationMatcherBase } from "./RelationMatcherBaseNew.js";
+
+export class ToBeAssignableTo extends RelationMatcherBase {
+  relation = this.typeChecker.relation.assignable;
+  relationExplanationText = "assignable to";
+}

--- a/source/expect/ToBeAssignableWith.ts
+++ b/source/expect/ToBeAssignableWith.ts
@@ -1,0 +1,17 @@
+import type ts from "typescript";
+import { RelationMatcherBase } from "./RelationMatcherBaseNew.js";
+import type { MatchResult } from "./types.js";
+
+export class ToBeAssignableWith extends RelationMatcherBase {
+  relation = this.typeChecker.relation.assignable;
+  relationExplanationText = "assignable with";
+
+  override match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
+    const isMatch = this.typeChecker.isTypeRelatedTo(targetType, sourceType, this.relation);
+
+    return {
+      explain: () => this.explain(sourceType, targetType, isNot),
+      isMatch,
+    };
+  }
+}

--- a/source/types.ts
+++ b/source/types.ts
@@ -79,6 +79,32 @@ interface Matchers {
     (target: unknown): void;
   };
   /**
+   * Checks if the source type is assignable to the target type.
+   */
+  toBeAssignableTo: {
+    /**
+     * Checks if the source type is assignable to the target type.
+     */
+    <Target>(): void;
+    /**
+     * Checks if the source type is assignable to type of the target expression.
+     */
+    (target: unknown): void;
+  };
+  /**
+   * Checks if the source type is assignable with the target type.
+   */
+  toBeAssignableWith: {
+    /**
+     * Checks if the source type is assignable with the target type.
+     */
+    <Target>(): void;
+    /**
+     * Checks if the source type is assignable with type of the target expression.
+     */
+    (target: unknown): void;
+  };
+  /**
    * Checks if the source type is `bigint`.
    */
   toBeBigInt: () => void;

--- a/tests/__fixtures__/api-toBeAssignableTo/__typetests__/toBeAssignableTo.tst.ts
+++ b/tests/__fixtures__/api-toBeAssignableTo/__typetests__/toBeAssignableTo.tst.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "tstyche";
+
+interface Names {
+  first: string;
+  last?: string;
+}
+
+describe("source type", () => {
+  test("is assignable to target expression?", () => {
+    expect<{ first: string }>().type.toBeAssignableTo({ first: "Jane" });
+
+    expect<{ first?: string }>().type.toBeAssignableTo({ first: "Jane" });
+  });
+
+  test("is NOT assignable to target expression?", () => {
+    expect<Names>().type.not.toBeAssignableTo({ first: "Rose", last: "Smith" });
+    expect<Names>().type.not.toBeAssignableTo({ first: "Rose", last: undefined });
+    expect<Names>().type.not.toBeAssignableTo({ middle: "O." });
+
+    expect<{ first: string }>().type.not.toBeAssignableTo({ first: "Jane" });
+  });
+
+  test("is assignable to target type?", () => {
+    expect<Names>().type.toBeAssignableTo<{ first: string }>();
+    expect<Names>().type.toBeAssignableTo<{ first: string; last?: string }>();
+
+    expect<Names>().type.toBeAssignableTo<{ middle: string }>();
+  });
+
+  test("is NOT assignable to target type?", () => {
+    expect<Names>().type.not.toBeAssignableTo<{ first: string; last: string }>();
+    expect<Names>().type.not.toBeAssignableTo<{ first: string; last: undefined }>();
+    expect<Names>().type.not.toBeAssignableTo<{ middle: string }>();
+
+    expect<Names>().type.not.toBeAssignableTo<{ first: string }>();
+  });
+});
+
+describe("source expression", () => {
+  test("is assignable to target expression?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose", last: "Smith" });
+
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose" });
+  });
+
+  test("is NOT assignable to target expression?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableTo({ first: "Rose" });
+
+    expect({ first: "Jane" }).type.not.toBeAssignableTo({ first: "Rose" });
+  });
+
+  test("is assignable to target type?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ first: string; last: string }>();
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ first: string; last?: string }>();
+
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ middle: string }>();
+  });
+
+  test("is NOT assignable to type?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableTo<{ middle: string }>();
+
+    expect({ first: "Jane" }).type.not.toBeAssignableTo<{ first: string }>();
+  });
+});

--- a/tests/__fixtures__/api-toBeAssignableTo/tsconfig.json
+++ b/tests/__fixtures__/api-toBeAssignableTo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/tests/__fixtures__/api-toBeAssignableWith/__typetests__/toBeAssignableWith.tst.ts
+++ b/tests/__fixtures__/api-toBeAssignableWith/__typetests__/toBeAssignableWith.tst.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "tstyche";
+
+interface Names {
+  first: string;
+  last?: string;
+}
+
+describe("source type", () => {
+  test("is assignable target expression?", () => {
+    expect<Names>().type.toBeAssignableWith({ first: "Rose" });
+    expect<Names>().type.toBeAssignableWith({ first: "Rose", last: "Smith" });
+    expect<Names>().type.toBeAssignableWith({ first: "Rose", last: undefined });
+
+    expect<Names>().type.toBeAssignableWith({ middle: "O." });
+  });
+
+  test("is NOT assignable target expression?", () => {
+    expect<Names>().type.not.toBeAssignableWith({ middle: "O." });
+
+    expect<Names>().type.not.toBeAssignableWith({ first: "Rose" });
+  });
+
+  test("is assignable target type?", () => {
+    expect<Names>().type.toBeAssignableWith<{ first: string }>();
+    expect<Names>().type.toBeAssignableWith<{ first: string; last: string }>();
+    expect<Names>().type.toBeAssignableWith<{ first: string; last: undefined }>();
+    expect<Names>().type.toBeAssignableWith<{ first: string; last?: string }>();
+
+    expect<Names>().type.toBeAssignableWith<{ middle: string }>();
+  });
+
+  test("is NOT assignable target type?", () => {
+    expect<Names>().type.not.toBeAssignableWith<{ middle: string }>();
+
+    expect<Names>().type.not.toBeAssignableWith<{ first: string }>();
+  });
+});
+
+describe("source expression", () => {
+  test("is assignable target expression?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ first: "Rose", last: "Smith" });
+
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ middle: "O." });
+  });
+
+  test("is NOT assignable target expression?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableWith({ middle: "O." });
+
+    expect({ first: "Jane" }).type.not.toBeAssignableWith({ first: "Rose" });
+  });
+
+  test("is assignable target type?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ first: string; last: string }>();
+
+    expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ middle: string }>();
+  });
+
+  test("is NOT assignable type?", () => {
+    expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableWith<{ middle: string }>();
+
+    expect({ first: "Jane" }).type.not.toBeAssignableWith<{ first: string }>();
+  });
+});

--- a/tests/__fixtures__/api-toBeAssignableWith/tsconfig.json
+++ b/tests/__fixtures__/api-toBeAssignableWith/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/tests/__fixtures__/api-toMatch/__typetests__/toMatch.tst.ts
+++ b/tests/__fixtures__/api-toMatch/__typetests__/toMatch.tst.ts
@@ -17,23 +17,23 @@ interface Size {
 }
 declare function getSize(): Size;
 
-test("difference from '.toBeAssignable()'", () => {
+test("difference from '.toBeAssignableTo()'", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  expect<{ a: string }>().type.toBeAssignable<any>();
+  expect<any>().type.toBeAssignableTo<string>();
   // But all types are not subtypes of the 'any' type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  expect<any>().type.not.toMatch<{ a: string }>();
+  expect<any>().type.not.toMatch<string>();
 
-  expect<Direction>().type.toBeAssignable<number>();
+  expect<number>().type.toBeAssignableTo<Direction>();
   // But an enum type is not a subtype of a number
   expect<number>().type.not.toMatch<Direction>();
 
-  expect<{ a: string; b?: number }>().type.toBeAssignable<{ a: string }>();
+  expect<{ a: string }>().type.toBeAssignableTo<{ a: string; b?: number }>();
   // But an object type with an optional property is not a subtype
   // of the same object type without that particular property
   expect<{ a: string }>().type.not.toMatch<{ a: string; b?: number }>();
 
-  expect<{ a: string }>().type.toBeAssignable<{ readonly a: string }>();
+  expect<{ readonly a: string }>().type.toBeAssignableTo<{ a: string }>();
   // But an object type with a particular property is not a subtype
   // of the same object type with that property marked 'readonly'
   expect<{ readonly a: string }>().type.not.toMatch<{ a: string }>();

--- a/tests/__snapshots__/api-toBeAssignableTo-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableTo-stderr.snap.txt
@@ -1,0 +1,96 @@
+Error: Type '{ first?: string | undefined; }' is not assignable to type '{ first: string; }'.
+
+  10 |     expect<{ first: string }>().type.toBeAssignableTo({ first: "Jane" });
+  11 | 
+> 12 |     expect<{ first?: string }>().type.toBeAssignableTo({ first: "Jane" });
+     |                                       ^
+  13 |   });
+  14 | 
+  15 |   test("is NOT assignable to target expression?", () => {
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:12:39 ❭ source type ❭ is assignable to target expression?
+
+Error: Type '{ first: string; }' is assignable to type '{ first: string; }'.
+
+  18 |     expect<Names>().type.not.toBeAssignableTo({ middle: "O." });
+  19 | 
+> 20 |     expect<{ first: string }>().type.not.toBeAssignableTo({ first: "Jane" });
+     |                                          ^
+  21 |   });
+  22 | 
+  23 |   test("is assignable to target type?", () => {
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:20:42 ❭ source type ❭ is NOT assignable to target expression?
+
+Error: Type 'Names' is not assignable to type '{ middle: string; }'.
+
+  25 |     expect<Names>().type.toBeAssignableTo<{ first: string; last?: string }>();
+  26 | 
+> 27 |     expect<Names>().type.toBeAssignableTo<{ middle: string }>();
+     |                          ^
+  28 |   });
+  29 | 
+  30 |   test("is NOT assignable to target type?", () => {
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:27:26 ❭ source type ❭ is assignable to target type?
+
+Error: Type 'Names' is assignable to type '{ first: string; }'.
+
+  33 |     expect<Names>().type.not.toBeAssignableTo<{ middle: string }>();
+  34 | 
+> 35 |     expect<Names>().type.not.toBeAssignableTo<{ first: string }>();
+     |                              ^
+  36 |   });
+  37 | });
+  38 | 
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:35:30 ❭ source type ❭ is NOT assignable to target type?
+
+Error: Type '{ first: string; last: string; }' is not assignable to type '{ first: string; }'.
+
+  41 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose", last: "Smith" });
+  42 | 
+> 43 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose" });
+     |                                                  ^
+  44 |   });
+  45 | 
+  46 |   test("is NOT assignable to target expression?", () => {
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:43:50 ❭ source expression ❭ is assignable to target expression?
+
+Error: Type '{ first: string; }' is assignable to type '{ first: string; }'.
+
+  47 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableTo({ first: "Rose" });
+  48 | 
+> 49 |     expect({ first: "Jane" }).type.not.toBeAssignableTo({ first: "Rose" });
+     |                                        ^
+  50 |   });
+  51 | 
+  52 |   test("is assignable to target type?", () => {
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:49:40 ❭ source expression ❭ is NOT assignable to target expression?
+
+Error: Type '{ first: string; last: string; }' is not assignable to type '{ middle: string; }'.
+
+  54 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ first: string; last?: string }>();
+  55 | 
+> 56 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ middle: string }>();
+     |                                                  ^
+  57 |   });
+  58 | 
+  59 |   test("is NOT assignable to type?", () => {
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:56:50 ❭ source expression ❭ is assignable to target type?
+
+Error: Type '{ first: string; }' is assignable to type '{ first: string; }'.
+
+  60 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableTo<{ middle: string }>();
+  61 | 
+> 62 |     expect({ first: "Jane" }).type.not.toBeAssignableTo<{ first: string }>();
+     |                                        ^
+  63 |   });
+  64 | });
+  65 | 
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:62:40 ❭ source expression ❭ is NOT assignable to type?
+

--- a/tests/__snapshots__/api-toBeAssignableTo-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableTo-stdout.snap.txt
@@ -1,0 +1,21 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/toBeAssignableTo.tst.ts
+  source type
+    × is assignable to target expression?
+    × is NOT assignable to target expression?
+    × is assignable to target type?
+    × is NOT assignable to target type?
+  source expression
+    × is assignable to target expression?
+    × is NOT assignable to target expression?
+    × is assignable to target type?
+    × is NOT assignable to type?
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      8 failed, 8 total
+Assertions: 8 failed, 14 passed, 22 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/api-toBeAssignableWith-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableWith-stderr.snap.txt
@@ -1,0 +1,96 @@
+Error: Type 'Names' is not assignable with type '{ middle: string; }'.
+
+  12 |     expect<Names>().type.toBeAssignableWith({ first: "Rose", last: undefined });
+  13 | 
+> 14 |     expect<Names>().type.toBeAssignableWith({ middle: "O." });
+     |                          ^
+  15 |   });
+  16 | 
+  17 |   test("is NOT assignable target expression?", () => {
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:14:26 ❭ source type ❭ is assignable target expression?
+
+Error: Type 'Names' is assignable with type '{ first: string; }'.
+
+  18 |     expect<Names>().type.not.toBeAssignableWith({ middle: "O." });
+  19 | 
+> 20 |     expect<Names>().type.not.toBeAssignableWith({ first: "Rose" });
+     |                              ^
+  21 |   });
+  22 | 
+  23 |   test("is assignable target type?", () => {
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:20:30 ❭ source type ❭ is NOT assignable target expression?
+
+Error: Type 'Names' is not assignable with type '{ middle: string; }'.
+
+  27 |     expect<Names>().type.toBeAssignableWith<{ first: string; last?: string }>();
+  28 | 
+> 29 |     expect<Names>().type.toBeAssignableWith<{ middle: string }>();
+     |                          ^
+  30 |   });
+  31 | 
+  32 |   test("is NOT assignable target type?", () => {
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:29:26 ❭ source type ❭ is assignable target type?
+
+Error: Type 'Names' is assignable with type '{ first: string; }'.
+
+  33 |     expect<Names>().type.not.toBeAssignableWith<{ middle: string }>();
+  34 | 
+> 35 |     expect<Names>().type.not.toBeAssignableWith<{ first: string }>();
+     |                              ^
+  36 |   });
+  37 | });
+  38 | 
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:35:30 ❭ source type ❭ is NOT assignable target type?
+
+Error: Type '{ first: string; last: string; }' is not assignable with type '{ middle: string; }'.
+
+  41 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ first: "Rose", last: "Smith" });
+  42 | 
+> 43 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ middle: "O." });
+     |                                                  ^
+  44 |   });
+  45 | 
+  46 |   test("is NOT assignable target expression?", () => {
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:43:50 ❭ source expression ❭ is assignable target expression?
+
+Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
+
+  47 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableWith({ middle: "O." });
+  48 | 
+> 49 |     expect({ first: "Jane" }).type.not.toBeAssignableWith({ first: "Rose" });
+     |                                        ^
+  50 |   });
+  51 | 
+  52 |   test("is assignable target type?", () => {
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:49:40 ❭ source expression ❭ is NOT assignable target expression?
+
+Error: Type '{ first: string; last: string; }' is not assignable with type '{ middle: string; }'.
+
+  53 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ first: string; last: string }>();
+  54 | 
+> 55 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ middle: string }>();
+     |                                                  ^
+  56 |   });
+  57 | 
+  58 |   test("is NOT assignable type?", () => {
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:55:50 ❭ source expression ❭ is assignable target type?
+
+Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
+
+  59 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableWith<{ middle: string }>();
+  60 | 
+> 61 |     expect({ first: "Jane" }).type.not.toBeAssignableWith<{ first: string }>();
+     |                                        ^
+  62 |   });
+  63 | });
+  64 | 
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:61:40 ❭ source expression ❭ is NOT assignable type?
+

--- a/tests/__snapshots__/api-toBeAssignableWith-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableWith-stdout.snap.txt
@@ -1,0 +1,21 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/toBeAssignableWith.tst.ts
+  source type
+    × is assignable target expression?
+    × is NOT assignable target expression?
+    × is assignable target type?
+    × is NOT assignable target type?
+  source expression
+    × is assignable target expression?
+    × is NOT assignable target expression?
+    × is assignable target type?
+    × is NOT assignable type?
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      8 failed, 8 total
+Assertions: 8 failed, 13 passed, 21 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/api-toMatch-stdout.snap.txt
+++ b/tests/__snapshots__/api-toMatch-stdout.snap.txt
@@ -1,7 +1,7 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toMatch.tst.ts
-  + difference from '.toBeAssignable()'
+  + difference from '.toBeAssignableTo()'
   received type
     × matches expected type
     × does NOT match expected type

--- a/tests/api-toBeAssignableTo.test.js
+++ b/tests/api-toBeAssignableTo.test.js
@@ -1,0 +1,30 @@
+import { test } from "mocha";
+import * as tstyche from "tstyche";
+import * as assert from "./__utilities__/assert.js";
+import { getFixtureFileUrl, getTestFileName } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName);
+
+test("'toBeAssignableTo' implementation", function() {
+  tstyche.expect({ a: "sample" }).type.toBeAssignableTo({ a: "sample" });
+  tstyche.expect({ a: "sample" }).type.not.toBeAssignableTo({ b: "sample" });
+});
+
+test("toBeAssignableTo", async function() {
+  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+  await assert.matchSnapshot(normalizeOutput(stdout), {
+    fileName: `${testFileName}-stdout`,
+    testFileUrl: import.meta.url,
+  });
+
+  await assert.matchSnapshot(stderr, {
+    fileName: `${testFileName}-stderr`,
+    testFileUrl: import.meta.url,
+  });
+
+  assert.equal(exitCode, 1);
+});

--- a/tests/api-toBeAssignableWith.test.js
+++ b/tests/api-toBeAssignableWith.test.js
@@ -1,0 +1,30 @@
+import { test } from "mocha";
+import * as tstyche from "tstyche";
+import * as assert from "./__utilities__/assert.js";
+import { getFixtureFileUrl, getTestFileName } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName);
+
+test("'toBeAssignableWith' implementation", function() {
+  tstyche.expect({ a: "sample" }).type.toBeAssignableWith({ a: "sample" });
+  tstyche.expect({ a: "sample" }).type.not.toBeAssignableWith({ b: "sample" });
+});
+
+test("toBeAssignableWith", async function() {
+  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+  await assert.matchSnapshot(normalizeOutput(stdout), {
+    fileName: `${testFileName}-stdout`,
+    testFileUrl: import.meta.url,
+  });
+
+  await assert.matchSnapshot(stderr, {
+    fileName: `${testFileName}-stderr`,
+    testFileUrl: import.meta.url,
+  });
+
+  assert.equal(exitCode, 1);
+});

--- a/tests/feature-runner.test.js
+++ b/tests/feature-runner.test.js
@@ -200,7 +200,7 @@ test("'strictFunctionTypes': true", () => {
     return a;
   }
 
-  expect<(a: string | number) => void>().type.not.toBeAssignable(y);
+  expect<(a: string | number) => void>().type.not.toBeAssignableWith(y);
 });
 
 test("'useUnknownInCatchVariables': false", () => {

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -5,20 +5,26 @@ import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
 
-const toBeAssignableTestText = `import { expect, test } from "tstyche";
+const toBeAssignableToTestText = `import { expect, test } from "tstyche";
 
-interface Sample {
-  locale?: Array<"en" | "de">;
-  root?: string;
-}
+test("is assignable to?", () => {
+  expect(new Set(["abc"])).type.toBeAssignableTo<Set<string>>();
+  expect(new Set([123])).type.toBeAssignableTo<Set<number>>();
 
-test("is assignable?", () => {
-  expect<Sample>().type.toBeAssignable({});
+  expect(new Set([123, "abc"])).type.not.toBeAssignableTo<Set<string>>();
+  expect(new Set([123, "abc"])).type.not.toBeAssignableTo<Set<number>>();
+});`;
 
-  expect<Sample>().type.toBeAssignable({
-    locale: ["en" as const, "de" as const],
-    root: "./",
-  });
+const toBeAssignableWithTestText = `import { expect, test } from "tstyche";
+
+type Awaitable<T> = T | PromiseLike<T>;
+
+test("is assignable with?", () => {
+  expect<Awaitable<string>>().type.toBeAssignableWith("abc");
+  expect<Awaitable<string>>().type.toBeAssignableWith(Promise.resolve("abc"));
+
+  expect<Awaitable<string>>().type.not.toBeAssignableWith(123);
+  expect<Awaitable<string>>().type.not.toBeAssignableWith(Promise.resolve(123));
 });`;
 
 const toEqualTestText = `import { expect, test } from "tstyche";
@@ -103,7 +109,8 @@ describe("TypeScript 4.x", function() {
   before(async function() {
     await writeFixture(fixtureUrl, {
       // 'moduleResolution: "node"' does not support self-referencing, but TSTyche needs 'import from "tstyche"' to be able to collect test nodes
-      ["__typetests__/toBeAssignable.test.ts"]: `// @ts-expect-error\n${toBeAssignableTestText}`,
+      ["__typetests__/toBeAssignableTo.test.ts"]: `// @ts-expect-error\n${toBeAssignableToTestText}`,
+      ["__typetests__/toBeAssignableWith.test.ts"]: `// @ts-expect-error\n${toBeAssignableWithTestText}`,
       ["__typetests__/toEqual.test.ts"]: `// @ts-expect-error\n${toEqualTestText}`,
       ["__typetests__/toHaveProperty.test.ts"]: `// @ts-expect-error\n${toHavePropertyTestText}`,
       ["__typetests__/toMatch.test.ts"]: `// @ts-expect-error\n${toMatchTestText}`,
@@ -145,7 +152,8 @@ describe("TypeScript 4.x", function() {
 describe("TypeScript 5.x", function() {
   before(async function() {
     await writeFixture(fixtureUrl, {
-      ["__typetests__/toBeAssignable.test.ts"]: toBeAssignableTestText,
+      ["__typetests__/toBeAssignableTo.test.ts"]: toBeAssignableToTestText,
+      ["__typetests__/toBeAssignableWith.test.ts"]: toBeAssignableWithTestText,
       ["__typetests__/toEqual.test.ts"]: toEqualTestText,
       ["__typetests__/toHaveProperty.test.ts"]: toHavePropertyTestText,
       ["__typetests__/toMatch.test.ts"]: toMatchTestText,


### PR DESCRIPTION
This PR is adding `.toBeAssignableTo()` and `.toBeAssignableWith()` matchers.

Real world usage shows that it is useful to check assignability both ways (similarly to `>=` and `=<`).

@jdeniau Thanks for finding better name for `.toBeAssignableWith()`.