### PR TITLE
feat(config)!: always set `configFilePath` property in the resolved config

### DIFF
--- a/tests/config-configFile.test.js
+++ b/tests/config-configFile.test.js
@@ -116,7 +116,7 @@ describe("'--config' command line option", function () {
     ]);
 
     assert.matchObject(normalizeOutput(stdout), {
-      config: "<<cwd>>/tests/__fixtures__/.generated/config-configFile/config/tstyche.json",
+      configFilePath: "<<cwd>>/tests/__fixtures__/.generated/config-configFile/config/tstyche.json",
       rootPath: "<<cwd>>/tests/__fixtures__/.generated/config-configFile",
     });
 

--- a/tests/config-rootPath.test.js
+++ b/tests/config-rootPath.test.js
@@ -41,7 +41,7 @@ describe("'rootPath' configuration file option", function () {
     ]);
 
     assert.matchObject(normalizeOutput(stdout), {
-      config: "<<cwd>>/tests/__fixtures__/.generated/config-rootPath/config/tstyche.json",
+      configFilePath: "<<cwd>>/tests/__fixtures__/.generated/config-rootPath/config/tstyche.json",
       rootPath: "<<cwd>>/tests/__fixtures__/.generated/config-rootPath/config",
     });
 
@@ -65,7 +65,7 @@ describe("'rootPath' configuration file option", function () {
     ]);
 
     assert.matchObject(normalizeOutput(stdout), {
-      config: "<<cwd>>/tests/__fixtures__/.generated/config-rootPath/config/tstyche.json",
+      configFilePath: "<<cwd>>/tests/__fixtures__/.generated/config-rootPath/config/tstyche.json",
       rootPath: "<<cwd>>/tests/__fixtures__/.generated/config-rootPath",
     });
 


### PR DESCRIPTION
Always set `configFilePath` property in the resolved config. This can be useful to watch the config file for changes.