### PR TITLE
refactor!(collect, expect): rename `.toEqual()` to `.toBe()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ function firstItem<T>(target: Array<T>): T | undefined {
 }
 
 test("firstItem", () => {
-  expect(firstItem(["a", "b", "c"])).type.toEqual<string | undefined>();
+  expect(firstItem(["a", "b", "c"])).type.toBe<string | undefined>();
 
   expect(firstItem()).type.toRaiseError("Expected 1 argument");
 });
@@ -52,13 +52,13 @@ function secondItem<T>(target: Array<T>): T | undefined {
 test("handles numbers", () => {
   assert.strictEqual(secondItem([1, 2, 3]), 2);
 
-  tstyche.expect(secondItem([1, 2, 3])).type.toEqual<number | undefined>();
+  tstyche.expect(secondItem([1, 2, 3])).type.toBe<number | undefined>();
 });
 ```
 
 Here is the list of all matchers:
 
-- `.toBeAssignableTo()`, `.toBeAssignableWith()`, `.toEqual()`, `.toMatch()` compares types or types of expression,
+- `.toBe()`, `.toBeAssignableTo()`, `.toBeAssignableWith()`, `.toMatch()` compare types or types of expression,
 - `.toHaveProperty()` looks up keys on an object type,
 - `.toRaiseError()` captures the type error message or code,
 - `.toBeString()`, `.toBeNumber()`, `.toBeVoid()` and 9 more shorthand checks for primitive types.

--- a/examples/MethodLikeKeys.tst.ts
+++ b/examples/MethodLikeKeys.tst.ts
@@ -13,6 +13,6 @@ interface Sample {
   getWidth?: () => number;
 }
 
-test("is equal?", () => {
-  expect<MethodLikeKeys<Sample>>().type.toEqual<"getLength" | "getWidth">();
+test("MethodLikeKeys", () => {
+  expect<MethodLikeKeys<Sample>>().type.toBe<"getLength" | "getWidth">();
 });

--- a/examples/firstItem.tst.ts
+++ b/examples/firstItem.tst.ts
@@ -4,8 +4,8 @@ function firstItem<T>(target: Array<T>): T | undefined {
   return target[0];
 }
 
-expect(firstItem(["a", "b"])).type.toEqual<string | undefined>();
+expect(firstItem(["a", "b"])).type.toBe<string | undefined>();
 
-expect(firstItem([1, 2, 3])).type.toEqual<number | undefined>();
+expect(firstItem([1, 2, 3])).type.toBe<number | undefined>();
 
 expect(firstItem()).type.toRaiseError("Expected 1 argument");

--- a/examples/function-types.tst.ts
+++ b/examples/function-types.tst.ts
@@ -6,14 +6,14 @@ declare function takesTwo(a: string, b?: number): void;
 
 describe("function types", () => {
   test("does not take arguments", () => {
-    expect(takesNone).type.toEqual<() => void>();
+    expect(takesNone).type.toBe<() => void>();
   });
 
   test("takes one argument", () => {
-    expect(takesOne).type.toEqual<(a: number) => void>();
+    expect(takesOne).type.toBe<(a: number) => void>();
   });
 
   test("takes two arguments", () => {
-    expect(takesTwo).type.toEqual<(a: string, b?: number) => void>();
+    expect(takesTwo).type.toBe<(a: string, b?: number) => void>();
   });
 });

--- a/source/collect/CollectService.ts
+++ b/source/collect/CollectService.ts
@@ -7,6 +7,7 @@ import { TestTree } from "./TestTree.js";
 
 export class CollectService {
   readonly matcherIdentifiers = [
+    "toBe",
     "toBeAny",
     "toBeAssignable",
     "toBeAssignableTo",

--- a/source/expect/ToBe.ts
+++ b/source/expect/ToBe.ts
@@ -1,6 +1,6 @@
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
 
-export class ToEqual extends RelationMatcherBase {
+export class ToBe extends RelationMatcherBase {
   relation = this.typeChecker.relation.identity;
   relationExplanationText = "identical to";
   relationExplanationVerb = "is";

--- a/source/types.ts
+++ b/source/types.ts
@@ -62,6 +62,19 @@ interface Test {
 
 interface Matchers {
   /**
+   * Checks if the source type is identical to the target type.
+   */
+  toBe: {
+    /**
+     * Checks if the source type is identical to the target type.
+     */
+    <Target>(): void;
+    /**
+     * Checks if the source type is identical to type of the target expression.
+     */
+    (target: unknown): void;
+  };
+  /**
    * Checks if the source type is `any`.
    */
   toBeAny: () => void;
@@ -156,14 +169,20 @@ interface Matchers {
   toBeVoid: () => void;
   /**
    * Checks if the source type is identical to the target type.
+   *
+   * @deprecated This matcher has been renamed to `.toBe()`.
    */
   toEqual: {
     /**
      * Checks if the source type is identical to the target type.
+     *
+     * @deprecated This matcher has been renamed to `.toBe()`.
      */
     <Target>(): void;
     /**
      * Checks if the source type is identical to type of the target expression.
+     *
+     * @deprecated This matcher has been renamed to `.toBe()`.
      */
     (target: unknown): void;
   };

--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "tstyche";
+
+interface Names {
+  first: string;
+  last?: string;
+}
+declare function getNames(): Names;
+
+interface Size {
+  height: number;
+  width: number;
+}
+declare function getSize(): Size;
+
+test("edge cases", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  expect<any>().type.not.toBe<never>();
+  expect<any>().type.not.toBe<unknown>();
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  expect(Date).type.toBe<typeof Date>();
+});
+
+describe("source type", () => {
+  test("is identical to target type", () => {
+    expect<{ a: string; b: number }>().type.toBe<{ a: string; b: number }>();
+    expect<Names>().type.toBe<{ first: string; last?: string }>();
+
+    expect<Names>().type.toBe<{ first: string; last: string }>();
+  });
+
+  test("is NOT identical to target type", () => {
+    expect<Names>().type.not.toBe<{ first: string; last: string }>();
+
+    expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+  });
+
+  test("is identical to target expression", () => {
+    expect<Names>().type.toBe(getNames());
+    expect<{ first: string; last?: string }>().type.toBe(getNames());
+
+    expect<{ first: string; last: string }>().type.toBe(getNames());
+  });
+
+  test("is NOT identical to target expression", () => {
+    expect<{ first: string; last: string }>().type.not.toBe(getNames());
+
+    expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+  });
+});
+
+describe("source expression", () => {
+  test("identical to target type", () => {
+    expect(getNames()).type.toBe<{ first: string; last?: string }>();
+    expect(getNames()).type.toBe<Names>();
+
+    expect(getNames()).type.toBe<{ first: string; last: string }>();
+  });
+
+  test("is NOT identical to target type", () => {
+    expect(getNames()).type.not.toBe<{ first: string; last: string }>();
+
+    expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+  });
+
+  test("identical to target expression", () => {
+    expect({ height: 14, width: 25 }).type.toBe(getSize());
+
+    expect({ height: 14 }).type.toBe(getSize());
+  });
+
+  test("is NOT identical to target expression", () => {
+    expect({ height: 14 }).type.not.toBe(getSize());
+
+    expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+  });
+});

--- a/tests/__fixtures__/api-toBe/tsconfig.json
+++ b/tests/__fixtures__/api-toBe/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/tests/__fixtures__/validation-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/validation-toBe/__typetests__/toBe.tst.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "tstyche";
+
+describe("argument for 'source'", () => {
+  test("must be provided", () => {
+    expect().type.toBe<{ test: void }>();
+  });
+});
+
+describe("argument for 'target'", () => {
+  test("must be provided", () => {
+    expect<{ test: void }>().type.toBe();
+  });
+});

--- a/tests/__fixtures__/validation-toBe/tsconfig.json
+++ b/tests/__fixtures__/validation-toBe/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -1,0 +1,96 @@
+Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
+
+  27 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
+  28 | 
+> 29 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+     |                          ^
+  30 |   });
+  31 | 
+  32 |   test("is NOT identical to target type", () => {
+
+       at ./__typetests__/toBe.tst.ts:29:26 ❭ source type ❭ is identical to target type
+
+Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
+
+  33 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
+  34 | 
+> 35 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+     |                              ^
+  36 |   });
+  37 | 
+  38 |   test("is identical to target expression", () => {
+
+       at ./__typetests__/toBe.tst.ts:35:30 ❭ source type ❭ is NOT identical to target type
+
+Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
+
+  40 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
+  41 | 
+> 42 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+     |                                                    ^
+  43 |   });
+  44 | 
+  45 |   test("is NOT identical to target expression", () => {
+
+       at ./__typetests__/toBe.tst.ts:42:52 ❭ source type ❭ is identical to target expression
+
+Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
+
+  46 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
+  47 | 
+> 48 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+     |                                                         ^
+  49 |   });
+  50 | });
+  51 | 
+
+       at ./__typetests__/toBe.tst.ts:48:57 ❭ source type ❭ is NOT identical to target expression
+
+Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
+
+  55 |     expect(getNames()).type.toBe<Names>();
+  56 | 
+> 57 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+     |                             ^
+  58 |   });
+  59 | 
+  60 |   test("is NOT identical to target type", () => {
+
+       at ./__typetests__/toBe.tst.ts:57:29 ❭ source expression ❭ identical to target type
+
+Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
+
+  61 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
+  62 | 
+> 63 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+     |                                 ^
+  64 |   });
+  65 | 
+  66 |   test("identical to target expression", () => {
+
+       at ./__typetests__/toBe.tst.ts:63:33 ❭ source expression ❭ is NOT identical to target type
+
+Error: Type '{ height: number; }' is not identical to type 'Size'.
+
+  67 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
+  68 | 
+> 69 |     expect({ height: 14 }).type.toBe(getSize());
+     |                                 ^
+  70 |   });
+  71 | 
+  72 |   test("is NOT identical to target expression", () => {
+
+       at ./__typetests__/toBe.tst.ts:69:33 ❭ source expression ❭ identical to target expression
+
+Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
+
+  73 |     expect({ height: 14 }).type.not.toBe(getSize());
+  74 | 
+> 75 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+     |                                                ^
+  76 |   });
+  77 | });
+  78 | 
+
+       at ./__typetests__/toBe.tst.ts:75:48 ❭ source expression ❭ is NOT identical to target expression
+

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -1,0 +1,22 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/toBe.tst.ts
+  + edge cases
+  source type
+    × is identical to target type
+    × is NOT identical to target type
+    × is identical to target expression
+    × is NOT identical to target expression
+  source expression
+    × identical to target type
+    × is NOT identical to target type
+    × identical to target expression
+    × is NOT identical to target expression
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      8 failed, 1 passed, 9 total
+Assertions: 8 failed, 14 passed, 22 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
@@ -1,6 +1,6 @@
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
    8 | describe("received type", () => {
    9 |   test("is assignable expected value?", () => {
@@ -14,7 +14,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
    9 |   test("is assignable expected value?", () => {
   10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
@@ -28,7 +28,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
   11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
@@ -42,7 +42,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
   13 | 
@@ -68,7 +68,7 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   16 | 
   17 |   test("is NOT assignable expected value?", () => {
@@ -82,7 +82,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
   19 | 
@@ -108,7 +108,7 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   22 | 
   23 |   test("is assignable expected type?", () => {
@@ -122,7 +122,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   23 |   test("is assignable expected type?", () => {
   24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
@@ -136,7 +136,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
   25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
@@ -150,7 +150,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
   26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
@@ -164,7 +164,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
   28 | 
@@ -190,7 +190,7 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   31 | 
   32 |   test("is NOT assignable expected type?", () => {
@@ -204,7 +204,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
   34 | 
@@ -230,7 +230,7 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   39 | describe("received value", () => {
   40 |   test("is assignable expected value?", () => {
@@ -244,7 +244,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   44 |     });
   45 | 
@@ -270,7 +270,7 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   50 | 
   51 |   test("is NOT assignable expected value?", () => {
@@ -284,7 +284,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   54 |     });
   55 | 
@@ -310,7 +310,7 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   58 | 
   59 |   test("is assignable expected type?", () => {
@@ -324,7 +324,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   63 |     }>();
   64 | 
@@ -350,7 +350,7 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   69 | 
   70 |   test("is NOT assignable type?", () => {
@@ -364,7 +364,7 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   73 |     }>();
   74 | 

--- a/tests/__snapshots__/api-toEqual-stderr.snap.txt
+++ b/tests/__snapshots__/api-toEqual-stderr.snap.txt
@@ -1,3 +1,87 @@
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  15 | test("edge cases", () => {
+  16 |   /* eslint-disable @typescript-eslint/no-explicit-any */
+> 17 |   expect<any>().type.not.toEqual<never>();
+     |                          ^
+  18 |   expect<any>().type.not.toEqual<unknown>();
+  19 |   /* eslint-enable @typescript-eslint/no-explicit-any */
+  20 | 
+
+       at ./__typetests__/toEqual.tst.ts:17:26
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  16 |   /* eslint-disable @typescript-eslint/no-explicit-any */
+  17 |   expect<any>().type.not.toEqual<never>();
+> 18 |   expect<any>().type.not.toEqual<unknown>();
+     |                          ^
+  19 |   /* eslint-enable @typescript-eslint/no-explicit-any */
+  20 | 
+  21 |   expect(Date).type.toEqual<typeof Date>();
+
+       at ./__typetests__/toEqual.tst.ts:18:26
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  19 |   /* eslint-enable @typescript-eslint/no-explicit-any */
+  20 | 
+> 21 |   expect(Date).type.toEqual<typeof Date>();
+     |                     ^
+  22 | });
+  23 | 
+  24 | describe("received type", () => {
+
+       at ./__typetests__/toEqual.tst.ts:21:21
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  24 | describe("received type", () => {
+  25 |   test("equals expected type", () => {
+> 26 |     expect<{ a: string; b: number }>().type.toEqual<{ a: string; b: number }>();
+     |                                             ^
+  27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
+  28 | 
+  29 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
+
+       at ./__typetests__/toEqual.tst.ts:26:45
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  25 |   test("equals expected type", () => {
+  26 |     expect<{ a: string; b: number }>().type.toEqual<{ a: string; b: number }>();
+> 27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
+     |                          ^
+  28 | 
+  29 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
+  30 |   });
+
+       at ./__typetests__/toEqual.tst.ts:27:26
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
+  28 | 
+> 29 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
+     |                          ^
+  30 |   });
+  31 | 
+  32 |   test("does NOT equal expected type", () => {
+
+       at ./__typetests__/toEqual.tst.ts:29:26
+
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
   27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
@@ -9,6 +93,34 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
   32 |   test("does NOT equal expected type", () => {
 
        at ./__typetests__/toEqual.tst.ts:29:26 ❭ received type ❭ equals expected type
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  31 | 
+  32 |   test("does NOT equal expected type", () => {
+> 33 |     expect<Names>().type.not.toEqual<{ first: string; last: string }>();
+     |                              ^
+  34 | 
+  35 |     expect<Names>().type.not.toEqual<{ first: string; last?: string }>();
+  36 |   });
+
+       at ./__typetests__/toEqual.tst.ts:33:30
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  33 |     expect<Names>().type.not.toEqual<{ first: string; last: string }>();
+  34 | 
+> 35 |     expect<Names>().type.not.toEqual<{ first: string; last?: string }>();
+     |                              ^
+  36 |   });
+  37 | 
+  38 |   test("equals expected value", () => {
+
+       at ./__typetests__/toEqual.tst.ts:35:30
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
@@ -22,6 +134,48 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
        at ./__typetests__/toEqual.tst.ts:35:30 ❭ received type ❭ does NOT equal expected type
 
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  37 | 
+  38 |   test("equals expected value", () => {
+> 39 |     expect<Names>().type.toEqual(getNames());
+     |                          ^
+  40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
+  41 | 
+  42 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
+
+       at ./__typetests__/toEqual.tst.ts:39:26
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  38 |   test("equals expected value", () => {
+  39 |     expect<Names>().type.toEqual(getNames());
+> 40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
+     |                                                     ^
+  41 | 
+  42 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
+  43 |   });
+
+       at ./__typetests__/toEqual.tst.ts:40:53
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
+  41 | 
+> 42 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
+     |                                                    ^
+  43 |   });
+  44 | 
+  45 |   test("does NOT equal expected value", () => {
+
+       at ./__typetests__/toEqual.tst.ts:42:52
+
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
   40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
@@ -33,6 +187,34 @@ Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
   45 |   test("does NOT equal expected value", () => {
 
        at ./__typetests__/toEqual.tst.ts:42:52 ❭ received type ❭ equals expected value
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  44 | 
+  45 |   test("does NOT equal expected value", () => {
+> 46 |     expect<{ first: string; last: string }>().type.not.toEqual(getNames());
+     |                                                        ^
+  47 | 
+  48 |     expect<{ first: string; last?: string }>().type.not.toEqual(getNames());
+  49 |   });
+
+       at ./__typetests__/toEqual.tst.ts:46:56
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  46 |     expect<{ first: string; last: string }>().type.not.toEqual(getNames());
+  47 | 
+> 48 |     expect<{ first: string; last?: string }>().type.not.toEqual(getNames());
+     |                                                         ^
+  49 |   });
+  50 | });
+  51 | 
+
+       at ./__typetests__/toEqual.tst.ts:48:57
 
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
@@ -46,6 +228,48 @@ Error: Type '{ first: string; last?: string | undefined; }' is identical to type
 
        at ./__typetests__/toEqual.tst.ts:48:57 ❭ received type ❭ does NOT equal expected value
 
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  52 | describe("received value", () => {
+  53 |   test("equals expected type", () => {
+> 54 |     expect(getNames()).type.toEqual<{ first: string; last?: string }>();
+     |                             ^
+  55 |     expect(getNames()).type.toEqual<Names>();
+  56 | 
+  57 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
+
+       at ./__typetests__/toEqual.tst.ts:54:29
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  53 |   test("equals expected type", () => {
+  54 |     expect(getNames()).type.toEqual<{ first: string; last?: string }>();
+> 55 |     expect(getNames()).type.toEqual<Names>();
+     |                             ^
+  56 | 
+  57 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
+  58 |   });
+
+       at ./__typetests__/toEqual.tst.ts:55:29
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  55 |     expect(getNames()).type.toEqual<Names>();
+  56 | 
+> 57 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
+     |                             ^
+  58 |   });
+  59 | 
+  60 |   test("does NOT equal expected type", () => {
+
+       at ./__typetests__/toEqual.tst.ts:57:29
+
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
   55 |     expect(getNames()).type.toEqual<Names>();
@@ -57,6 +281,34 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
   60 |   test("does NOT equal expected type", () => {
 
        at ./__typetests__/toEqual.tst.ts:57:29 ❭ received value ❭ equals expected type
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  59 | 
+  60 |   test("does NOT equal expected type", () => {
+> 61 |     expect(getNames()).type.not.toEqual<{ first: string; last: string }>();
+     |                                 ^
+  62 | 
+  63 |     expect(getNames()).type.not.toEqual<{ first: string; last?: string }>();
+  64 |   });
+
+       at ./__typetests__/toEqual.tst.ts:61:33
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  61 |     expect(getNames()).type.not.toEqual<{ first: string; last: string }>();
+  62 | 
+> 63 |     expect(getNames()).type.not.toEqual<{ first: string; last?: string }>();
+     |                                 ^
+  64 |   });
+  65 | 
+  66 |   test("equals expected value", () => {
+
+       at ./__typetests__/toEqual.tst.ts:63:33
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
@@ -70,6 +322,34 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
        at ./__typetests__/toEqual.tst.ts:63:33 ❭ received value ❭ does NOT equal expected type
 
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  65 | 
+  66 |   test("equals expected value", () => {
+> 67 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
+     |                                            ^
+  68 | 
+  69 |     expect({ height: 14 }).type.toEqual(getSize());
+  70 |   });
+
+       at ./__typetests__/toEqual.tst.ts:67:44
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  67 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
+  68 | 
+> 69 |     expect({ height: 14 }).type.toEqual(getSize());
+     |                                 ^
+  70 |   });
+  71 | 
+  72 |   test("does NOT equal expected value", () => {
+
+       at ./__typetests__/toEqual.tst.ts:69:33
+
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
   67 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
@@ -81,6 +361,34 @@ Error: Type '{ height: number; }' is not identical to type 'Size'.
   72 |   test("does NOT equal expected value", () => {
 
        at ./__typetests__/toEqual.tst.ts:69:33 ❭ received value ❭ equals expected value
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  71 | 
+  72 |   test("does NOT equal expected value", () => {
+> 73 |     expect({ height: 14 }).type.not.toEqual(getSize());
+     |                                     ^
+  74 | 
+  75 |     expect({ height: 14, width: 25 }).type.not.toEqual(getSize());
+  76 |   });
+
+       at ./__typetests__/toEqual.tst.ts:73:37
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  73 |     expect({ height: 14 }).type.not.toEqual(getSize());
+  74 | 
+> 75 |     expect({ height: 14, width: 25 }).type.not.toEqual(getSize());
+     |                                                ^
+  76 |   });
+  77 | });
+  78 | 
+
+       at ./__typetests__/toEqual.tst.ts:75:48
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 

--- a/tests/__snapshots__/validation-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBe-stderr.snap.txt
@@ -1,0 +1,24 @@
+Error: An argument for 'source' or type argument for 'Source' must be provided.
+
+  3 | describe("argument for 'source'", () => {
+  4 |   test("must be provided", () => {
+> 5 |     expect().type.toBe<{ test: void }>();
+    |     ^
+  6 |   });
+  7 | });
+  8 | 
+
+      at ./__typetests__/toBe.tst.ts:5:5
+
+Error: An argument for 'target' or type argument for 'Target' must be provided.
+
+   9 | describe("argument for 'target'", () => {
+  10 |   test("must be provided", () => {
+> 11 |     expect<{ test: void }>().type.toBe();
+     |                                   ^
+  12 |   });
+  13 | });
+  14 | 
+
+       at ./__typetests__/toBe.tst.ts:11:35
+

--- a/tests/__snapshots__/validation-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBe-stdout.snap.txt
@@ -1,0 +1,15 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/toBe.tst.ts
+  argument for 'source'
+    × must be provided
+  argument for 'target'
+    × must be provided
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      2 failed, 2 total
+Assertions: 2 failed, 2 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
@@ -1,6 +1,6 @@
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
@@ -26,7 +26,7 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
 Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 2.
+Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {

--- a/tests/__snapshots__/validation-toEqual-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toEqual-stderr.snap.txt
@@ -1,3 +1,17 @@
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+  3 | describe("argument for 'source'", () => {
+  4 |   test("must be provided", () => {
+> 5 |     expect().type.toEqual<{ test: void }>();
+    |                   ^
+  6 |   });
+  7 | });
+  8 | 
+
+      at ./__typetests__/toEqual.tst.ts:5:19
+
 Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
@@ -9,6 +23,20 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
   8 | 
 
       at ./__typetests__/toEqual.tst.ts:5:5
+
+Warning: '.toEqual()' has been renamed to '.toBe()'.
+
+Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+
+   9 | describe("argument for 'target'", () => {
+  10 |   test("must be provided", () => {
+> 11 |     expect<{ test: void }>().type.toEqual();
+     |                                   ^
+  12 |   });
+  13 | });
+  14 | 
+
+       at ./__typetests__/toEqual.tst.ts:11:35
 
 Error: An argument for 'target' or type argument for 'Target' must be provided.
 

--- a/tests/api-toBe.test.js
+++ b/tests/api-toBe.test.js
@@ -1,0 +1,30 @@
+import { test } from "mocha";
+import * as tstyche from "tstyche";
+import * as assert from "./__utilities__/assert.js";
+import { getFixtureFileUrl, getTestFileName } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName);
+
+test("'toBe' implementation", function() {
+  tstyche.expect("sample").type.toBe("sample");
+  tstyche.expect("123").type.not.toBe(123);
+});
+
+test("toBe", async function() {
+  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+  await assert.matchSnapshot(normalizeOutput(stdout), {
+    fileName: `${testFileName}-stdout`,
+    testFileUrl: import.meta.url,
+  });
+
+  await assert.matchSnapshot(stderr, {
+    fileName: `${testFileName}-stderr`,
+    testFileUrl: import.meta.url,
+  });
+
+  assert.equal(exitCode, 1);
+});

--- a/tests/feature-runner.test.js
+++ b/tests/feature-runner.test.js
@@ -192,7 +192,7 @@ test("'strictNullChecks': true", () => {
     return a;
   }
 
-  expect(x()).type.not.toEqual<string>();
+  expect(x()).type.not.toBe<string>();
 });
 
 test("'strictFunctionTypes': true", () => {

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -27,17 +27,14 @@ test("is assignable with?", () => {
   expect<Awaitable<string>>().type.not.toBeAssignableWith(Promise.resolve(123));
 });`;
 
-const toEqualTestText = `import { expect, test } from "tstyche";
+const toBeTestText = `import { expect, test } from "tstyche";
 
 interface Sample {
   getLength: () => number;
   getWidth?: () => number;
 }
 
-test("is equal?", () => {
-  expect<keyof Sample>().type.toEqual<"getLength" | "getWidth">();
-});
-
+expect<keyof Sample>().type.toBe<"getLength" | "getWidth">();
 `;
 
 const toHavePropertyTestText = `import { expect } from "tstyche";
@@ -109,9 +106,9 @@ describe("TypeScript 4.x", function() {
   before(async function() {
     await writeFixture(fixtureUrl, {
       // 'moduleResolution: "node"' does not support self-referencing, but TSTyche needs 'import from "tstyche"' to be able to collect test nodes
+      ["__typetests__/toBe.test.ts"]: `// @ts-expect-error\n${toBeTestText}`,
       ["__typetests__/toBeAssignableTo.test.ts"]: `// @ts-expect-error\n${toBeAssignableToTestText}`,
       ["__typetests__/toBeAssignableWith.test.ts"]: `// @ts-expect-error\n${toBeAssignableWithTestText}`,
-      ["__typetests__/toEqual.test.ts"]: `// @ts-expect-error\n${toEqualTestText}`,
       ["__typetests__/toHaveProperty.test.ts"]: `// @ts-expect-error\n${toHavePropertyTestText}`,
       ["__typetests__/toMatch.test.ts"]: `// @ts-expect-error\n${toMatchTestText}`,
       ["__typetests__/toRaiseError.test.ts"]: `// @ts-expect-error\n${toRaiseErrorTestText}`,
@@ -152,9 +149,9 @@ describe("TypeScript 4.x", function() {
 describe("TypeScript 5.x", function() {
   before(async function() {
     await writeFixture(fixtureUrl, {
+      ["__typetests__/toBe.test.ts"]: toBeTestText,
       ["__typetests__/toBeAssignableTo.test.ts"]: toBeAssignableToTestText,
       ["__typetests__/toBeAssignableWith.test.ts"]: toBeAssignableWithTestText,
-      ["__typetests__/toEqual.test.ts"]: toEqualTestText,
       ["__typetests__/toHaveProperty.test.ts"]: toHavePropertyTestText,
       ["__typetests__/toMatch.test.ts"]: toMatchTestText,
       ["__typetests__/toRaiseError.test.ts"]: toRaiseErrorTestText,

--- a/tests/validation-toBe.test.js
+++ b/tests/validation-toBe.test.js
@@ -1,0 +1,24 @@
+import { test } from "mocha";
+import * as assert from "./__utilities__/assert.js";
+import { getFixtureFileUrl, getTestFileName } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName);
+
+test("toBe", async function() {
+  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+  await assert.matchSnapshot(normalizeOutput(stdout), {
+    fileName: `${testFileName}-stdout`,
+    testFileUrl: import.meta.url,
+  });
+
+  await assert.matchSnapshot(stderr, {
+    fileName: `${testFileName}-stderr`,
+    testFileUrl: import.meta.url,
+  });
+
+  assert.equal(exitCode, 1);
+});


### PR DESCRIPTION
This is just a matcher rename from `.toEqual()` to `.toBe()`.

I think it was a mistake to call it `.toEqual()`. It would be fine to keep it, but I see why renaming makes sense.

First equality exists between values, but types are not values (they are models, shapes, but not values).

Second, it reads better and fits well with primitive type matchers:

```ts
.type.toBe<number | undefined>();

.type.toBeNumber();
.type.toBeUndefined();
```

This matcher checks identity that’s why it must be called `.toBe()`.