### PR TITLE
refactor(store)!: use `fetch()` global

### DIFF
--- a/source/store/ManifestWorker.ts
+++ b/source/store/ManifestWorker.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
-import https from "node:https";
 import { Diagnostic } from "#diagnostic";
 import { Environment } from "#environment";
 import { Path } from "#path";
@@ -44,51 +43,6 @@ export class ManifestWorker {
     return manifest;
   }
 
-  async #fetch() {
-    return new Promise<PackageMetadata>((resolve, reject) => {
-      const request = https.get(
-        new URL("typescript", this.#registryUrl),
-        {
-          // reference: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
-          headers: { accept: "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*" },
-          timeout: this.#timeout,
-        },
-        (response) => {
-          if (response.statusCode !== 200) {
-            reject(new Error(`Request failed with status code ${String(response.statusCode)}.`));
-
-            // consume response data to free up memory
-            response.resume();
-
-            return;
-          }
-
-          response.setEncoding("utf8");
-
-          let rawData = "";
-
-          response.on("data", (chunk) => {
-            rawData += chunk as string;
-          });
-
-          response.on("end", () => {
-            const packageMetadata = JSON.parse(rawData) as PackageMetadata;
-
-            resolve(packageMetadata);
-          });
-        },
-      );
-
-      request.on("error", (error) => {
-        reject(error);
-      });
-
-      request.on("timeout", () => {
-        request.destroy();
-      });
-    });
-  }
-
   isOutdated(manifest: Manifest, ageTolerance = 0): boolean {
     if (Date.now() - manifest.lastUpdated > 2 * 60 * 60 * 1000 /* 2 hours */ + ageTolerance * 1000) {
       return true;
@@ -108,7 +62,17 @@ export class ManifestWorker {
     let packageMetadata: PackageMetadata | undefined;
 
     try {
-      packageMetadata = await this.#fetch();
+      const response = await fetch(new URL("typescript", this.#registryUrl), {
+        // reference: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
+        headers: { accept: "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*" },
+        signal: AbortSignal.timeout(this.#timeout),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status code ${String(response.status)}.`);
+      }
+
+      packageMetadata = (await response.json()) as PackageMetadata;
     } catch (error) {
       if (options?.quite === true) {
         return;
@@ -116,7 +80,7 @@ export class ManifestWorker {
 
       const text = [`Failed to fetch metadata of the 'typescript' package from '${this.#registryUrl.toString()}'.`];
 
-      if (error instanceof Error && "code" in error && error.code === "ECONNRESET") {
+      if (error instanceof Error && error.name === "TimeoutError") {
         text.push(`Setup timeout of ${String(this.#timeout / 1000)}s was exceeded.`);
       } else {
         text.push("Might be there is an issue with the registry or the network connection.");

--- a/source/store/StoreDiagnosticText.ts
+++ b/source/store/StoreDiagnosticText.ts
@@ -1,0 +1,17 @@
+export class StoreDiagnosticText {
+  static failedToFetchMetadata(registryUrl: URL): string {
+    return `Failed to fetch metadata of the 'typescript' package from '${registryUrl.toString()}'.`;
+  }
+
+  static failedWithStatusCode(code: number): string {
+    return `Request failed with status code ${String(code)}.`;
+  }
+
+  static maybeNetworkConnectionIssue(): string {
+    return "Might be there is an issue with the registry or the network connection.";
+  }
+
+  static setupTimeoutExceeded(timeout: number): string {
+    return `Setup timeout of ${String(timeout / 1000)}s was exceeded.`;
+  }
+}

--- a/tests/config-configFile.test.js
+++ b/tests/config-configFile.test.js
@@ -69,7 +69,7 @@ describe("'tstyche.config.json' file", function () {
     const configText = `{
   /* test */
   "failFast": true,
-  /* test */ "target": ["rc"],
+  /* test */ "target": ["current"],
   // test
   "testFileMatch": /* test */ [
     "examples/**/*.test.ts" /* test */,
@@ -86,7 +86,7 @@ describe("'tstyche.config.json' file", function () {
 
     assert.matchObject(stdout, {
       failFast: true,
-      target: ["rc"],
+      target: ["current"],
       testFileMatch: ["examples/**/*.test.ts", "**/__typetests__/*.test.ts"],
     });
 

--- a/tests/config-install.test.js
+++ b/tests/config-install.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { normalizeOutput } from "./__utilities__/output.js";
@@ -19,6 +19,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("'--install' command line option", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });

--- a/tests/config-storePath.test.js
+++ b/tests/config-storePath.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { normalizeOutput } from "./__utilities__/output.js";
@@ -14,6 +14,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("'TSTYCHE_STORE_PATH' environment variable", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });

--- a/tests/config-target.test.js
+++ b/tests/config-target.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { normalizeOutput } from "./__utilities__/output.js";
@@ -25,6 +25,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("'--target' command line option", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });
@@ -143,6 +150,13 @@ describe("'--target' command line option", function () {
 });
 
 describe("'target' configuration file option", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });

--- a/tests/config-typescriptPath.test.js
+++ b/tests/config-typescriptPath.test.js
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { normalizeOutput } from "./__utilities__/output.js";
@@ -15,6 +15,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("'TSTYCHE_TYPESCRIPT_PATH' environment variable", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });

--- a/tests/config-update.test.js
+++ b/tests/config-update.test.js
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
@@ -8,6 +8,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("'--update' command line option", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });

--- a/tests/feature-store.test.js
+++ b/tests/feature-store.test.js
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
@@ -13,12 +13,19 @@ test("is string?", () => {
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
-describe("compiler module", function () {
+describe("store", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });
 
-  test("when module is not installed", async function () {
+  test("when compiler module is not installed", async function () {
     const compilerModuleUrl = new URL("./.store/5.2.2", fixtureUrl);
 
     await writeFixture(fixtureUrl, {
@@ -36,7 +43,7 @@ describe("compiler module", function () {
     assert.equal(exitCode, 0);
   });
 
-  test("when module is already installed", async function () {
+  test("when compiler module is already installed", async function () {
     const compilerModuleUrl = new URL("./.store/5.2.2", fixtureUrl);
 
     await writeFixture(fixtureUrl, {
@@ -54,12 +61,6 @@ describe("compiler module", function () {
     assert.match(stdout, /^uses TypeScript 5.2.2/);
     assert.equal(stderr, "");
     assert.equal(exitCode, 0);
-  });
-});
-
-describe("store manifest", function () {
-  afterEach(async function () {
-    await clearFixture(fixtureUrl);
   });
 
   test("when target is default, store manifest is not generated", async function () {

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -90,19 +90,17 @@ await spawnTyche(fixtureUrl, ["--update"]);
 
 const storeUrl = new URL("./.store/", fixtureUrl);
 
-const manifestText = await fs.readFile(new URL("./store-manifest.json", storeUrl), { encoding: "utf8" });
-const { resolutions } = /** @type {{ resolutions: Record<string, string> }} */ (JSON.parse(manifestText));
-
-const versionTags = Object.entries(resolutions)
-  .filter((resolution) => resolution[0].startsWith("5"))
-  .map((resolution) => resolution[1]);
-
 describe("TypeScript 4.x", function () {
   after(async function () {
     await clearFixture(fixtureUrl);
   });
 
   before(async function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+
     await writeFixture(fixtureUrl, {
       // 'moduleResolution: "node"' does not support self-referencing, but TSTyche needs 'import from "tstyche"' to be able to collect test nodes
       ["__typetests__/toBe.test.ts"]: `// @ts-expect-error\n${toBeTestText}`,
@@ -133,8 +131,13 @@ describe("TypeScript 4.x", function () {
   });
 });
 
-describe("TypeScript 5.x", function () {
+describe("TypeScript 5.x", async function () {
   before(async function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+
     await writeFixture(fixtureUrl, {
       ["__typetests__/toBe.test.ts"]: toBeTestText,
       ["__typetests__/toBeAssignableTo.test.ts"]: toBeAssignableToTestText,
@@ -148,6 +151,13 @@ describe("TypeScript 5.x", function () {
   after(async function () {
     await clearFixture(fixtureUrl);
   });
+
+  const manifestText = await fs.readFile(new URL("./store-manifest.json", storeUrl), { encoding: "utf8" });
+  const { resolutions } = /** @type {{ resolutions: Record<string, string> }} */ (JSON.parse(manifestText));
+
+  const versionTags = Object.entries(resolutions)
+    .filter((resolution) => resolution[0].startsWith("5"))
+    .map((resolution) => resolution[1]);
 
   const testCases = ["5.0.2", ...versionTags];
 

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
@@ -13,6 +13,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("store", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });

--- a/tests/validation-target.test.js
+++ b/tests/validation-target.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "mocha";
+import { afterEach, before, describe, test } from "mocha";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
@@ -13,6 +13,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 describe("'--target' command line option", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });
@@ -81,6 +88,13 @@ describe("'--target' command line option", function () {
 });
 
 describe("'target' configuration file option", function () {
+  before(function () {
+    if (process.versions.node.startsWith("16")) {
+      // store is not supported on Node.js 16
+      this.skip();
+    }
+  });
+
   afterEach(async function () {
     await clearFixture(fixtureUrl);
   });


### PR DESCRIPTION
It is time to use `fetch()` global (and to ship lees code).

This means that testing on specified versions of TypeScript will not be supported on Node.js 16. The rest works as expected, so I think that is fine.