### PR TITLE
refactor(runner)!: use `resolvedConfig.target` option

### DIFF
--- a/source/api/TSTyche.ts
+++ b/source/api/TSTyche.ts
@@ -64,7 +64,6 @@ export class TSTyche {
   async run(testFiles: Array<string | URL>): Promise<void> {
     await this.#taskRunner.run(
       testFiles.map((testFile) => new TestFile(testFile)),
-      this.resolvedConfig.target,
       this.#cancellationToken,
     );
   }

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -10,7 +10,6 @@ export class TaskRunner {
   #resultManager: ResultManager;
   #storeService: StoreService;
 
-  // TODO should be `taskConfig`, not `resolvedConfig`
   constructor(
     readonly resolvedConfig: ResolvedConfig,
     storeService: StoreService,
@@ -23,12 +22,12 @@ export class TaskRunner {
     });
   }
 
-  async run(testFiles: Array<TestFile>, target: Array<string>, cancellationToken?: CancellationToken): Promise<void> {
+  async run(testFiles: Array<TestFile>, cancellationToken?: CancellationToken): Promise<void> {
     const result = new Result(this.resolvedConfig, testFiles);
 
     EventEmitter.dispatch(["run:start", { result }]);
 
-    for (const versionTag of target) {
+    for (const versionTag of this.resolvedConfig.target) {
       const targetResult = new TargetResult(versionTag, testFiles);
 
       EventEmitter.dispatch(["target:start", { result: targetResult }]);

--- a/tests/feature-programmatic-api.test.js
+++ b/tests/feature-programmatic-api.test.js
@@ -51,7 +51,7 @@ describe("runs type tests", function() {
 
   testCases.forEach(({ testCase, identifier }) => {
     test(testCase, async function() {
-      await taskRunner.run([new tstyche.TestFile(identifier)], resolvedConfig.target);
+      await taskRunner.run([new tstyche.TestFile(identifier)]);
 
       assert.deepEqual(result?.expectCount, { failed: 1, passed: 2, skipped: 3, todo: 0 });
       assert.deepEqual(result?.fileCount, { failed: 1, passed: 0, skipped: 0, todo: 0 });
@@ -63,7 +63,7 @@ describe("runs type tests", function() {
     test(`${testCase} with position is pointing to 'expect'`, async function() {
       const testFile = new tstyche.TestFile(identifier);
 
-      await taskRunner.run([testFile.add({ position: isWindows ? 73 : 70 })], resolvedConfig.target);
+      await taskRunner.run([testFile.add({ position: isWindows ? 73 : 70 })]);
 
       assert.deepEqual(result?.expectCount, { failed: 0, passed: 1, skipped: 5, todo: 0 });
       assert.deepEqual(result?.fileCount, { failed: 0, passed: 1, skipped: 0, todo: 0 });
@@ -75,7 +75,7 @@ describe("runs type tests", function() {
     test(`${testCase} with position is pointing to 'expect.skip'`, async function() {
       const testFile = new tstyche.TestFile(identifier);
 
-      await taskRunner.run([testFile.add({ position: isWindows ? 273 : 261 })], resolvedConfig.target);
+      await taskRunner.run([testFile.add({ position: isWindows ? 273 : 261 })]);
 
       assert.deepEqual(result?.expectCount, { failed: 1, passed: 0, skipped: 5, todo: 0 });
       assert.deepEqual(result?.fileCount, { failed: 1, passed: 0, skipped: 0, todo: 0 });
@@ -87,7 +87,7 @@ describe("runs type tests", function() {
     test(`${testCase} with position is pointing to 'test'`, async function() {
       const testFile = new tstyche.TestFile(identifier);
 
-      await taskRunner.run([testFile.add({ position: isWindows ? 43 : 41 })], resolvedConfig.target);
+      await taskRunner.run([testFile.add({ position: isWindows ? 43 : 41 })]);
 
       assert.deepEqual(result?.expectCount, { failed: 0, passed: 1, skipped: 5, todo: 0 });
       assert.deepEqual(result?.fileCount, { failed: 0, passed: 1, skipped: 0, todo: 0 });
@@ -99,7 +99,7 @@ describe("runs type tests", function() {
     test(`${testCase} with position is pointing to 'test.skip'`, async function() {
       const testFile = new tstyche.TestFile(identifier);
 
-      await taskRunner.run([testFile.add({ position: isWindows ? 117 : 111 })], resolvedConfig.target);
+      await taskRunner.run([testFile.add({ position: isWindows ? 117 : 111 })]);
 
       assert.deepEqual(result?.expectCount, { failed: 1, passed: 1, skipped: 4, todo: 0 });
       assert.deepEqual(result?.fileCount, { failed: 1, passed: 0, skipped: 0, todo: 0 });


### PR DESCRIPTION
The `TaskRunner` has `resolvedConfig.target` option set already, let’s use it.