### PR TITLE
refactor: warn only once per deprecation

### DIFF
--- a/eslint.config.json
+++ b/eslint.config.json
@@ -80,6 +80,7 @@
     "@typescript-eslint/promise-function-async": "error",
     "@typescript-eslint/strict-boolean-expressions": "error",
     "@typescript-eslint/switch-exhaustiveness-check": "error",
+
     "import/first": "error",
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",
@@ -96,6 +97,7 @@
         ]
       }
     ],
+
     "simple-import-sort/imports": [
       "error",
       {
@@ -104,11 +106,13 @@
       }
     ],
     "simple-import-sort/exports": "error",
+
     "curly": "error",
     "eqeqeq": ["error", "smart"],
     "func-style": ["error", "declaration"],
     "object-shorthand": "error",
     "no-console": "warn",
+    "no-fallthrough": ["error", { "commentPattern": "break is omitted" }],
     "no-implicit-coercion": "error",
     "no-negated-condition": "error",
     "no-nested-ternary": "error",

--- a/source/events/EventEmitter.ts
+++ b/source/events/EventEmitter.ts
@@ -3,12 +3,13 @@ import type { DescribeResult, ExpectResult, FileResult, Result, TargetResult, Te
 
 export type Event =
   | ["config:error", { diagnostics: Array<Diagnostic> }]
-  | ["select:error", { diagnostics: Array<Diagnostic> }]
-  | ["store:info", { compilerVersion: string; installationPath: string }]
-  | ["store:error", { diagnostics: Array<Diagnostic> }]
+  | ["deprecation:info", { diagnostics: Array<Diagnostic> }]
   | ["input", { key: string }]
+  | ["select:error", { diagnostics: Array<Diagnostic> }]
   | ["run:start", { result: Result }]
   | ["run:end", { result: Result }]
+  | ["store:info", { compilerVersion: string; installationPath: string }]
+  | ["store:error", { diagnostics: Array<Diagnostic> }]
   | ["target:start", { result: TargetResult }]
   | ["target:end", { result: TargetResult }]
   | ["project:info", { compilerVersion: string; projectConfigFilePath: string | undefined }]

--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -92,19 +92,15 @@ export class Expect {
     const matcherNameText = assertion.matcherName.getText();
 
     switch (matcherNameText) {
-      case "toBe":
       case "toBeAssignable":
+      case "toEqual":
+        this.#onDeprecatedMatcher(assertion);
+        // break is omitted intentionally
+
+      case "toBe":
       case "toBeAssignableTo":
       case "toBeAssignableWith":
-      case "toEqual":
       case "toMatch":
-        if (matcherNameText === "toBeAssignable") {
-          this.#onDeprecatedMatcher(assertion, expectResult, "toBeAssignableWith");
-        }
-        if (matcherNameText === "toEqual") {
-          this.#onDeprecatedMatcher(assertion, expectResult, "toBe");
-        }
-
         if (assertion.source[0] == null) {
           this.#onSourceArgumentMustBeProvided(assertion, expectResult);
 
@@ -208,12 +204,12 @@ export class Expect {
     }
   }
 
-  #onDeprecatedMatcher(assertion: Assertion, expectResult: ExpectResult, newNameText: string) {
+  #onDeprecatedMatcher(assertion: Assertion) {
     const oldNameText = assertion.matcherName.getText();
 
     const text = [
-      `'.${oldNameText}()' has been renamed to '.${newNameText}()'.`,
-      `Please update the test. '.${oldNameText}()' is deprecated and will be removed in TSTyche 3.`,
+      `'.${oldNameText}()' is deprecated and will be removed in TSTyche 3.`,
+      "To learn more, visit https://tstyche.org/guide/upgrade",
     ];
     const origin = {
       end: assertion.matcherName.getEnd(),
@@ -222,8 +218,8 @@ export class Expect {
     };
 
     EventEmitter.dispatch([
-      "expect:error",
-      { diagnostics: [Diagnostic.warning(text, origin)], result: expectResult },
+      "deprecation:info",
+      { diagnostics: [Diagnostic.warning(text, origin)] },
     ]);
   }
 

--- a/source/reporters/ThoroughReporter.ts
+++ b/source/reporters/ThoroughReporter.ts
@@ -12,6 +12,7 @@ export class ThoroughReporter extends Reporter {
   #hasReportedAdds = false;
   #hasReportedError = false;
   #isFileViewExpanded = false;
+  #seenDeprecations = new Set<string>();
 
   get #isLastFile() {
     return this.#fileCount === 0;
@@ -19,6 +20,15 @@ export class ThoroughReporter extends Reporter {
 
   handleEvent([eventName, payload]: Event): void {
     switch (eventName) {
+      case "deprecation:info":
+        for (const diagnostic of payload.diagnostics) {
+          if (!this.#seenDeprecations.has(diagnostic.text.toString())) {
+            this.#fileView.addMessage(diagnosticText(diagnostic));
+            this.#seenDeprecations.add(diagnostic.text.toString());
+          }
+        }
+        break;
+
       case "run:start":
         this.#isFileViewExpanded = payload.result.testFiles.length === 1 && this.resolvedConfig.watch !== true;
         break;

--- a/source/result/ResultManager.ts
+++ b/source/result/ResultManager.ts
@@ -190,10 +190,6 @@ export class ResultManager {
         break;
 
       case "expect:error":
-        if (payload.diagnostics.every((diagnostic) => diagnostic.category === DiagnosticCategory.Warning)) {
-          return;
-        }
-
         this.#result!.expectCount.failed++;
         this.#fileResult!.expectCount.failed++;
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -81,19 +81,22 @@ interface Matchers {
   /**
    * Checks if the source type is assignable with the target type.
    *
-   * @deprecated This matcher has been renamed to `.toBeAssignableWith()`.
+   * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+   * To learn more, visit https://tstyche.org/guide/upgrade.
    */
   toBeAssignable: {
     /**
      * Checks if the source type is assignable with the target type.
      *
-     * @deprecated This matcher has been renamed to `.toBeAssignableWith()`.
+     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     <Target>(): void;
     /**
      * Checks if the source type is assignable with type of the target expression.
      *
-     * @deprecated This matcher has been renamed to `.toBeAssignableWith()`.
+     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     (target: unknown): void;
   };
@@ -170,19 +173,22 @@ interface Matchers {
   /**
    * Checks if the source type is identical to the target type.
    *
-   * @deprecated This matcher has been renamed to `.toBe()`.
+   * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+   * To learn more, visit https://tstyche.org/guide/upgrade.
    */
   toEqual: {
     /**
      * Checks if the source type is identical to the target type.
      *
-     * @deprecated This matcher has been renamed to `.toBe()`.
+     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     <Target>(): void;
     /**
      * Checks if the source type is identical to type of the target expression.
      *
-     * @deprecated This matcher has been renamed to `.toBe()`.
+     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     (target: unknown): void;
   };

--- a/source/types.ts
+++ b/source/types.ts
@@ -81,21 +81,21 @@ interface Matchers {
   /**
    * Checks if the source type is assignable with the target type.
    *
-   * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+   * @deprecated Use `.toBeAssignableWith()` or `.toBeAssignableTo()` instead. This matcher will be removed in TSTyche 3.
    * To learn more, visit https://tstyche.org/guide/upgrade.
    */
   toBeAssignable: {
     /**
      * Checks if the source type is assignable with the target type.
      *
-     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * @deprecated Use `.toBeAssignableWith()` or `.toBeAssignableTo()` instead. This matcher will be removed in TSTyche 3.
      * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     <Target>(): void;
     /**
      * Checks if the source type is assignable with type of the target expression.
      *
-     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * @deprecated Use `.toBeAssignableWith()` or `.toBeAssignableTo()` instead. This matcher will be removed in TSTyche 3.
      * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     (target: unknown): void;
@@ -173,21 +173,21 @@ interface Matchers {
   /**
    * Checks if the source type is identical to the target type.
    *
-   * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+   * @deprecated Use `.toBe()` instead. This matcher will be removed in TSTyche 3.
    * To learn more, visit https://tstyche.org/guide/upgrade.
    */
   toEqual: {
     /**
      * Checks if the source type is identical to the target type.
      *
-     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * @deprecated Use `.toBe()` instead. This matcher will be removed in TSTyche 3.
      * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     <Target>(): void;
     /**
      * Checks if the source type is identical to type of the target expression.
      *
-     * @deprecated This matcher is deprecated and will be removed in TSTyche 3.
+     * @deprecated This matcher will be removed in TSTyche 3.
      * To learn more, visit https://tstyche.org/guide/upgrade.
      */
     (target: unknown): void;

--- a/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
@@ -1,6 +1,6 @@
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+Warning: '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
+To learn more, visit https://tstyche.org/guide/upgrade
 
    8 | describe("received type", () => {
    9 |   test("is assignable expected value?", () => {
@@ -11,48 +11,6 @@ Please update the test. '.toBeAssignable()' is deprecated and will be removed in
   13 | 
 
        at ./__typetests__/toBeAssignable.tst.ts:10:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-   9 |   test("is assignable expected value?", () => {
-  10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
-> 11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
-     |                          ^
-  12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
-  13 | 
-  14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
-
-       at ./__typetests__/toBeAssignable.tst.ts:11:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
-  11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
-> 12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
-     |                          ^
-  13 | 
-  14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
-  15 |   });
-
-       at ./__typetests__/toBeAssignable.tst.ts:12:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
-  13 | 
-> 14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
-     |                          ^
-  15 |   });
-  16 | 
-  17 |   test("is NOT assignable expected value?", () => {
-
-       at ./__typetests__/toBeAssignable.tst.ts:14:26
 
 Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
@@ -66,34 +24,6 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
        at ./__typetests__/toBeAssignable.tst.ts:14:26 ❭ received type ❭ is assignable expected value?
 
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  16 | 
-  17 |   test("is NOT assignable expected value?", () => {
-> 18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
-     |                              ^
-  19 | 
-  20 |     expect<Names>().type.not.toBeAssignable({ first: "Rose" });
-  21 |   });
-
-       at ./__typetests__/toBeAssignable.tst.ts:18:30
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
-  19 | 
-> 20 |     expect<Names>().type.not.toBeAssignable({ first: "Rose" });
-     |                              ^
-  21 |   });
-  22 | 
-  23 |   test("is assignable expected type?", () => {
-
-       at ./__typetests__/toBeAssignable.tst.ts:20:30
-
 Error: Type 'Names' is assignable with type '{ first: string; }'.
 
   18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
@@ -105,76 +35,6 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
   23 |   test("is assignable expected type?", () => {
 
        at ./__typetests__/toBeAssignable.tst.ts:20:30 ❭ received type ❭ is NOT assignable expected value?
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  22 | 
-  23 |   test("is assignable expected type?", () => {
-> 24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
-     |                          ^
-  25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
-  26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
-  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
-
-       at ./__typetests__/toBeAssignable.tst.ts:24:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  23 |   test("is assignable expected type?", () => {
-  24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
-> 25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
-     |                          ^
-  26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
-  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
-  28 | 
-
-       at ./__typetests__/toBeAssignable.tst.ts:25:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  24 |     expect<Names>().type.toBeAssignable<{ first: string }>();
-  25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
-> 26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
-     |                          ^
-  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
-  28 | 
-  29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
-
-       at ./__typetests__/toBeAssignable.tst.ts:26:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  25 |     expect<Names>().type.toBeAssignable<{ first: string; last: string }>();
-  26 |     expect<Names>().type.toBeAssignable<{ first: string; last: undefined }>();
-> 27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
-     |                          ^
-  28 | 
-  29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
-  30 |   });
-
-       at ./__typetests__/toBeAssignable.tst.ts:27:26
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
-  28 | 
-> 29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
-     |                          ^
-  30 |   });
-  31 | 
-  32 |   test("is NOT assignable expected type?", () => {
-
-       at ./__typetests__/toBeAssignable.tst.ts:29:26
 
 Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
@@ -188,34 +48,6 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
        at ./__typetests__/toBeAssignable.tst.ts:29:26 ❭ received type ❭ is assignable expected type?
 
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  31 | 
-  32 |   test("is NOT assignable expected type?", () => {
-> 33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
-     |                              ^
-  34 | 
-  35 |     expect<Names>().type.not.toBeAssignable<{ first: string }>();
-  36 |   });
-
-       at ./__typetests__/toBeAssignable.tst.ts:33:30
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
-  34 | 
-> 35 |     expect<Names>().type.not.toBeAssignable<{ first: string }>();
-     |                              ^
-  36 |   });
-  37 | });
-  38 | 
-
-       at ./__typetests__/toBeAssignable.tst.ts:35:30
-
 Error: Type 'Names' is assignable with type '{ first: string; }'.
 
   33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
@@ -227,34 +59,6 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
   38 | 
 
        at ./__typetests__/toBeAssignable.tst.ts:35:30 ❭ received type ❭ is NOT assignable expected type?
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  39 | describe("received value", () => {
-  40 |   test("is assignable expected value?", () => {
-> 41 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable({
-     |                                                  ^
-  42 |       first: "Rose",
-  43 |       last: "Smith",
-  44 |     });
-
-       at ./__typetests__/toBeAssignable.tst.ts:41:50
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  44 |     });
-  45 | 
-> 46 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable({
-     |                                                  ^
-  47 |       middle: "O.",
-  48 |     });
-  49 |   });
-
-       at ./__typetests__/toBeAssignable.tst.ts:46:50
 
 Error: Type '{ first: string; last: string; }' is not assignable with type '{ middle: string; }'.
 
@@ -268,34 +72,6 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
        at ./__typetests__/toBeAssignable.tst.ts:46:50 ❭ received value ❭ is assignable expected value?
 
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  50 | 
-  51 |   test("is NOT assignable expected value?", () => {
-> 52 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignable({
-     |                                                      ^
-  53 |       middle: "O.",
-  54 |     });
-  55 | 
-
-       at ./__typetests__/toBeAssignable.tst.ts:52:54
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  54 |     });
-  55 | 
-> 56 |     expect({ first: "Jane" }).type.not.toBeAssignable({ first: "Rose" });
-     |                                        ^
-  57 |   });
-  58 | 
-  59 |   test("is assignable expected type?", () => {
-
-       at ./__typetests__/toBeAssignable.tst.ts:56:40
-
 Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
   54 |     });
@@ -308,34 +84,6 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
        at ./__typetests__/toBeAssignable.tst.ts:56:40 ❭ received value ❭ is NOT assignable expected value?
 
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  58 | 
-  59 |   test("is assignable expected type?", () => {
-> 60 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable<{
-     |                                                  ^
-  61 |       first: string;
-  62 |       last: string;
-  63 |     }>();
-
-       at ./__typetests__/toBeAssignable.tst.ts:60:50
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  63 |     }>();
-  64 | 
-> 65 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable<{
-     |                                                  ^
-  66 |       middle: string;
-  67 |     }>();
-  68 |   });
-
-       at ./__typetests__/toBeAssignable.tst.ts:65:50
-
 Error: Type '{ first: string; last: string; }' is not assignable with type '{ middle: string; }'.
 
   63 |     }>();
@@ -347,34 +95,6 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
   68 |   });
 
        at ./__typetests__/toBeAssignable.tst.ts:65:50 ❭ received value ❭ is assignable expected type?
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  69 | 
-  70 |   test("is NOT assignable type?", () => {
-> 71 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignable<{
-     |                                                      ^
-  72 |       middle: string;
-  73 |     }>();
-  74 | 
-
-       at ./__typetests__/toBeAssignable.tst.ts:71:54
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-  73 |     }>();
-  74 | 
-> 75 |     expect({ first: "Jane" }).type.not.toBeAssignable<{ first: string }>();
-     |                                        ^
-  76 |   });
-  77 | });
-  78 | 
-
-       at ./__typetests__/toBeAssignable.tst.ts:75:40
 
 Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 

--- a/tests/__snapshots__/api-toEqual-stderr.snap.txt
+++ b/tests/__snapshots__/api-toEqual-stderr.snap.txt
@@ -1,6 +1,6 @@
-Warning: '.toEqual()' has been renamed to '.toBe()'.
+Warning: '.toEqual()' is deprecated and will be removed in TSTyche 3.
 
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+To learn more, visit https://tstyche.org/guide/upgrade
 
   15 | test("edge cases", () => {
   16 |   /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -11,76 +11,6 @@ Please update the test. '.toEqual()' is deprecated and will be removed in TSTych
   20 | 
 
        at ./__typetests__/toEqual.tst.ts:17:26
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  16 |   /* eslint-disable @typescript-eslint/no-explicit-any */
-  17 |   expect<any>().type.not.toEqual<never>();
-> 18 |   expect<any>().type.not.toEqual<unknown>();
-     |                          ^
-  19 |   /* eslint-enable @typescript-eslint/no-explicit-any */
-  20 | 
-  21 |   expect(Date).type.toEqual<typeof Date>();
-
-       at ./__typetests__/toEqual.tst.ts:18:26
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  19 |   /* eslint-enable @typescript-eslint/no-explicit-any */
-  20 | 
-> 21 |   expect(Date).type.toEqual<typeof Date>();
-     |                     ^
-  22 | });
-  23 | 
-  24 | describe("received type", () => {
-
-       at ./__typetests__/toEqual.tst.ts:21:21
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  24 | describe("received type", () => {
-  25 |   test("equals expected type", () => {
-> 26 |     expect<{ a: string; b: number }>().type.toEqual<{ a: string; b: number }>();
-     |                                             ^
-  27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
-  28 | 
-  29 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
-
-       at ./__typetests__/toEqual.tst.ts:26:45
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  25 |   test("equals expected type", () => {
-  26 |     expect<{ a: string; b: number }>().type.toEqual<{ a: string; b: number }>();
-> 27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
-     |                          ^
-  28 | 
-  29 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
-  30 |   });
-
-       at ./__typetests__/toEqual.tst.ts:27:26
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  27 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
-  28 | 
-> 29 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
-     |                          ^
-  30 |   });
-  31 | 
-  32 |   test("does NOT equal expected type", () => {
-
-       at ./__typetests__/toEqual.tst.ts:29:26
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
@@ -94,34 +24,6 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
        at ./__typetests__/toEqual.tst.ts:29:26 ❭ received type ❭ equals expected type
 
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  31 | 
-  32 |   test("does NOT equal expected type", () => {
-> 33 |     expect<Names>().type.not.toEqual<{ first: string; last: string }>();
-     |                              ^
-  34 | 
-  35 |     expect<Names>().type.not.toEqual<{ first: string; last?: string }>();
-  36 |   });
-
-       at ./__typetests__/toEqual.tst.ts:33:30
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  33 |     expect<Names>().type.not.toEqual<{ first: string; last: string }>();
-  34 | 
-> 35 |     expect<Names>().type.not.toEqual<{ first: string; last?: string }>();
-     |                              ^
-  36 |   });
-  37 | 
-  38 |   test("equals expected value", () => {
-
-       at ./__typetests__/toEqual.tst.ts:35:30
-
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
   33 |     expect<Names>().type.not.toEqual<{ first: string; last: string }>();
@@ -133,48 +35,6 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
   38 |   test("equals expected value", () => {
 
        at ./__typetests__/toEqual.tst.ts:35:30 ❭ received type ❭ does NOT equal expected type
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  37 | 
-  38 |   test("equals expected value", () => {
-> 39 |     expect<Names>().type.toEqual(getNames());
-     |                          ^
-  40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
-  41 | 
-  42 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
-
-       at ./__typetests__/toEqual.tst.ts:39:26
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  38 |   test("equals expected value", () => {
-  39 |     expect<Names>().type.toEqual(getNames());
-> 40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
-     |                                                     ^
-  41 | 
-  42 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
-  43 |   });
-
-       at ./__typetests__/toEqual.tst.ts:40:53
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  40 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
-  41 | 
-> 42 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
-     |                                                    ^
-  43 |   });
-  44 | 
-  45 |   test("does NOT equal expected value", () => {
-
-       at ./__typetests__/toEqual.tst.ts:42:52
 
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
@@ -188,34 +48,6 @@ Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
        at ./__typetests__/toEqual.tst.ts:42:52 ❭ received type ❭ equals expected value
 
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  44 | 
-  45 |   test("does NOT equal expected value", () => {
-> 46 |     expect<{ first: string; last: string }>().type.not.toEqual(getNames());
-     |                                                        ^
-  47 | 
-  48 |     expect<{ first: string; last?: string }>().type.not.toEqual(getNames());
-  49 |   });
-
-       at ./__typetests__/toEqual.tst.ts:46:56
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  46 |     expect<{ first: string; last: string }>().type.not.toEqual(getNames());
-  47 | 
-> 48 |     expect<{ first: string; last?: string }>().type.not.toEqual(getNames());
-     |                                                         ^
-  49 |   });
-  50 | });
-  51 | 
-
-       at ./__typetests__/toEqual.tst.ts:48:57
-
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
   46 |     expect<{ first: string; last: string }>().type.not.toEqual(getNames());
@@ -227,48 +59,6 @@ Error: Type '{ first: string; last?: string | undefined; }' is identical to type
   51 | 
 
        at ./__typetests__/toEqual.tst.ts:48:57 ❭ received type ❭ does NOT equal expected value
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  52 | describe("received value", () => {
-  53 |   test("equals expected type", () => {
-> 54 |     expect(getNames()).type.toEqual<{ first: string; last?: string }>();
-     |                             ^
-  55 |     expect(getNames()).type.toEqual<Names>();
-  56 | 
-  57 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
-
-       at ./__typetests__/toEqual.tst.ts:54:29
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  53 |   test("equals expected type", () => {
-  54 |     expect(getNames()).type.toEqual<{ first: string; last?: string }>();
-> 55 |     expect(getNames()).type.toEqual<Names>();
-     |                             ^
-  56 | 
-  57 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
-  58 |   });
-
-       at ./__typetests__/toEqual.tst.ts:55:29
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  55 |     expect(getNames()).type.toEqual<Names>();
-  56 | 
-> 57 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
-     |                             ^
-  58 |   });
-  59 | 
-  60 |   test("does NOT equal expected type", () => {
-
-       at ./__typetests__/toEqual.tst.ts:57:29
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
@@ -282,34 +72,6 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
        at ./__typetests__/toEqual.tst.ts:57:29 ❭ received value ❭ equals expected type
 
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  59 | 
-  60 |   test("does NOT equal expected type", () => {
-> 61 |     expect(getNames()).type.not.toEqual<{ first: string; last: string }>();
-     |                                 ^
-  62 | 
-  63 |     expect(getNames()).type.not.toEqual<{ first: string; last?: string }>();
-  64 |   });
-
-       at ./__typetests__/toEqual.tst.ts:61:33
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  61 |     expect(getNames()).type.not.toEqual<{ first: string; last: string }>();
-  62 | 
-> 63 |     expect(getNames()).type.not.toEqual<{ first: string; last?: string }>();
-     |                                 ^
-  64 |   });
-  65 | 
-  66 |   test("equals expected value", () => {
-
-       at ./__typetests__/toEqual.tst.ts:63:33
-
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
   61 |     expect(getNames()).type.not.toEqual<{ first: string; last: string }>();
@@ -322,34 +84,6 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
        at ./__typetests__/toEqual.tst.ts:63:33 ❭ received value ❭ does NOT equal expected type
 
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  65 | 
-  66 |   test("equals expected value", () => {
-> 67 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
-     |                                            ^
-  68 | 
-  69 |     expect({ height: 14 }).type.toEqual(getSize());
-  70 |   });
-
-       at ./__typetests__/toEqual.tst.ts:67:44
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  67 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
-  68 | 
-> 69 |     expect({ height: 14 }).type.toEqual(getSize());
-     |                                 ^
-  70 |   });
-  71 | 
-  72 |   test("does NOT equal expected value", () => {
-
-       at ./__typetests__/toEqual.tst.ts:69:33
-
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
   67 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
@@ -361,34 +95,6 @@ Error: Type '{ height: number; }' is not identical to type 'Size'.
   72 |   test("does NOT equal expected value", () => {
 
        at ./__typetests__/toEqual.tst.ts:69:33 ❭ received value ❭ equals expected value
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  71 | 
-  72 |   test("does NOT equal expected value", () => {
-> 73 |     expect({ height: 14 }).type.not.toEqual(getSize());
-     |                                     ^
-  74 | 
-  75 |     expect({ height: 14, width: 25 }).type.not.toEqual(getSize());
-  76 |   });
-
-       at ./__typetests__/toEqual.tst.ts:73:37
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-  73 |     expect({ height: 14 }).type.not.toEqual(getSize());
-  74 | 
-> 75 |     expect({ height: 14, width: 25 }).type.not.toEqual(getSize());
-     |                                                ^
-  76 |   });
-  77 | });
-  78 | 
-
-       at ./__typetests__/toEqual.tst.ts:75:48
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 

--- a/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
@@ -1,6 +1,6 @@
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
+Warning: '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
 
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
+To learn more, visit https://tstyche.org/guide/upgrade
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
@@ -23,20 +23,6 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
   8 | 
 
       at ./__typetests__/toBeAssignable.tst.ts:5:5
-
-Warning: '.toBeAssignable()' has been renamed to '.toBeAssignableWith()'.
-
-Please update the test. '.toBeAssignable()' is deprecated and will be removed in TSTyche 3.
-
-   9 | describe("argument for 'target'", () => {
-  10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toBeAssignable();
-     |                                   ^
-  12 |   });
-  13 | });
-  14 | 
-
-       at ./__typetests__/toBeAssignable.tst.ts:11:35
 
 Error: An argument for 'target' or type argument for 'Target' must be provided.
 

--- a/tests/__snapshots__/validation-toEqual-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toEqual-stderr.snap.txt
@@ -1,6 +1,6 @@
-Warning: '.toEqual()' has been renamed to '.toBe()'.
+Warning: '.toEqual()' is deprecated and will be removed in TSTyche 3.
 
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
+To learn more, visit https://tstyche.org/guide/upgrade
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
@@ -23,20 +23,6 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
   8 | 
 
       at ./__typetests__/toEqual.tst.ts:5:5
-
-Warning: '.toEqual()' has been renamed to '.toBe()'.
-
-Please update the test. '.toEqual()' is deprecated and will be removed in TSTyche 3.
-
-   9 | describe("argument for 'target'", () => {
-  10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toEqual();
-     |                                   ^
-  12 |   });
-  13 | });
-  14 | 
-
-       at ./__typetests__/toEqual.tst.ts:11:35
 
 Error: An argument for 'target' or type argument for 'Target' must be provided.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": true,
-    "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,


### PR DESCRIPTION
Less noise. It is enough to warn only once per deprecation.