### PR TITLE
feat: report the exit code of the last test rerun

### DIFF
--- a/source/api/TSTyche.ts
+++ b/source/api/TSTyche.ts
@@ -1,4 +1,3 @@
-import process from "node:process";
 import type { ResolvedConfig } from "#config";
 import { DiagnosticCategory } from "#diagnostic";
 import { EventEmitter } from "#events";
@@ -38,10 +37,6 @@ export class TSTyche {
         "diagnostics" in payload &&
         payload.diagnostics.some((diagnostic) => diagnostic.category === DiagnosticCategory.Error)
       ) {
-        if (this.resolvedConfig.watch !== true) {
-          process.exitCode = 1;
-        }
-
         if (this.resolvedConfig.failFast) {
           cancellationToken.cancel(CancellationReason.FailFast);
         }

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -5,10 +5,10 @@ import { DiagnosticCategory } from "#diagnostic";
 import { Environment } from "#environment";
 import { EventEmitter, type EventHandler } from "#events";
 import { OutputService, addsPackageStepText, diagnosticText, formattedText, helpText } from "#output";
+import { ExitCodeReporter } from "#reporters";
 import { SelectService } from "#select";
 import { StoreService } from "#store";
 import { CancellationReason, CancellationToken } from "#token";
-import { ExitCodeHandler } from "./ExitCodeHandler.js";
 
 export class Cli {
   #eventEmitter = new EventEmitter();
@@ -16,10 +16,10 @@ export class Cli {
   #storeService = new StoreService();
 
   async run(commandLineArguments: Array<string>, cancellationToken = new CancellationToken()): Promise<void> {
-    const exitCodeHandler = new ExitCodeHandler();
+    const exitCodeReporter = new ExitCodeReporter();
 
     this.#eventEmitter.addHandler((event) => {
-      exitCodeHandler.handleEvent(event);
+      exitCodeReporter.handleEvent(event);
     });
 
     const setupEventHandler: EventHandler = ([eventName, payload]) => {

--- a/source/cli/ExitCodeHandler.ts
+++ b/source/cli/ExitCodeHandler.ts
@@ -1,0 +1,41 @@
+import process from "node:process";
+import { DiagnosticCategory } from "#diagnostic";
+import type { Event } from "#events";
+
+export class ExitCodeHandler {
+  handleEvent([eventName, payload]: Event): void {
+    switch (eventName) {
+      case "run:start": {
+        // useful when tests are reran in the watch mode
+        this.resetCode();
+        break;
+      }
+
+      case "config:error":
+      case "select:error":
+      case "store:error":
+      case "project:error":
+      case "file:error":
+      case "test:error":
+      case "expect:error":
+      case "expect:fail": {
+        if (payload.diagnostics.some((diagnostic) => diagnostic.category === DiagnosticCategory.Error)) {
+          this.#setCode(1);
+        }
+
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  resetCode(): void {
+    this.#setCode(0);
+  }
+
+  #setCode(exitCode: number): void {
+    process.exitCode = exitCode;
+  }
+}

--- a/source/events/EventEmitter.ts
+++ b/source/events/EventEmitter.ts
@@ -49,6 +49,11 @@ export class EventEmitter {
     }
   }
 
+  removeHandler(handler: EventHandler): void {
+    this.#scopeHandlers.delete(handler);
+    EventEmitter.#handlers.delete(handler);
+  }
+
   removeHandlers(): void {
     for (const handler of this.#scopeHandlers) {
       EventEmitter.#handlers.delete(handler);

--- a/source/reporters/ExitCodeReporter.ts
+++ b/source/reporters/ExitCodeReporter.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import { DiagnosticCategory } from "#diagnostic";
 import type { Event } from "#events";
 
-export class ExitCodeHandler {
+export class ExitCodeReporter {
   handleEvent([eventName, payload]: Event): void {
     switch (eventName) {
       case "run:start": {

--- a/source/reporters/index.ts
+++ b/source/reporters/index.ts
@@ -1,3 +1,4 @@
+export { ExitCodeReporter } from "./ExitCodeReporter.js";
 export { Reporter } from "./Reporter.js";
 export { SummaryReporter } from "./SummaryReporter.js";
 export { ThoroughReporter } from "./ThoroughReporter.js";

--- a/tests/feature-watch.test.js
+++ b/tests/feature-watch.test.js
@@ -181,7 +181,7 @@ describe("watch", function () {
 
       const { exitCode } = await process.waitForExit();
 
-      assert.equal(exitCode, 0);
+      assert.equal(exitCode, 1);
     });
 
     test("when multiple test files are added", async function () {
@@ -209,7 +209,7 @@ describe("watch", function () {
 
       const { exitCode } = await process.waitForExit();
 
-      assert.equal(exitCode, 0);
+      assert.equal(exitCode, 1);
     });
 
     test("when single test file is changed", async function () {
@@ -236,7 +236,7 @@ describe("watch", function () {
 
       const { exitCode } = await process.waitForExit();
 
-      assert.equal(exitCode, 0);
+      assert.equal(exitCode, 1);
     });
 
     test("when multiple test files are changed", async function () {
@@ -264,7 +264,7 @@ describe("watch", function () {
 
       const { exitCode } = await process.waitForExit();
 
-      assert.equal(exitCode, 0);
+      assert.equal(exitCode, 1);
     });
 
     test("when single test file is renamed", async function () {
@@ -406,7 +406,7 @@ describe("watch", function () {
 
       const { exitCode } = await process.waitForExit();
 
-      assert.equal(exitCode, 0);
+      assert.equal(exitCode, 1);
     });
   });
 });


### PR DESCRIPTION
This change allows reporting the exit code of the last test rerun (in the watch mode). Also the exit code will be handled in a single place.