### PR TITLE
feat(config, models): add the `fileExtensions` configuration option

### DIFF
--- a/models/ConfigFileOptions.ts
+++ b/models/ConfigFileOptions.ts
@@ -9,6 +9,10 @@ export interface ConfigFileOptions {
      */
     failFast?: boolean;
     /**
+     * The list of allowed file extensions.
+     */
+    fileExtensions?: Array<string>;
+    /**
      * The path to a directory containing files of a test project.
      */
     rootPath?: string;

--- a/models/__tests__/__fixtures__/invalid-fileExtensions-1.json
+++ b/models/__tests__/__fixtures__/invalid-fileExtensions-1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "fileExtensions": [true]
+}

--- a/models/__tests__/__fixtures__/invalid-fileExtensions-3.json
+++ b/models/__tests__/__fixtures__/invalid-fileExtensions-3.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "fileExtensions": ["json", "json"]
+}

--- a/models/__tests__/__fixtures__/invalid-fileExtensions-4.json
+++ b/models/__tests__/__fixtures__/invalid-fileExtensions-4.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "fileExtensions": "json"
+}

--- a/models/__tests__/__fixtures__/valid-all-options.json
+++ b/models/__tests__/__fixtures__/valid-all-options.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../config-schema.json",
   "failFast": true,
+  "fileExtensions": ["js", "ts"],
   "rootPath": "../",
   "target": ["4.9", "5.0.4", "beta", "latest", "next", "rc"],
   "testFileMatch": ["examples/*.test.ts", "**/__typetests__/*.test.ts"]

--- a/models/__tests__/__fixtures__/valid-fileExtensions.json
+++ b/models/__tests__/__fixtures__/valid-fileExtensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "fileExtensions": ["js", "ts"]
+}

--- a/models/__tests__/config-schema.test.js
+++ b/models/__tests__/config-schema.test.js
@@ -40,6 +40,10 @@ describe("config-schema.json", function() {
         testCase: "'failFast' option",
       },
       {
+        fixtureFileName: "valid-fileExtensions.json",
+        testCase: "'fileExtensions' option",
+      },
+      {
         fixtureFileName: "valid-rootPath.json",
         testCase: "'rootPath' option",
       },
@@ -68,6 +72,18 @@ describe("config-schema.json", function() {
       {
         fixtureFileName: "invalid-failFast.json",
         testCase: "value of 'failFast' option must be of type boolean",
+      },
+      {
+        fixtureFileName: "invalid-fileExtensions-1.json",
+        testCase: "item of 'fileExtensions' option must be of type string",
+      },
+      {
+        fixtureFileName: "invalid-fileExtensions-3.json",
+        testCase: "items of 'fileExtensions' option must NOT be identical",
+      },
+      {
+        fixtureFileName: "invalid-fileExtensions-4.json",
+        testCase: "value of 'fileExtensions' option must be of type Array",
       },
       {
         fixtureFileName: "invalid-rootPath.json",

--- a/models/__typetests__/ConfigFileOptions.tst.ts
+++ b/models/__typetests__/ConfigFileOptions.tst.ts
@@ -21,7 +21,7 @@ describe("ConfigFileOptions", () => {
 
   test("'fileExtensions' option", () => {
     expect<tstyche.ConfigFileOptions>().type.toMatch<{
-      target?: Array<string>;
+      fileExtensions?: Array<string>;
     }>();
   });
 

--- a/models/__typetests__/ConfigFileOptions.tst.ts
+++ b/models/__typetests__/ConfigFileOptions.tst.ts
@@ -19,6 +19,12 @@ describe("ConfigFileOptions", () => {
     }>();
   });
 
+  test("'fileExtensions' option", () => {
+    expect<tstyche.ConfigFileOptions>().type.toMatch<{
+      target?: Array<string>;
+    }>();
+  });
+
   test("'rootPath' option", () => {
     expect<tstyche.ConfigFileOptions>().type.toMatch<{
       rootPath?: string;

--- a/models/config-schema.json
+++ b/models/config-schema.json
@@ -6,6 +6,24 @@
       "description": "Stop running tests after the first failed assertion.",
       "type": "boolean"
     },
+    "fileExtensions": {
+      "default": [
+        "ts",
+        "tsx",
+        "mts",
+        "cts",
+        "js",
+        "jsx",
+        "mjs",
+        "cjs"
+      ],
+      "description": "The list of allowed file extensions.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
     "rootPath": {
       "default": "./",
       "description": "The path to a directory containing files of a test project.",

--- a/source/config/ConfigService.ts
+++ b/source/config/ConfigService.ts
@@ -23,6 +23,7 @@ export class ConfigService {
 
   static #defaultOptions: Required<ConfigFileOptions> = {
     failFast: false,
+    fileExtensions: ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
     rootPath: Path.resolve("./"),
     target: [Environment.typescriptPath == null ? "latest" : "current"],
     testFileMatch: ["**/*.tst.*", "**/__typetests__/*.test.*", "**/typetests/*.test.*"],
@@ -106,11 +107,11 @@ export class ConfigService {
   }
 
   selectTestFiles(): Array<string> {
-    const { pathMatch, rootPath, testFileMatch } = this.resolveConfig();
+    const { fileExtensions, pathMatch, rootPath, testFileMatch } = this.resolveConfig();
 
     let testFilePaths = this.compiler.sys.readDirectory(
       rootPath,
-      ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
+      fileExtensions,
       /* exclude */ undefined,
       /* include */ testFileMatch,
     );

--- a/source/config/OptionDefinitionsMap.ts
+++ b/source/config/OptionDefinitionsMap.ts
@@ -49,6 +49,17 @@ export class OptionDefinitionsMap {
     },
 
     {
+      brand: OptionBrand.List,
+      description: "The list of allowed file extensions.",
+      group: OptionGroup.ConfigFile,
+      items: {
+        brand: OptionBrand.String,
+        name: "fileExtensions",
+      },
+      name: "fileExtensions",
+    },
+
+    {
       brand: OptionBrand.True,
       description: "Print the list of command line options with brief descriptions and exit.",
       group: OptionGroup.CommandLine,

--- a/tests/__snapshots__/config-fileExtensions-default-list-stdout.snap.txt
+++ b/tests/__snapshots__/config-fileExtensions-default-list-stdout.snap.txt
@@ -1,0 +1,10 @@
+[
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/cjsSample.test.cjs",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/ctsSample.test.cts",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/jsSample.test.js",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/jsxSample.test.jsx",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/mjsSample.test.mjs",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/mtsSample.test.mts",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/tsSample.test.ts",
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/tsxSample.test.tsx"
+]

--- a/tests/__snapshots__/config-fileExtensions-specified-extensions-stdout.snap.txt
+++ b/tests/__snapshots__/config-fileExtensions-specified-extensions-stdout.snap.txt
@@ -1,0 +1,3 @@
+[
+  "<<cwd>>/tests/__fixtures__/.generated/config-fileExtensions/__typetests__/jsSample.test.js"
+]

--- a/tests/__snapshots__/validation-fileExtensions-wrong-list-item-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-fileExtensions-wrong-list-item-type-stderr.snap.txt
@@ -1,0 +1,11 @@
+Error: Item of the 'fileExtensions' list must be of type string.
+
+  2 |   "fileExtensions": [
+  3 |     "json",
+> 4 |     true
+    |     ^
+  5 |   ]
+  6 | }
+
+      at ./tstyche.config.json:4:5
+

--- a/tests/__snapshots__/validation-fileExtensions-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-fileExtensions-wrong-option-value-type-stderr.snap.txt
@@ -1,0 +1,9 @@
+Error: Option 'fileExtensions' requires an argument of type list.
+
+  1 | {
+> 2 |   "fileExtensions": "json"
+    |                     ^
+  3 | }
+
+      at ./tstyche.config.json:2:21
+

--- a/tests/config-fileExtensions.test.js
+++ b/tests/config-fileExtensions.test.js
@@ -1,0 +1,69 @@
+import { afterEach, describe, test } from "mocha";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const cjsFileText = `module.exports = function hello() {
+  console.log("Hello, world!");
+}
+`;
+
+const esmFileText = `export function hello() {
+  console.log("Hello, world!");
+}
+`;
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+afterEach(async function() {
+  await clearFixture(fixtureUrl);
+});
+
+describe("'fileExtensions' config file option", function() {
+  test("selects all files from the default list of extensions", async function() {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/cjsSample.test.cjs"]: cjsFileText,
+      ["__typetests__/ctsSample.test.cts"]: cjsFileText,
+      ["__typetests__/jsSample.test.js"]: esmFileText,
+      ["__typetests__/jsxSample.test.jsx"]: esmFileText,
+      ["__typetests__/mjsSample.test.mjs"]: esmFileText,
+      ["__typetests__/mtsSample.test.mts"]: esmFileText,
+      ["__typetests__/tsSample.test.ts"]: esmFileText,
+      ["__typetests__/tsxSample.test.tsx"]: esmFileText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--listFiles"]);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-default-list-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
+  test("selects files with specified extensions", async function() {
+    const config = {
+      fileExtensions: ["js"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/jsSample.test.js"]: esmFileText,
+      ["__typetests__/tsSample.test.ts"]: esmFileText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--listFiles"]);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-specified-extensions-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+});

--- a/tests/validation-fileExtensions.test.js
+++ b/tests/validation-fileExtensions.test.js
@@ -1,0 +1,55 @@
+import { afterEach, describe, test } from "mocha";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+afterEach(async function() {
+  await clearFixture(fixtureUrl);
+});
+
+describe("'fileExtensions' configuration file option", function() {
+  test("when option value is not a list", async function() {
+    const config = {
+      fileExtensions: "json",
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    assert.equal(stdout, "");
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-wrong-option-value-type-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  test("when item of the list is not a string", async function() {
+    const config = {
+      fileExtensions: ["json", true],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    assert.equal(stdout, "");
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-wrong-list-item-type-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+});


### PR DESCRIPTION
It makes sense to allow configuring `fileExtensions`, instead of predefined list. For instance, TSTyche could be used to type check `svelte` files.