### PR TITLE
chore: drop support for Node.js 14

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14.17', '14.x', '16.x', '18.x', '20.x', '22.x']
+        node-version: ['16.14', '16.x', '18.x', '20.x', '22.x']
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
   },
   "packageManager": "yarn@3.8.2",
   "engines": {
-    "node": ">=14.17"
+    "node": ">=16.14"
   }
 }

--- a/tests/__utilities__/process.js
+++ b/tests/__utilities__/process.js
@@ -1,6 +1,4 @@
 import { spawn } from "node:child_process";
-import { stderr, stdout } from "node:process";
-import { fileURLToPath } from "node:url";
 
 class Deferred {
   constructor() {
@@ -36,8 +34,7 @@ export class Process {
    */
   constructor(fixtureUrl, args, options) {
     this.#subprocess = spawn("tstyche", args, {
-      // TODO use URL directly after dropping support for Node.js 16.4.0
-      cwd: fileURLToPath(fixtureUrl),
+      cwd: fixtureUrl,
       env: {
         ...process.env,
         ["TSTYCHE_NO_COLOR"]: "true",

--- a/tests/__utilities__/tstyche.js
+++ b/tests/__utilities__/tstyche.js
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 
 /**
  * @param {URL} fixtureUrl
@@ -10,8 +9,7 @@ import { fileURLToPath } from "node:url";
 export async function spawnTyche(fixtureUrl, args, options) {
   return new Promise((resolve, reject) => {
     const tstyche = spawn("tstyche", args, {
-      // TODO use URL directly after dropping support for Node.js 16.4.0
-      cwd: fileURLToPath(fixtureUrl),
+      cwd: fixtureUrl,
       env: {
         ...process.env,
         ["TSTYCHE_NO_COLOR"]: "true",

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -38,31 +38,26 @@ test("when fetching of metadata from the registry times out", async function () 
 });
 
 test("when installing 'typescript' times out", async function () {
-  if (process.versions.node.startsWith("14.17")) {
-    // Node.js 14.17 does not support 'timeout' option in 'child_process.spawn()'
-    this.skip();
-  } else {
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-    });
+  await writeFixture(fixtureUrl, {
+    ["__typetests__/dummy.test.ts"]: isStringTestText,
+  });
 
-    await spawnTyche(fixtureUrl, ["--target", "5.2"]);
+  await spawnTyche(fixtureUrl, ["--target", "5.2"]);
 
-    const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.1"], {
-      env: {
-        ["TSTYCHE_TIMEOUT"]: "0.001",
-      },
-    });
+  const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.1"], {
+    env: {
+      ["TSTYCHE_TIMEOUT"]: "0.001",
+    },
+  });
 
-    const expected = [
-      "Error: Failed to install 'typescript@5.1.6'.",
-      "",
-      "Error: setup timeout of 0.001s was exceeded",
-    ].join("\n");
+  const expected = [
+    "Error: Failed to install 'typescript@5.1.6'.",
+    "",
+    "Error: setup timeout of 0.001s was exceeded",
+  ].join("\n");
 
-    assert.match(stderr, new RegExp(`^${expected}`));
-    assert.equal(exitCode, 1);
-  }
+  assert.match(stderr, new RegExp(`^${expected}`));
+  assert.equal(exitCode, 1);
 });
 
 describe("warns if resolution of a tag may be outdated", function () {


### PR DESCRIPTION
Dropping support for Node.js 14.