### PR TITLE
feat(types): deprecate `.toBeAssignable()` in favour of `.toBeAssignableWith()`

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -67,6 +67,8 @@ interface Matchers {
   toBeAny: () => void;
   /**
    * Checks if the target type is assignable to the source type.
+   *
+   * @deprecated This matcher has been renamed to `.toBeAssignableWith()`.
    */
   toBeAssignable: {
     /**


### PR DESCRIPTION
`.toBeAssignable()` has been renamed to `.toBeAssignableWith()` (see #141).