### PR TITLE
fix(runner): show deprecation warnings for each test file

### DIFF
--- a/source/handlers/RuntimeReporter.ts
+++ b/source/handlers/RuntimeReporter.ts
@@ -125,6 +125,7 @@ export class RuntimeReporter implements EventHandler {
           this.#hasReportedError = true;
         }
 
+        this.#seenDeprecations.clear();
         this.#fileView.reset();
         break;
       }


### PR DESCRIPTION
It sounds like a better idea to show deprecation warnings for each file. One can instantly see how many files must be updated. That’s essentially better in the watch mode.