### PR TITLE
feat(expect, result): add `.toBeAssignable()` deprecation warning

### DIFF
--- a/models/__typetests__/CommandLineOptions.tst.ts
+++ b/models/__typetests__/CommandLineOptions.tst.ts
@@ -5,7 +5,7 @@ const options: tstyche.CommandLineOptions = {};
 
 describe("CommandLineOptions", () => {
   test("all options", () => {
-    expect(options).type.toBeAssignable({
+    expect(options).type.toBeAssignableWith({
       config: "./config/tstyche.json",
       failFast: true,
       help: true,

--- a/models/__typetests__/ConfigFileOptions.tst.ts
+++ b/models/__typetests__/ConfigFileOptions.tst.ts
@@ -5,7 +5,7 @@ const options: tstyche.ConfigFileOptions = {};
 
 describe("ConfigFileOptions", () => {
   test("all options", () => {
-    expect(options).type.toBeAssignable({
+    expect(options).type.toBeAssignableWith({
       failFast: true,
       rootPath: "../",
       target: ["4.9.5" as const, "5.0" as const, "latest" as const],

--- a/source/result/ResultManager.ts
+++ b/source/result/ResultManager.ts
@@ -190,6 +190,10 @@ export class ResultManager {
         break;
 
       case "expect:error":
+        if (payload.diagnostics.every((diagnostic) => diagnostic.category === DiagnosticCategory.Warning)) {
+          return;
+        }
+
         this.#result!.expectCount.failed++;
         this.#fileResult!.expectCount.failed++;
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -73,10 +73,14 @@ interface Matchers {
   toBeAssignable: {
     /**
      * Checks if the source type is assignable with the target type.
+     *
+     * @deprecated This matcher has been renamed to `.toBeAssignableWith()`.
      */
     <Target>(): void;
     /**
      * Checks if the source type is assignable with type of the target expression.
+     *
+     * @deprecated This matcher has been renamed to `.toBeAssignableWith()`.
      */
     (target: unknown): void;
   };

--- a/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
@@ -1,3 +1,59 @@
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+   8 | describe("received type", () => {
+   9 |   test("is assignable expected value?", () => {
+> 10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
+     |                          ^
+  11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
+  12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
+  13 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:10:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+   9 |   test("is assignable expected value?", () => {
+  10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
+> 11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
+     |                          ^
+  12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
+  13 | 
+  14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
+
+       at ./__typetests__/toBeAssignable.tst.ts:11:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
+  11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
+> 12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
+     |                          ^
+  13 | 
+  14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
+  15 |   });
+
+       at ./__typetests__/toBeAssignable.tst.ts:12:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
+  13 | 
+> 14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
+     |                          ^
+  15 |   });
+  16 | 
+  17 |   test("is NOT assignable expected value?", () => {
+
+       at ./__typetests__/toBeAssignable.tst.ts:14:26
+
 Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
   12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
@@ -9,6 +65,34 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
   17 |   test("is NOT assignable expected value?", () => {
 
        at ./__typetests__/toBeAssignable.tst.ts:14:26 ❭ received type ❭ is assignable expected value?
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  16 | 
+  17 |   test("is NOT assignable expected value?", () => {
+> 18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
+     |                              ^
+  19 | 
+  20 |     expect<Names>().type.not.toBeAssignable({ first: "Rose" });
+  21 |   });
+
+       at ./__typetests__/toBeAssignable.tst.ts:18:30
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
+  19 | 
+> 20 |     expect<Names>().type.not.toBeAssignable({ first: "Rose" });
+     |                              ^
+  21 |   });
+  22 | 
+  23 |   test("is assignable expected type?", () => {
+
+       at ./__typetests__/toBeAssignable.tst.ts:20:30
 
 Error: Type 'Names' is assignable with type '{ first: string; }'.
 
@@ -22,6 +106,76 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
        at ./__typetests__/toBeAssignable.tst.ts:20:30 ❭ received type ❭ is NOT assignable expected value?
 
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  22 | 
+  23 |   test("is assignable expected type?", () => {
+> 24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
+     |                          ^
+  25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
+  26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
+  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
+
+       at ./__typetests__/toBeAssignable.tst.ts:24:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  23 |   test("is assignable expected type?", () => {
+  24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
+> 25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
+     |                          ^
+  26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
+  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
+  28 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:25:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
+  25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
+> 26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
+     |                          ^
+  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
+  28 | 
+  29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
+
+       at ./__typetests__/toBeAssignable.tst.ts:26:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
+  26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
+> 27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
+     |                          ^
+  28 | 
+  29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
+  30 |   });
+
+       at ./__typetests__/toBeAssignable.tst.ts:27:26
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
+  28 | 
+> 29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
+     |                          ^
+  30 |   });
+  31 | 
+  32 |   test("is NOT assignable expected type?", () => {
+
+       at ./__typetests__/toBeAssignable.tst.ts:29:26
+
 Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
   27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
@@ -33,6 +187,34 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
   32 |   test("is NOT assignable expected type?", () => {
 
        at ./__typetests__/toBeAssignable.tst.ts:29:26 ❭ received type ❭ is assignable expected type?
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  31 | 
+  32 |   test("is NOT assignable expected type?", () => {
+> 33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
+     |                              ^
+  34 | 
+  35 |     expect<Names>().type.not.toBeAssignable<{ first: string }>();
+  36 |   });
+
+       at ./__typetests__/toBeAssignable.tst.ts:33:30
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
+  34 | 
+> 35 |     expect<Names>().type.not.toBeAssignable<{ first: string }>();
+     |                              ^
+  36 |   });
+  37 | });
+  38 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:35:30
 
 Error: Type 'Names' is assignable with type '{ first: string; }'.
 
@@ -46,6 +228,34 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
        at ./__typetests__/toBeAssignable.tst.ts:35:30 ❭ received type ❭ is NOT assignable expected type?
 
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  39 | describe("received value", () => {
+  40 |   test("is assignable expected value?", () => {
+> 41 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable({
+     |                                                  ^
+  42 |       first: "Rose",
+  43 |       last: "Smith",
+  44 |     });
+
+       at ./__typetests__/toBeAssignable.tst.ts:41:50
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  44 |     });
+  45 | 
+> 46 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable({
+     |                                                  ^
+  47 |       middle: "O.",
+  48 |     });
+  49 |   });
+
+       at ./__typetests__/toBeAssignable.tst.ts:46:50
+
 Error: Type '{ first: string; last: string; }' is not assignable with type '{ middle: string; }'.
 
   44 |     });
@@ -57,6 +267,34 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
   49 |   });
 
        at ./__typetests__/toBeAssignable.tst.ts:46:50 ❭ received value ❭ is assignable expected value?
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  50 | 
+  51 |   test("is NOT assignable expected value?", () => {
+> 52 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignable({
+     |                                                      ^
+  53 |       middle: "O.",
+  54 |     });
+  55 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:52:54
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  54 |     });
+  55 | 
+> 56 |     expect({ first: "Jane" }).type.not.toBeAssignable({ first: "Rose" });
+     |                                        ^
+  57 |   });
+  58 | 
+  59 |   test("is assignable expected type?", () => {
+
+       at ./__typetests__/toBeAssignable.tst.ts:56:40
 
 Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
@@ -70,6 +308,34 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
        at ./__typetests__/toBeAssignable.tst.ts:56:40 ❭ received value ❭ is NOT assignable expected value?
 
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  58 | 
+  59 |   test("is assignable expected type?", () => {
+> 60 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable<{
+     |                                                  ^
+  61 |       first: string;
+  62 |       last: string;
+  63 |     }>();
+
+       at ./__typetests__/toBeAssignable.tst.ts:60:50
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  63 |     }>();
+  64 | 
+> 65 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable<{
+     |                                                  ^
+  66 |       middle: string;
+  67 |     }>();
+  68 |   });
+
+       at ./__typetests__/toBeAssignable.tst.ts:65:50
+
 Error: Type '{ first: string; last: string; }' is not assignable with type '{ middle: string; }'.
 
   63 |     }>();
@@ -81,6 +347,34 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
   68 |   });
 
        at ./__typetests__/toBeAssignable.tst.ts:65:50 ❭ received value ❭ is assignable expected type?
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  69 | 
+  70 |   test("is NOT assignable type?", () => {
+> 71 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignable<{
+     |                                                      ^
+  72 |       middle: string;
+  73 |     }>();
+  74 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:71:54
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  73 |     }>();
+  74 | 
+> 75 |     expect({ first: "Jane" }).type.not.toBeAssignable<{ first: string }>();
+     |                                        ^
+  76 |   });
+  77 | });
+  78 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:75:40
 
 Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 

--- a/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
@@ -1,3 +1,17 @@
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+  3 | describe("argument for 'source'", () => {
+  4 |   test("must be provided", () => {
+> 5 |     expect().type.toBeAssignable<{ test: void }>();
+    |                   ^
+  6 |   });
+  7 | });
+  8 | 
+
+      at ./__typetests__/toBeAssignable.tst.ts:5:19
+
 Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
@@ -9,6 +23,20 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
   8 | 
 
       at ./__typetests__/toBeAssignable.tst.ts:5:5
+
+Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+
+   9 | describe("argument for 'target'", () => {
+  10 |   test("must be provided", () => {
+> 11 |     expect<{ test: void }>().type.toBeAssignable();
+     |                                   ^
+  12 |   });
+  13 | });
+  14 | 
+
+       at ./__typetests__/toBeAssignable.tst.ts:11:35
 
 Error: An argument for 'target' or type argument for 'Target' must be provided.
 


### PR DESCRIPTION
Deprecation warning is needed for `.toBeAssignable()`. Too easy to miss it.