### PR TITLE
feat(api, cli, events, runner): add and remove event handlers for each scope

### DIFF
--- a/source/api/TSTyche.ts
+++ b/source/api/TSTyche.ts
@@ -11,6 +11,7 @@ import { CancellationReason, CancellationToken } from "#token";
 
 // biome-ignore lint/style/useNamingConvention: this is an exception
 export class TSTyche {
+  #eventEmitter = new EventEmitter();
   #selectService: SelectService;
   #storeService: StoreService;
   #taskRunner: TaskRunner;
@@ -26,8 +27,12 @@ export class TSTyche {
     this.#taskRunner = new TaskRunner(this.resolvedConfig, this.#selectService, this.#storeService);
   }
 
+  close(): void {
+    this.#taskRunner.close();
+  }
+
   async run(testFiles: Array<string | URL>, cancellationToken = new CancellationToken()): Promise<void> {
-    EventEmitter.addHandler(([eventName, payload]) => {
+    this.#eventEmitter.addHandler(([eventName, payload]) => {
       if (
         (eventName.endsWith("error") || eventName.endsWith("fail")) &&
         "diagnostics" in payload &&
@@ -52,7 +57,7 @@ export class TSTyche {
     }
 
     for (const reporter of reporters) {
-      EventEmitter.addHandler((event) => {
+      this.#eventEmitter.addHandler((event) => {
         reporter.handleEvent(event);
       });
     }
@@ -62,6 +67,6 @@ export class TSTyche {
       cancellationToken,
     );
 
-    EventEmitter.removeAllHandlers();
+    this.#eventEmitter.removeHandlers();
   }
 }

--- a/source/events/EventEmitter.ts
+++ b/source/events/EventEmitter.ts
@@ -36,8 +36,10 @@ export type EventHandler = (event: Event) => void;
 
 export class EventEmitter {
   static #handlers = new Set<EventHandler>();
+  #scopeHandlers = new Set<EventHandler>();
 
-  static addHandler(handler: EventHandler): void {
+  addHandler(handler: EventHandler): void {
+    this.#scopeHandlers.add(handler);
     EventEmitter.#handlers.add(handler);
   }
 
@@ -47,11 +49,11 @@ export class EventEmitter {
     }
   }
 
-  static removeAllHandlers(): void {
-    EventEmitter.#handlers = new Set<EventHandler>();
-  }
+  removeHandlers(): void {
+    for (const handler of this.#scopeHandlers) {
+      EventEmitter.#handlers.delete(handler);
+    }
 
-  static removeHandler(handler: EventHandler): void {
-    EventEmitter.#handlers.delete(handler);
+    this.#scopeHandlers.clear();
   }
 }


### PR DESCRIPTION
Removing all event handlers breaks the logic. Hence adding and removing handlers should be done separately for each scope.