### PR TITLE
refactor(config): use 'option value' consistently in error messages

### DIFF
--- a/source/config/CommandLineOptionsWorker.ts
+++ b/source/config/CommandLineOptionsWorker.ts
@@ -38,9 +38,9 @@ export class CommandLineOptionsWorker {
     this.#optionValidator = new OptionValidator(OptionGroup.CommandLine, this.#storeService, this.#onDiagnostic);
   }
 
-  async #onExpectsArgumentDiagnostic(optionDefinition: OptionDefinition) {
+  async #onExpectsValue(optionDefinition: OptionDefinition) {
     const text = [
-      this.#optionDiagnosticText.expectsArgument(optionDefinition.name),
+      this.#optionDiagnosticText.expectsValue(optionDefinition.name),
       ...(await this.#optionUsageText.get(optionDefinition.name, optionDefinition.brand)),
     ];
 
@@ -105,7 +105,7 @@ export class CommandLineOptionsWorker {
           break;
         }
 
-        await this.#onExpectsArgumentDiagnostic(optionDefinition);
+        await this.#onExpectsValue(optionDefinition);
         break;
 
       case OptionBrand.String:
@@ -122,7 +122,7 @@ export class CommandLineOptionsWorker {
           break;
         }
 
-        await this.#onExpectsArgumentDiagnostic(optionDefinition);
+        await this.#onExpectsValue(optionDefinition);
         break;
 
       default:

--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -189,8 +189,7 @@ export class ConfigFileOptionsWorker {
     };
     const text = isListItem
       ? this.#optionDiagnosticText.expectsListItemType(optionDefinition.name, optionDefinition.brand)
-      // TODO here it would be better to require "a value of type", not "an argument of type"
-      : this.#optionDiagnosticText.requiresArgumentType(optionDefinition.name, optionDefinition.brand);
+      : this.#optionDiagnosticText.requiresValueType(optionDefinition.name, optionDefinition.brand);
 
     this.#onDiagnostic(Diagnostic.error(text, origin));
 

--- a/source/config/OptionDiagnosticText.ts
+++ b/source/config/OptionDiagnosticText.ts
@@ -11,14 +11,14 @@ export class OptionDiagnosticText {
     return "String literal with double quotes expected.";
   }
 
-  expectsArgument(optionName: string): string {
-    optionName = this.#optionName(optionName);
-
-    return `Option '${optionName}' expects an argument.`;
-  }
-
   expectsListItemType(optionName: string, optionBrand: OptionBrand): string {
     return `Item of the '${optionName}' list must be of type ${optionBrand}.`;
+  }
+
+  expectsValue(optionName: string): string {
+    optionName = this.#optionName(optionName);
+
+    return `Option '${optionName}' expects a value.`;
   }
 
   fileDoesNotExist(filePath: string): string {
@@ -35,10 +35,10 @@ export class OptionDiagnosticText {
     }
   }
 
-  requiresArgumentType(optionName: string, optionBrand: OptionBrand): string {
+  requiresValueType(optionName: string, optionBrand: OptionBrand): string {
     optionName = this.#optionName(optionName);
 
-    return `Option '${optionName}' requires an argument of type ${optionBrand}.`;
+    return `Option '${optionName}' requires a value of type ${optionBrand}.`;
   }
 
   unknownOption(optionName: string): string {

--- a/source/config/OptionUsageText.ts
+++ b/source/config/OptionUsageText.ts
@@ -24,7 +24,7 @@ export class OptionUsageText {
         switch (this.#optionGroup) {
           case OptionGroup.CommandLine:
             usageText.push(
-              "Argument for the '--target' option must be a single tag or a comma separated list.",
+              "Value for the '--target' option must be a single tag or a comma separated list.",
               "Usage examples: '--target 4.9', '--target latest', '--target 4.9,5.3.2,current'.",
               supportedTagsText,
             );
@@ -38,7 +38,7 @@ export class OptionUsageText {
       }
 
       default:
-        usageText.push(this.#optionDiagnosticText.requiresArgumentType(optionName, optionBrand));
+        usageText.push(this.#optionDiagnosticText.requiresValueType(optionName, optionBrand));
     }
 
     return usageText;

--- a/tests/__snapshots__/validation-configFile-tabs-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-configFile-tabs-wrong-option-value-type-stderr.snap.txt
@@ -1,7 +1,18 @@
-Error: Option 'rootPath' requires an argument of type string.
+Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-  2 |  "failFast": false,
+> 2 |  "failFast": "always",
+    |              ^
+  3 |  "rootPath": true
+  4 | }
+  5 | 
+
+      at ./tstyche.config.json:2:14
+
+Error: Option 'rootPath' requires a value of type string.
+
+  1 | {
+  2 |  "failFast": "always",
 > 3 |  "rootPath": true
     |              ^
   4 | }

--- a/tests/__snapshots__/validation-configFile-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-configFile-wrong-option-value-type-stderr.snap.txt
@@ -1,9 +1,20 @@
-Error: Option 'failFast' requires an argument of type boolean.
+Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |   "failFast": "always"
+> 2 |   "failFast": "always",
     |               ^
-  3 | }
+  3 |   "rootPath": true
+  4 | }
 
       at ./tstyche.config.json:2:15
+
+Error: Option 'rootPath' requires a value of type string.
+
+  1 | {
+  2 |   "failFast": "always",
+> 3 |   "rootPath": true
+    |               ^
+  4 | }
+
+      at ./tstyche.config.json:3:15
 

--- a/tests/__snapshots__/validation-failFast-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-failFast-wrong-option-value-type-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: Option 'failFast' requires an argument of type boolean.
+Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
 > 2 |   "failFast": "never"

--- a/tests/__snapshots__/validation-rootPath-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-rootPath-wrong-option-value-type-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: Option 'rootPath' requires an argument of type string.
+Error: Option 'rootPath' requires a value of type string.
 
   1 | {
 > 2 |   "rootPath": true

--- a/tests/__snapshots__/validation-target-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-target-wrong-option-value-type-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: Option 'target' requires an argument of type list.
+Error: Option 'target' requires a value of type list.
 
   1 | {
 > 2 |   "target": "current"

--- a/tests/__snapshots__/validation-testFileMatch-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-wrong-option-value-type-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: Option 'testFileMatch' requires an argument of type list.
+Error: Option 'testFileMatch' requires a value of type list.
 
   1 | {
 > 2 |   "testFileMatch": "feature"

--- a/tests/config-failFast.test.js
+++ b/tests/config-failFast.test.js
@@ -48,7 +48,7 @@ describe("'--failFast' command line option", function() {
     assert.equal(exitCode, 1);
   });
 
-  test("when 'true' is passed as an argument", async function() {
+  test("when 'true' is specified as a value", async function() {
     await writeFixture(fixtureUrl, {
       ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
       ["__typetests__/isString.tst.ts"]: isStringTestText,
@@ -70,7 +70,7 @@ describe("'--failFast' command line option", function() {
     assert.equal(exitCode, 1);
   });
 
-  test("when 'false' is passed as an argument", async function() {
+  test("when 'false' is specified as a value", async function() {
     await writeFixture(fixtureUrl, {
       ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
       ["__typetests__/isString.tst.ts"]: isStringTestText,

--- a/tests/validation-configFile.test.js
+++ b/tests/validation-configFile.test.js
@@ -34,9 +34,10 @@ describe("'tstyche.config.json' file", function() {
     assert.equal(exitCode, 1);
   });
 
-  test("handles option value of wrong type", async function() {
+  test("handles option values of wrong type", async function() {
     const config = {
       failFast: "always",
+      "rootPath": true,
     };
 
     await writeFixture(fixtureUrl, {
@@ -55,9 +56,9 @@ describe("'tstyche.config.json' file", function() {
     assert.equal(exitCode, 1);
   });
 
-  test("when tabs are used for indentation, handles option value of wrong type", async function() {
+  test("when tabs are used for indentation, handles option values of wrong type", async function() {
     const configText = `{
-\t"failFast": false,
+\t"failFast": "always",
 \t"rootPath": true
 }
 `;
@@ -183,7 +184,7 @@ describe("'tstyche.config.json' file", function() {
 });
 
 describe("'--config' command line option", function() {
-  test("when option argument is missing", async function() {
+  test("when option value is missing", async function() {
     await writeFixture(fixtureUrl);
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--config"]);
@@ -193,9 +194,9 @@ describe("'--config' command line option", function() {
     assert.equal(
       stderr,
       [
-        "Error: Option '--config' expects an argument.",
+        "Error: Option '--config' expects a value.",
         "",
-        "Option '--config' requires an argument of type string.",
+        "Option '--config' requires a value of type string.",
         "",
         "",
       ].join("\n"),

--- a/tests/validation-only.test.js
+++ b/tests/validation-only.test.js
@@ -11,7 +11,7 @@ afterEach(async function() {
 });
 
 describe("'--only' command line option", function() {
-  test("when option argument is missing", async function() {
+  test("when option value is missing", async function() {
     await writeFixture(fixtureUrl);
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--only"]);
@@ -21,9 +21,9 @@ describe("'--only' command line option", function() {
     assert.equal(
       stderr,
       [
-        "Error: Option '--only' expects an argument.",
+        "Error: Option '--only' expects a value.",
         "",
-        "Option '--only' requires an argument of type string.",
+        "Option '--only' requires a value of type string.",
         "",
         "",
       ].join("\n"),

--- a/tests/validation-skip.test.js
+++ b/tests/validation-skip.test.js
@@ -11,7 +11,7 @@ afterEach(async function() {
 });
 
 describe("'--skip' command line option", function() {
-  test("when option argument is missing", async function() {
+  test("when option value is missing", async function() {
     await writeFixture(fixtureUrl);
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--skip"]);
@@ -21,9 +21,9 @@ describe("'--skip' command line option", function() {
     assert.equal(
       stderr,
       [
-        "Error: Option '--skip' expects an argument.",
+        "Error: Option '--skip' expects a value.",
         "",
-        "Option '--skip' requires an argument of type string.",
+        "Option '--skip' requires a value of type string.",
         "",
         "",
       ].join("\n"),

--- a/tests/validation-target.test.js
+++ b/tests/validation-target.test.js
@@ -17,7 +17,7 @@ afterEach(async function() {
 });
 
 describe("'--target' command line option", function() {
-  test("when option argument is missing", async function() {
+  test("when option value is missing", async function() {
     await writeFixture(fixtureUrl, {
       ["__typetests__/dummy.test.ts"]: isStringTestText,
     });
@@ -27,9 +27,9 @@ describe("'--target' command line option", function() {
     assert.equal(stdout, "");
 
     const expected = [
-      "Error: Option '--target' expects an argument.",
+      "Error: Option '--target' expects a value.",
       "",
-      "Argument for the '--target' option must be a single tag or a comma separated list.",
+      "Value for the '--target' option must be a single tag or a comma separated list.",
       "Usage examples:",
     ].join("\n");
 
@@ -49,7 +49,7 @@ describe("'--target' command line option", function() {
     const expected = [
       "Error: TypeScript version 'new' is not supported.",
       "",
-      "Argument for the '--target' option must be a single tag or a comma separated list.",
+      "Value for the '--target' option must be a single tag or a comma separated list.",
       "Usage examples:",
     ].join("\n");
 
@@ -71,7 +71,7 @@ describe("'--target' command line option", function() {
     const expected = [
       "Error: Cannot use 'current' as a target. Failed to resolve the path to the currently installed TypeScript module.",
       "",
-      "Argument for the '--target' option must be a single tag or a comma separated list.",
+      "Value for the '--target' option must be a single tag or a comma separated list.",
       "Usage examples:",
     ].join("\n");
 


### PR DESCRIPTION
Refactoring error messages to use 'option value' consistently.