### PR TITLE
refactor(output, scribbler): use function components

### DIFF
--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -2,87 +2,81 @@ import type { DiagnosticOrigin } from "#diagnostic";
 import { Path } from "#path";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 
-export class CodeSpanText implements ScribblerJsx.ElementClass {
-  props: DiagnosticOrigin;
+export function CodeSpanText(diagnosticOrigin: DiagnosticOrigin) {
+  const lastLineInFile = diagnosticOrigin.sourceFile.getLineAndCharacterOfPosition(
+    diagnosticOrigin.sourceFile.text.length,
+  ).line;
 
-  constructor(props: DiagnosticOrigin) {
-    this.props = props;
-  }
+  const { character: markedCharacter, line: markedLine } = diagnosticOrigin.sourceFile.getLineAndCharacterOfPosition(
+    diagnosticOrigin.start,
+  );
+  const firstLine = Math.max(markedLine - 2, 0);
+  const lastLine = Math.min(firstLine + 5, lastLineInFile);
+  const lineNumberMaxWidth = String(lastLine + 1).length;
 
-  render(): ScribblerJsx.Element {
-    const lastLineInFile = this.props.sourceFile.getLineAndCharacterOfPosition(this.props.sourceFile.text.length).line;
+  const codeSpan: Array<ScribblerJsx.Element> = [];
 
-    const { character: markedCharacter, line: markedLine } = this.props.sourceFile.getLineAndCharacterOfPosition(
-      this.props.start,
-    );
-    const firstLine = Math.max(markedLine - 2, 0);
-    const lastLine = Math.min(firstLine + 5, lastLineInFile);
-    const lineNumberMaxWidth = String(lastLine + 1).length;
+  for (let index = firstLine; index <= lastLine; index++) {
+    const lineStart = diagnosticOrigin.sourceFile.getPositionOfLineAndCharacter(index, 0);
+    const lineEnd =
+      index === lastLineInFile
+        ? diagnosticOrigin.sourceFile.text.length
+        : diagnosticOrigin.sourceFile.getPositionOfLineAndCharacter(index + 1, 0);
 
-    const codeSpan: Array<ScribblerJsx.Element> = [];
+    const lineNumberText = String(index + 1);
+    const lineText = diagnosticOrigin.sourceFile.text.slice(lineStart, lineEnd).trimEnd().replace(/\t/g, " ");
 
-    for (let index = firstLine; index <= lastLine; index++) {
-      const lineStart = this.props.sourceFile.getPositionOfLineAndCharacter(index, 0);
-      const lineEnd =
-        index === lastLineInFile
-          ? this.props.sourceFile.text.length
-          : this.props.sourceFile.getPositionOfLineAndCharacter(index + 1, 0);
-
-      const lineNumberText = String(index + 1);
-      const lineText = this.props.sourceFile.text.slice(lineStart, lineEnd).trimEnd().replace(/\t/g, " ");
-
-      if (index === markedLine) {
-        codeSpan.push(
-          <Line>
-            <Text color={Color.Red}>{">"}</Text>
-            <Text> </Text>
-            {lineNumberText.padStart(lineNumberMaxWidth)}
-            <Text> </Text>
-            <Text color={Color.Gray}>|</Text> {lineText}
-          </Line>,
-          <Line>
-            {" ".repeat(lineNumberMaxWidth + 3)}
-            <Text color={Color.Gray}>|</Text>
-            {" ".repeat(markedCharacter + 1)}
-            <Text color={Color.Red}>{"^"}</Text>
-          </Line>,
-        );
-      } else {
-        codeSpan.push(
-          <Line>
-            {" ".repeat(2)}
-            <Text color={Color.Gray}>
-              {lineNumberText.padStart(lineNumberMaxWidth)} | {lineText || ""}
-            </Text>
-          </Line>,
-        );
-      }
+    if (index === markedLine) {
+      codeSpan.push(
+        <Line>
+          <Text color={Color.Red}>{">"}</Text>
+          <Text> </Text>
+          {lineNumberText.padStart(lineNumberMaxWidth)}
+          <Text> </Text>
+          <Text color={Color.Gray}>|</Text> {lineText}
+        </Line>,
+        <Line>
+          {" ".repeat(lineNumberMaxWidth + 3)}
+          <Text color={Color.Gray}>|</Text>
+          {" ".repeat(markedCharacter + 1)}
+          <Text color={Color.Red}>{"^"}</Text>
+        </Line>,
+      );
+    } else {
+      codeSpan.push(
+        <Line>
+          {" ".repeat(2)}
+          <Text color={Color.Gray}>
+            {lineNumberText.padStart(lineNumberMaxWidth)} | {lineText || ""}
+          </Text>
+        </Line>,
+      );
     }
-
-    const breadcrumbs = this.props.breadcrumbs?.flatMap((ancestor) => [
-      <Text color={Color.Gray}>{" ❭ "}</Text>,
-      <Text>{ancestor}</Text>,
-    ]);
-
-    const location = (
-      <Line>
-        {" ".repeat(lineNumberMaxWidth + 5)}
-        <Text color={Color.Gray}>at</Text>
-        <Text> </Text>
-        <Text color={Color.Cyan}>{Path.relative("", this.props.sourceFile.fileName)}</Text>
-        <Text color={Color.Gray}>
-          :{String(markedLine + 1)}:{String(markedCharacter + 1)}
-        </Text>
-        {breadcrumbs}
-      </Line>
-    );
-
-    return (
-      <Text>
-        {codeSpan}
-        <Line />
-        {location}
-      </Text>
-    );
   }
+
+  const breadcrumbs = diagnosticOrigin.breadcrumbs?.flatMap((ancestor) => [
+    <Text color={Color.Gray}>{" ❭ "}</Text>,
+    <Text>{ancestor}</Text>,
+  ]);
+
+  const location = (
+    <Line>
+      {" ".repeat(lineNumberMaxWidth + 5)}
+      <Text color={Color.Gray}>at</Text>
+      <Text> </Text>
+      <Text color={Color.Cyan}>{Path.relative("", diagnosticOrigin.sourceFile.fileName)}</Text>
+      <Text color={Color.Gray}>
+        :{String(markedLine + 1)}:{String(markedCharacter + 1)}
+      </Text>
+      {breadcrumbs}
+    </Line>
+  );
+
+  return (
+    <Text>
+      {codeSpan}
+      <Line />
+      {location}
+    </Text>
+  );
 }

--- a/source/output/diagnosticText.tsx
+++ b/source/output/diagnosticText.tsx
@@ -6,51 +6,38 @@ interface DiagnosticTextProps {
   diagnostic: Diagnostic;
 }
 
-class DiagnosticText implements ScribblerJsx.ElementClass {
-  props: DiagnosticTextProps;
+function DiagnosticText({ diagnostic }: DiagnosticTextProps) {
+  const code = typeof diagnostic.code === "string" ? <Text color={Color.Gray}> {diagnostic.code}</Text> : undefined;
 
-  constructor(props: DiagnosticTextProps) {
-    this.props = props;
-  }
+  const text = Array.isArray(diagnostic.text) ? diagnostic.text : [diagnostic.text];
 
-  render(): ScribblerJsx.Element {
-    const code =
-      typeof this.props.diagnostic.code === "string" ? (
-        <Text color={Color.Gray}> {this.props.diagnostic.code}</Text>
-      ) : undefined;
+  const message = text.map((text, index) => (
+    <Text>
+      {index === 1 ? <Line /> : undefined}
+      <Line>
+        {text}
+        {code}
+      </Line>
+    </Text>
+  ));
 
-    const text = Array.isArray(this.props.diagnostic.text) ? this.props.diagnostic.text : [this.props.diagnostic.text];
+  const related = diagnostic.related?.map((relatedDiagnostic) => <DiagnosticText diagnostic={relatedDiagnostic} />);
 
-    const message = text.map((text, index) => (
-      <Text>
-        {index === 1 ? <Line /> : undefined}
-        <Line>
-          {text}
-          {code}
-        </Line>
-      </Text>
-    ));
+  const codeSpan = diagnostic.origin ? (
+    <Text>
+      <Line />
+      <CodeSpanText {...diagnostic.origin} />
+    </Text>
+  ) : undefined;
 
-    const related = this.props.diagnostic.related?.map((relatedDiagnostic) => (
-      <DiagnosticText diagnostic={relatedDiagnostic} />
-    ));
-
-    const codeSpan = this.props.diagnostic.origin ? (
-      <Text>
-        <Line />
-        <CodeSpanText {...this.props.diagnostic.origin} />
-      </Text>
-    ) : undefined;
-
-    return (
-      <Text>
-        {message}
-        {codeSpan}
-        <Line />
-        <Text indent={2}>{related}</Text>
-      </Text>
-    );
-  }
+  return (
+    <Text>
+      {message}
+      {codeSpan}
+      <Line />
+      <Text indent={2}>{related}</Text>
+    </Text>
+  );
 }
 
 export function diagnosticText(diagnostic: Diagnostic): ScribblerJsx.Element {

--- a/source/output/fileStatusText.tsx
+++ b/source/output/fileStatusText.tsx
@@ -7,27 +7,19 @@ interface FileNameTextProps {
   filePath: string;
 }
 
-class FileNameText implements ScribblerJsx.ElementClass {
-  props: FileNameTextProps;
+function FileNameText({ filePath }: FileNameTextProps) {
+  const relativePath = Path.relative("", filePath);
+  const lastPathSeparator = relativePath.lastIndexOf("/");
 
-  constructor(props: FileNameTextProps) {
-    this.props = props;
-  }
+  const directoryNameText = relativePath.slice(0, lastPathSeparator + 1);
+  const fileNameText = relativePath.slice(lastPathSeparator + 1);
 
-  render(): ScribblerJsx.Element {
-    const relativePath = Path.relative("", this.props.filePath);
-    const lastPathSeparator = relativePath.lastIndexOf("/");
-
-    const directoryNameText = relativePath.slice(0, lastPathSeparator + 1);
-    const fileNameText = relativePath.slice(lastPathSeparator + 1);
-
-    return (
-      <Text>
-        <Text color={Color.Gray}>{directoryNameText}</Text>
-        {fileNameText}
-      </Text>
-    );
-  }
+  return (
+    <Text>
+      <Text color={Color.Gray}>{directoryNameText}</Text>
+      {fileNameText}
+    </Text>
+  );
 }
 
 export function fileStatusText(status: FileResultStatus, testFile: TestFile): ScribblerJsx.Element {

--- a/source/output/formattedText.tsx
+++ b/source/output/formattedText.tsx
@@ -1,25 +1,15 @@
 import { Line, type ScribblerJsx } from "#scribbler";
 
-interface JsonTextProps {
-  input: Array<string> | Record<string, unknown>;
-}
-
-export class JsonText implements ScribblerJsx.ElementClass {
-  props: JsonTextProps;
-
-  constructor(props: JsonTextProps) {
-    this.props = props;
+export function formattedText(input: string | Array<string> | Record<string, unknown>): ScribblerJsx.Element {
+  if (typeof input === "string") {
+    return <Line>{input}</Line>;
   }
 
-  render(): ScribblerJsx.Element {
-    return <Line>{JSON.stringify(this.#sortObject(this.props.input), null, 2)}</Line>;
+  if (Array.isArray(input)) {
+    return <Line>{JSON.stringify(input, null, 2)}</Line>;
   }
 
-  #sortObject(target: Array<string> | Record<string, unknown>) {
-    if (Array.isArray(target)) {
-      return target;
-    }
-
+  function sortObject(target: Record<string, unknown>) {
     return Object.keys(target)
       .sort()
       .reduce<Record<string, unknown>>((result, key) => {
@@ -28,12 +18,6 @@ export class JsonText implements ScribblerJsx.ElementClass {
         return result;
       }, {});
   }
-}
 
-export function formattedText(input: string | Array<string> | Record<string, unknown>): ScribblerJsx.Element {
-  if (typeof input === "string") {
-    return <Line>{input}</Line>;
-  }
-
-  return <JsonText input={input} />;
+  return <Line>{JSON.stringify(sortObject(input), null, 2)}</Line>;
 }

--- a/source/output/helpText.tsx
+++ b/source/output/helpText.tsx
@@ -8,50 +8,28 @@ const usageExamples: Array<[commandText: string, descriptionText: string]> = [
 ];
 
 interface HintTextProps {
-  children: ScribblerJsx.Element;
+  children: ScribblerJsx.Element | string;
 }
 
-class HintText implements ScribblerJsx.ElementClass {
-  props: HintTextProps;
-
-  constructor(props: HintTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return (
-      <Text indent={1} color={Color.Gray}>
-        {this.props.children}
-      </Text>
-    );
-  }
+function HintText({ children }: HintTextProps) {
+  return (
+    <Text indent={1} color={Color.Gray}>
+      {children}
+    </Text>
+  );
 }
 
 interface HelpHeaderTextProps {
   tstycheVersion: string;
 }
 
-class HelpHeaderText implements ScribblerJsx.ElementClass {
-  props: HelpHeaderTextProps;
-
-  constructor(props: HelpHeaderTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    const hint = (
-      <HintText>
-        <Text>{this.props.tstycheVersion}</Text>
-      </HintText>
-    );
-
-    return (
-      <Line>
-        <Text>The TSTyche Type Test Runner</Text>
-        {hint}
-      </Line>
-    );
-  }
+function HelpHeaderText({ tstycheVersion }: HelpHeaderTextProps) {
+  return (
+    <Line>
+      The TSTyche Type Test Runner
+      <HintText>{tstycheVersion}</HintText>
+    </Line>
+  );
 }
 
 interface CommandTextProps {
@@ -59,142 +37,98 @@ interface CommandTextProps {
   text: string | ScribblerJsx.Element;
 }
 
-class CommandText implements ScribblerJsx.ElementClass {
-  props: CommandTextProps;
+function CommandText({ hint, text }: CommandTextProps) {
+  let hintText: ScribblerJsx.Element | undefined;
 
-  constructor(props: CommandTextProps) {
-    this.props = props;
+  if (hint != null) {
+    hintText = <HintText>{hint}</HintText>;
   }
 
-  render(): ScribblerJsx.Element {
-    let hint: ScribblerJsx.Element | undefined;
-
-    if (this.props.hint != null) {
-      hint = <HintText>{this.props.hint}</HintText>;
-    }
-
-    return (
-      <Line indent={1}>
-        <Text color={Color.Blue}>{this.props.text}</Text>
-        {hint}
-      </Line>
-    );
-  }
+  return (
+    <Line indent={1}>
+      <Text color={Color.Blue}>{text}</Text>
+      {hintText}
+    </Line>
+  );
 }
 
 interface OptionDescriptionTextProps {
   text: string;
 }
 
-class OptionDescriptionText implements ScribblerJsx.ElementClass {
-  props: OptionDescriptionTextProps;
-
-  constructor(props: OptionDescriptionTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return <Line indent={1}>{this.props.text}</Line>;
-  }
+function OptionDescriptionText({ text }: OptionDescriptionTextProps) {
+  return <Line indent={1}>{text}</Line>;
 }
 
-class CommandLineUsageText implements ScribblerJsx.ElementClass {
-  render(): ScribblerJsx.Element {
-    const usageText = usageExamples.map(([commandText, descriptionText]) => (
-      <Text>
-        <CommandText text={commandText} />
-        <OptionDescriptionText text={descriptionText} />
-        <Line />
-      </Text>
-    ));
+function CommandLineUsageText() {
+  const usageText = usageExamples.map(([commandText, descriptionText]) => (
+    <Text>
+      <CommandText text={commandText} />
+      <OptionDescriptionText text={descriptionText} />
+      <Line />
+    </Text>
+  ));
 
-    return <Text>{usageText}</Text>;
-  }
+  return <Text>{usageText}</Text>;
 }
 
 interface CommandLineOptionNameTextProps {
   text: string;
 }
 
-class CommandLineOptionNameText implements ScribblerJsx.ElementClass {
-  props: CommandLineOptionNameTextProps;
-
-  constructor(props: CommandLineOptionNameTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return <Text>--{this.props.text}</Text>;
-  }
+function CommandLineOptionNameText({ text }: CommandLineOptionNameTextProps) {
+  return <Text>--{text}</Text>;
 }
 
 interface CommandLineOptionHintTextProps {
   definition: OptionDefinition;
 }
 
-class CommandLineOptionHintText implements ScribblerJsx.ElementClass {
-  props: CommandLineOptionHintTextProps;
-
-  constructor(props: CommandLineOptionHintTextProps) {
-    this.props = props;
+function CommandLineOptionHintText({ definition }: CommandLineOptionHintTextProps) {
+  if (definition.brand === OptionBrand.List) {
+    return (
+      <Text>
+        {definition.brand} of {definition.items.brand}s
+      </Text>
+    );
   }
 
-  render(): ScribblerJsx.Element {
-    if (this.props.definition.brand === OptionBrand.List) {
-      return (
-        <Text>
-          {this.props.definition.brand} of {this.props.definition.items.brand}s
-        </Text>
-      );
-    }
-
-    return <Text>{this.props.definition.brand}</Text>;
-  }
+  return <Text>{definition.brand}</Text>;
 }
 
 interface CommandLineOptionsTextProps {
   optionDefinitions: Map<string, OptionDefinition>;
 }
 
-class CommandLineOptionsText implements ScribblerJsx.ElementClass {
-  props: CommandLineOptionsTextProps;
+function CommandLineOptionsText({ optionDefinitions }: CommandLineOptionsTextProps) {
+  const definitions = [...optionDefinitions.values()];
+  const optionsText = definitions.map((definition) => {
+    let hint: ScribblerJsx.Element | undefined;
 
-  constructor(props: CommandLineOptionsTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    const definitions = [...this.props.optionDefinitions.values()];
-    const optionsText = definitions.map((definition) => {
-      let hint: ScribblerJsx.Element | undefined;
-
-      if (definition.brand !== OptionBrand.BareTrue) {
-        hint = <CommandLineOptionHintText definition={definition} />;
-      }
-
-      return (
-        <Text>
-          <CommandText text={<CommandLineOptionNameText text={definition.name} />} hint={hint} />
-          <OptionDescriptionText text={definition.description} />
-          <Line />
-        </Text>
-      );
-    });
+    if (definition.brand !== OptionBrand.BareTrue) {
+      hint = <CommandLineOptionHintText definition={definition} />;
+    }
 
     return (
       <Text>
-        <Line>Command Line Options</Line>
+        <CommandText text={<CommandLineOptionNameText text={definition.name} />} hint={hint} />
+        <OptionDescriptionText text={definition.description} />
         <Line />
-        {optionsText}
       </Text>
     );
-  }
+  });
+
+  return (
+    <Text>
+      <Line>Command Line Options</Line>
+      <Line />
+      {optionsText}
+    </Text>
+  );
 }
 
-class HelpFooterText implements ScribblerJsx.ElementClass {
-  render(): ScribblerJsx.Element {
-    return <Line>To learn more, visit https://tstyche.org</Line>;
-  }
+function HelpFooterText() {
+  return <Line>To learn more, visit https://tstyche.org</Line>;
 }
 
 export function helpText(

--- a/source/output/summaryText.tsx
+++ b/source/output/summaryText.tsx
@@ -6,21 +6,13 @@ interface RowTextProps {
   text: ScribblerJsx.Element;
 }
 
-class RowText implements ScribblerJsx.ElementClass {
-  props: RowTextProps;
-
-  constructor(props: RowTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return (
-      <Line>
-        {`${this.props.label}:`.padEnd(12)}
-        {this.props.text}
-      </Line>
-    );
-  }
+function RowText({ label, text }: RowTextProps) {
+  return (
+    <Line>
+      {`${label}:`.padEnd(12)}
+      {text}
+    </Line>
+  );
 }
 
 interface CountTextProps {
@@ -31,108 +23,82 @@ interface CountTextProps {
   total: number;
 }
 
-class CountText implements ScribblerJsx.ElementClass {
-  props: CountTextProps;
-
-  constructor(props: CountTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return (
-      <Text>
-        {this.props.failed > 0 ? (
-          <Text>
-            <Text color={Color.Red}>{String(this.props.failed)} failed</Text>
-            <Text>{", "}</Text>
-          </Text>
-        ) : undefined}
-        {this.props.skipped > 0 ? (
-          <Text>
-            <Text color={Color.Yellow}>{String(this.props.skipped)} skipped</Text>
-            <Text>{", "}</Text>
-          </Text>
-        ) : undefined}
-        {this.props.todo > 0 ? (
-          <Text>
-            <Text color={Color.Magenta}>{String(this.props.todo)} todo</Text>
-            <Text>{", "}</Text>
-          </Text>
-        ) : undefined}
-        {this.props.passed > 0 ? (
-          <Text>
-            <Text color={Color.Green}>{String(this.props.passed)} passed</Text>
-            <Text>{", "}</Text>
-          </Text>
-        ) : undefined}
+function CountText({ failed, passed, skipped, todo, total }: CountTextProps) {
+  return (
+    <Text>
+      {failed > 0 ? (
         <Text>
-          {String(this.props.total)}
-          <Text>{" total"}</Text>
+          <Text color={Color.Red}>{String(failed)} failed</Text>
+          <Text>{", "}</Text>
         </Text>
+      ) : undefined}
+      {skipped > 0 ? (
+        <Text>
+          <Text color={Color.Yellow}>{String(skipped)} skipped</Text>
+          <Text>{", "}</Text>
+        </Text>
+      ) : undefined}
+      {todo > 0 ? (
+        <Text>
+          <Text color={Color.Magenta}>{String(todo)} todo</Text>
+          <Text>{", "}</Text>
+        </Text>
+      ) : undefined}
+      {passed > 0 ? (
+        <Text>
+          <Text color={Color.Green}>{String(passed)} passed</Text>
+          <Text>{", "}</Text>
+        </Text>
+      ) : undefined}
+      <Text>
+        {String(total)}
+        <Text>{" total"}</Text>
       </Text>
-    );
-  }
+    </Text>
+  );
 }
 
 interface DurationTextProps {
   duration: number;
 }
 
-class DurationText implements ScribblerJsx.ElementClass {
-  props: DurationTextProps;
+function DurationText({ duration }: DurationTextProps) {
+  const minutes = Math.floor(duration / 60);
+  const seconds = duration % 60;
 
-  constructor(props: DurationTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    const duration = this.props.duration / 1000;
-
-    const minutes = Math.floor(duration / 60);
-    const seconds = duration % 60;
-
-    return (
-      <Text>
-        {minutes > 0 ? `${String(minutes)}m ` : undefined}
-        {`${String(Math.round(seconds * 10) / 10)}s`}
-      </Text>
-    );
-  }
+  return (
+    <Text>
+      {minutes > 0 ? `${String(minutes)}m ` : undefined}
+      {`${String(Math.round(seconds * 10) / 10)}s`}
+    </Text>
+  );
 }
 
 interface MatchTextProps {
   text: Array<string> | string;
 }
 
-class MatchText implements ScribblerJsx.ElementClass {
-  props: MatchTextProps;
-
-  constructor(props: MatchTextProps) {
-    this.props = props;
+function MatchText({ text }: MatchTextProps) {
+  if (typeof text === "string") {
+    return <Text>'{text}'</Text>;
   }
 
-  render(): ScribblerJsx.Element {
-    if (typeof this.props.text === "string") {
-      return <Text>'{this.props.text}'</Text>;
-    }
-
-    if (this.props.text.length <= 1) {
-      return <Text>'{...this.props.text}'</Text>;
-    }
-
-    const lastItem = this.props.text.pop();
-
-    return (
-      <Text>
-        {this.props.text.map((match, index, list) => (
-          <Text>
-            '{match}'{index === list.length - 1 ? <Text> </Text> : <Text color={Color.Gray}>{", "}</Text>}
-          </Text>
-        ))}
-        <Text color={Color.Gray}>or</Text> '{lastItem}'
-      </Text>
-    );
+  if (text.length <= 1) {
+    return <Text>'{...text}'</Text>;
   }
+
+  const lastItem = text.pop();
+
+  return (
+    <Text>
+      {text.map((match, index, list) => (
+        <Text>
+          '{match}'{index === list.length - 1 ? <Text> </Text> : <Text color={Color.Gray}>{", "}</Text>}
+        </Text>
+      ))}
+      <Text color={Color.Gray}>or</Text> '{lastItem}'
+    </Text>
+  );
 }
 
 interface RanFilesTextProps {
@@ -141,59 +107,51 @@ interface RanFilesTextProps {
   skipMatch: string | undefined;
 }
 
-class RanFilesText implements ScribblerJsx.ElementClass {
-  props: RanFilesTextProps;
+function RanFilesText({ onlyMatch, pathMatch, skipMatch }: RanFilesTextProps) {
+  const testNameMatchText: Array<ScribblerJsx.Element> = [];
 
-  constructor(props: RanFilesTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    const testNameMatchText: Array<ScribblerJsx.Element> = [];
-
-    if (this.props.onlyMatch != null) {
-      testNameMatchText.push(
-        <Text>
-          <Text color={Color.Gray}>{"matching "}</Text>
-          <MatchText text={this.props.onlyMatch} />
-        </Text>,
-      );
-    }
-
-    if (this.props.skipMatch != null) {
-      testNameMatchText.push(
-        <Text>
-          {this.props.onlyMatch == null ? undefined : <Text color={Color.Gray}>{" and "}</Text>}
-          <Text color={Color.Gray}>{"not matching "}</Text>
-          <MatchText text={this.props.skipMatch} />
-        </Text>,
-      );
-    }
-
-    let pathMatchText: ScribblerJsx.Element | undefined;
-
-    if (this.props.pathMatch.length > 0) {
-      pathMatchText = (
-        <Text>
-          <Text color={Color.Gray}>{"test files matching "}</Text>
-          <MatchText text={this.props.pathMatch} />
-          <Text color={Color.Gray}>.</Text>
-        </Text>
-      );
-    } else {
-      pathMatchText = <Text color={Color.Gray}>all test files.</Text>;
-    }
-
-    return (
-      <Line>
-        <Text color={Color.Gray}>{"Ran "}</Text>
-        {testNameMatchText.length > 0 ? <Text color={Color.Gray}>{"tests "}</Text> : undefined}
-        {testNameMatchText}
-        {testNameMatchText.length > 0 ? <Text color={Color.Gray}>{" in "}</Text> : undefined}
-        {pathMatchText}
-      </Line>
+  if (onlyMatch != null) {
+    testNameMatchText.push(
+      <Text>
+        <Text color={Color.Gray}>{"matching "}</Text>
+        <MatchText text={onlyMatch} />
+      </Text>,
     );
   }
+
+  if (skipMatch != null) {
+    testNameMatchText.push(
+      <Text>
+        {onlyMatch == null ? undefined : <Text color={Color.Gray}>{" and "}</Text>}
+        <Text color={Color.Gray}>{"not matching "}</Text>
+        <MatchText text={skipMatch} />
+      </Text>,
+    );
+  }
+
+  let pathMatchText: ScribblerJsx.Element | undefined;
+
+  if (pathMatch.length > 0) {
+    pathMatchText = (
+      <Text>
+        <Text color={Color.Gray}>{"test files matching "}</Text>
+        <MatchText text={pathMatch} />
+        <Text color={Color.Gray}>.</Text>
+      </Text>
+    );
+  } else {
+    pathMatchText = <Text color={Color.Gray}>all test files.</Text>;
+  }
+
+  return (
+    <Line>
+      <Text color={Color.Gray}>{"Ran "}</Text>
+      {testNameMatchText.length > 0 ? <Text color={Color.Gray}>{"tests "}</Text> : undefined}
+      {testNameMatchText}
+      {testNameMatchText.length > 0 ? <Text color={Color.Gray}>{" in "}</Text> : undefined}
+      {pathMatchText}
+    </Line>
+  );
 }
 
 export function summaryText({
@@ -281,7 +239,7 @@ export function summaryText({
       {fileCountText}
       {testCount.total > 0 ? testCountText : undefined}
       {expectCount.total > 0 ? assertionCountText : undefined}
-      <RowText label="Duration" text={<DurationText duration={duration} />} />
+      <RowText label="Duration" text={<DurationText duration={duration / 1000} />} />
       <Line />
       <RanFilesText onlyMatch={onlyMatch} pathMatch={pathMatch} skipMatch={skipMatch} />
     </Text>

--- a/source/output/testNameText.tsx
+++ b/source/output/testNameText.tsx
@@ -4,24 +4,16 @@ interface StatusTextProps {
   status: "fail" | "pass" | "skip" | "todo";
 }
 
-class StatusText implements ScribblerJsx.ElementClass {
-  props: StatusTextProps;
-
-  constructor(props: StatusTextProps) {
-    this.props = props;
-  }
-
-  render() {
-    switch (this.props.status) {
-      case "fail":
-        return <Text color={Color.Red}>×</Text>;
-      case "pass":
-        return <Text color={Color.Green}>+</Text>;
-      case "skip":
-        return <Text color={Color.Yellow}>- skip</Text>;
-      case "todo":
-        return <Text color={Color.Magenta}>- todo</Text>;
-    }
+function StatusText({ status }: StatusTextProps) {
+  switch (status) {
+    case "fail":
+      return <Text color={Color.Red}>×</Text>;
+    case "pass":
+      return <Text color={Color.Green}>+</Text>;
+    case "skip":
+      return <Text color={Color.Yellow}>- skip</Text>;
+    case "todo":
+      return <Text color={Color.Magenta}>- todo</Text>;
   }
 }
 

--- a/source/output/usesCompilerStepText.tsx
+++ b/source/output/usesCompilerStepText.tsx
@@ -1,27 +1,6 @@
 import { Path } from "#path";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 
-interface ProjectNameTextProps {
-  filePath: string;
-}
-
-class ProjectNameText implements ScribblerJsx.ElementClass {
-  props: ProjectNameTextProps;
-
-  constructor(props: ProjectNameTextProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return (
-      <Text color={Color.Gray}>
-        {" with "}
-        {Path.relative("", this.props.filePath)}
-      </Text>
-    );
-  }
-}
-
 export function usesCompilerStepText(
   compilerVersion: string,
   tsconfigFilePath: string | undefined,
@@ -30,7 +9,12 @@ export function usesCompilerStepText(
   let projectPathText: ScribblerJsx.Element | undefined;
 
   if (tsconfigFilePath != null) {
-    projectPathText = <ProjectNameText filePath={tsconfigFilePath} />;
+    projectPathText = (
+      <Text color={Color.Gray}>
+        {" with "}
+        {Path.relative("", tsconfigFilePath)}
+      </Text>
+    );
   }
 
   return (

--- a/source/scribbler/Line.tsx
+++ b/source/scribbler/Line.tsx
@@ -1,26 +1,18 @@
 import { Text } from "./Text.js";
 import type { Color } from "./enums.js";
-import type { ScribblerJsx } from "./types.js";
+import type { ScribblerNode } from "./types.js";
 
 interface LineProps {
-  children?: ScribblerJsx.ElementChildrenAttribute["children"];
+  children?: ScribblerNode;
   color?: Color;
   indent?: number;
 }
 
-export class Line implements ScribblerJsx.ElementClass {
-  props: LineProps;
-
-  constructor(props: LineProps) {
-    this.props = props;
-  }
-
-  render(): ScribblerJsx.Element {
-    return (
-      <Text color={this.props.color} indent={this.props.indent}>
-        {this.props.children}
-        <newLine />
-      </Text>
-    );
-  }
+export function Line({ children, color, indent }: LineProps) {
+  return (
+    <Text color={color} indent={indent}>
+      {children}
+      <newLine />
+    </Text>
+  );
 }

--- a/source/scribbler/Scribbler.ts
+++ b/source/scribbler/Scribbler.ts
@@ -1,4 +1,4 @@
-import type { ElementChildren, ScribblerJsx } from "./types.js";
+import type { ScribblerJsx, ScribblerNode } from "./types.js";
 
 export interface ScribblerOptions {
   newLine?: string;
@@ -30,9 +30,7 @@ export class Scribbler {
 
   render(element: ScribblerJsx.Element): string {
     if (typeof element.type === "function") {
-      const instance = new element.type({ ...element.props });
-
-      return this.render(instance.render());
+      return this.render(element.type({ ...element.props }));
     }
 
     if (element.type === "ansi" && !this.#noColor) {
@@ -52,7 +50,7 @@ export class Scribbler {
     return "";
   }
 
-  #visitChildren(children: Array<ElementChildren>) {
+  #visitChildren(children: Array<ScribblerNode>) {
     const text: Array<string> = [];
 
     for (const child of children) {

--- a/source/scribbler/Text.tsx
+++ b/source/scribbler/Text.tsx
@@ -1,32 +1,24 @@
 import { Color } from "./enums.js";
-import type { ScribblerJsx } from "./types.js";
+import type { ScribblerNode } from "./types.js";
 
 interface TextProps {
-  children?: ScribblerJsx.ElementChildrenAttribute["children"];
+  children?: ScribblerNode;
   color?: Color | undefined;
   indent?: number | undefined;
 }
 
-export class Text implements ScribblerJsx.ElementClass {
-  props: TextProps;
+export function Text({ children, color, indent }: TextProps) {
+  const ansiEscapes: Array<Color> = [];
 
-  constructor(props: TextProps) {
-    this.props = props;
+  if (color != null) {
+    ansiEscapes.push(color);
   }
 
-  render(): ScribblerJsx.Element {
-    const ansiEscapes: Array<Color> = [];
-
-    if (this.props.color != null) {
-      ansiEscapes.push(this.props.color);
-    }
-
-    return (
-      <text indent={this.props.indent ?? 0}>
-        {ansiEscapes.length > 0 ? <ansi escapes={ansiEscapes} /> : undefined}
-        {this.props.children}
-        {ansiEscapes.length > 0 ? <ansi escapes={Color.Reset} /> : undefined}
-      </text>
-    );
-  }
+  return (
+    <text indent={indent ?? 0}>
+      {ansiEscapes.length > 0 ? <ansi escapes={ansiEscapes} /> : undefined}
+      {children}
+      {ansiEscapes.length > 0 ? <ansi escapes={Color.Reset} /> : undefined}
+    </text>
+  );
 }

--- a/source/scribbler/index.ts
+++ b/source/scribbler/index.ts
@@ -1,5 +1,5 @@
 export { Color } from "./enums.js";
 export { Line } from "./Line.js";
 export { Scribbler, type ScribblerOptions } from "./Scribbler.js";
-export { ScribblerJsx } from "./types.js";
+export { type ScribblerJsx } from "./types.js";
 export { Text } from "./Text.js";

--- a/source/scribbler/jsx-runtime.ts
+++ b/source/scribbler/jsx-runtime.ts
@@ -1,8 +1,8 @@
-import type { ComponentConstructor, ScribblerJsx } from "./types.js";
+import type { FunctionComponent, ScribblerJsx } from "./types.js";
 
 export type { ScribblerJsx as JSX };
 
-export function jsx(type: ComponentConstructor | string, props: Record<string, unknown>): ScribblerJsx.Element {
+export function jsx(type: FunctionComponent | string, props: Record<string, unknown>): ScribblerJsx.Element {
   return { props, type };
 }
 

--- a/source/scribbler/types.ts
+++ b/source/scribbler/types.ts
@@ -1,23 +1,16 @@
 import type { Color } from "./enums.js";
 
-export type ElementChildren = Array<ElementChildren> | ScribblerJsx.Element | string | undefined;
+export type ScribblerNode = Array<ScribblerNode> | ScribblerJsx.Element | string | undefined;
 
-// biome-ignore lint/correctness/noUnusedVariables: TODO might be false positive
-export type ComponentConstructor = new (props: Record<string, unknown>) => ScribblerJsx.ElementClass;
+export type FunctionComponent = (props: Record<string, unknown>) => ScribblerJsx.Element;
 
 export namespace ScribblerJsx {
   export interface Element {
     props: Record<string, unknown>;
-    type: ComponentConstructor | string;
-  }
-  export interface ElementAttributesProperty {
-    props: Record<string, unknown>;
-  }
-  export interface ElementClass {
-    render: () => ScribblerJsx.Element;
+    type: FunctionComponent | string;
   }
   export interface ElementChildrenAttribute {
-    children: ElementChildren;
+    children: ScribblerNode;
   }
   export interface IntrinsicElements {
     ansi: {
@@ -27,7 +20,7 @@ export namespace ScribblerJsx {
       // does not take props
     };
     text: {
-      children: Array<ElementChildren>;
+      children: Array<ScribblerNode>;
       indent: number;
     };
   }


### PR DESCRIPTION
This was supposed to be part of #199. Class components aren’t very useful. Migrating to function components reduces code duplication and complexity.