### PR TITLE
fix(config): allow `./` in the beginning of `testFileMatch` patterns

### DIFF
--- a/source/config/OptionDiagnosticText.ts
+++ b/source/config/OptionDiagnosticText.ts
@@ -57,6 +57,13 @@ export class OptionDiagnosticText {
     }
   }
 
+  static testFileMatchCannotStartWith(segment: string): Array<string> {
+    return [
+      `A test file match pattern cannot start with '${segment}'.`,
+      "The test files are only collected within the 'rootPath' directory.",
+    ];
+  }
+
   static requiresValueType(optionName: string, optionBrand: OptionBrand, optionGroup: OptionGroup): string {
     optionName = OptionDiagnosticText.#optionName(optionName, optionGroup);
 

--- a/source/config/OptionValidator.ts
+++ b/source/config/OptionValidator.ts
@@ -51,6 +51,15 @@ export class OptionValidator {
         break;
       }
 
+      case "testFileMatch": {
+        for (const segment of ["/", "../"]) {
+          if (optionValue.startsWith(segment)) {
+            this.#onDiagnostic(Diagnostic.error(OptionDiagnosticText.testFileMatchCannotStartWith(segment), origin));
+          }
+        }
+        break;
+      }
+
       case "watch": {
         if (Environment.isCi) {
           this.#onDiagnostic(Diagnostic.error(OptionDiagnosticText.watchCannotBeEnabledInCiEnvironment(), origin));

--- a/source/select/GlobPattern.ts
+++ b/source/select/GlobPattern.ts
@@ -11,6 +11,10 @@ export class GlobPattern {
     let optionalSegmentCount = 0;
 
     for (const segment of segments) {
+      if (segment === ".") {
+        continue;
+      }
+
       if (segment === "**") {
         resultPattern += "(\\/(?!(node_modules)(\\/|$))[^./][^/]*)*?";
         continue;

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-start-with-dot-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-start-with-dot-stdout.snap.txt
@@ -1,0 +1,12 @@
+uses TypeScript <<version>>
+
+pass ./tests/isNumber.tst.ts
+  + is number?
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/validation-testFileMatch-cannot-start-with-0.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-cannot-start-with-0.snap.txt
@@ -1,0 +1,13 @@
+Error: A test file match pattern cannot start with '/'.
+
+The test files are only collected within the 'rootPath' directory.
+
+  1 | {
+  2 |   "testFileMatch": [
+> 3 |     "/feature"
+    |     ^
+  4 |   ]
+  5 | }
+
+      at ./tstyche.config.json:3:5
+

--- a/tests/__snapshots__/validation-testFileMatch-cannot-start-with-1.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-cannot-start-with-1.snap.txt
@@ -1,0 +1,13 @@
+Error: A test file match pattern cannot start with '../'.
+
+The test files are only collected within the 'rootPath' directory.
+
+  1 | {
+  2 |   "testFileMatch": [
+> 3 |     "../feature"
+    |     ^
+  4 |   ]
+  5 | }
+
+      at ./tstyche.config.json:3:5
+

--- a/tests/config-testFileMatch.test.js
+++ b/tests/config-testFileMatch.test.js
@@ -135,6 +135,27 @@ describe("'testFileMatch' configuration file option", function () {
       assert.equal(exitCode, 0);
     });
 
+    test("can start with './'", async function () {
+      const config = {
+        testFileMatch: ["./tests/*.ts"],
+      };
+
+      await writeFixture(fixtureUrl, {
+        ["tests/isNumber.tst.ts"]: isNumberTestText,
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+      });
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+      await assert.matchSnapshot(normalizeOutput(stdout), {
+        fileName: `${testFileName}-specified-patterns-start-with-dot-stdout`,
+        testFileUrl: import.meta.url,
+      });
+
+      assert.equal(stderr, "");
+      assert.equal(exitCode, 0);
+    });
+
     test("can select the '.' paths", async function () {
       const config = {
         testFileMatch: ["**/.generated/*.tst.*"],

--- a/tests/validation-testFileMatch.test.js
+++ b/tests/validation-testFileMatch.test.js
@@ -17,6 +17,37 @@ describe("'testFileMatch' configuration file option", function () {
     await clearFixture(fixtureUrl);
   });
 
+  const testCases = [
+    {
+      segment: "/",
+      testCase: "when a pattern starts with '/'",
+    },
+    {
+      segment: "../",
+      testCase: "when a pattern starts with '../'",
+    },
+  ];
+
+  testCases.forEach(({ segment, testCase }, index) => {
+    test(testCase, async function () {
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+        ["tstyche.config.json"]: JSON.stringify({ testFileMatch: [`${segment}feature`] }, null, 2),
+      });
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+      assert.equal(stdout, "");
+
+      await assert.matchSnapshot(stderr, {
+        fileName: `${testFileName}-cannot-start-with-${index}`,
+        testFileUrl: import.meta.url,
+      });
+
+      assert.equal(exitCode, 1);
+    });
+  });
+
   test("when option value is not a list", async function () {
     const config = {
       testFileMatch: "feature",


### PR DESCRIPTION
It must be allowed to have `./` in the beginning of `testFileMatch` patterns.