### PR TITLE
feat(watch): exit the watch mode when `q` or `Q` is pressed

### DIFF
--- a/source/watch/WatchService.ts
+++ b/source/watch/WatchService.ts
@@ -38,6 +38,8 @@ export class WatchService {
         case "\u0003" /* Ctrl-C */:
         case "\u0004" /* Ctrl-D */:
         case "\u001B" /* Escape */:
+        case "\u0051" /* Latin capital letter Q */:
+        case "\u0071" /* Latin small letter Q */:
         case "\u0058" /* Latin capital letter X */:
         case "\u0078" /* Latin small letter X */: {
           this.close();

--- a/tests/feature-watch.test.js
+++ b/tests/feature-watch.test.js
@@ -92,6 +92,14 @@ describe("watch", function () {
         testCase: "exits watch mode, when 'Escape' is pressed",
       },
       {
+        key: "q",
+        testCase: "exits watch mode, when 'q' is pressed",
+      },
+      {
+        key: "Q",
+        testCase: "exits watch mode, when 'Q' is pressed",
+      },
+      {
         key: "x",
         testCase: "exits watch mode, when 'x' is pressed",
       },


### PR DESCRIPTION
Reference: https://github.com/FloEdelmann/vue-ts-types/pull/574#issuecomment-2149820371

It sounds useful to add `q` as one more alias to exit the watch mode.