### PR TITLE
fix(expect): handle not supported matchers

### DIFF
--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -250,7 +250,7 @@ export class Expect {
     EventEmitter.dispatch([
       "expect:error",
       {
-        diagnostics: [Diagnostic.error(`The '${matcherNameText}()' matcher is not supported.`, origin)],
+        diagnostics: [Diagnostic.error(`The '.${matcherNameText}()' matcher is not supported.`, origin)],
         result: expectResult,
       },
     ]);

--- a/tests/__fixtures__/validation-expect/__typetests__/matcher-not-supported.tst.ts
+++ b/tests/__fixtures__/validation-expect/__typetests__/matcher-not-supported.tst.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "tstyche";
+
+test("is string?", () => {
+  expect<string>().type.toBeString();
+  expect<number>().type.not.toBeString();
+});
+
+test("is not supported?", () => {
+  // @ts-expect-error
+  expect<string>().type.toBeSupported();
+  // @ts-expect-error
+  expect<number>().type.not.toBeSupported();
+});

--- a/tests/__snapshots__/validation-expect-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stdout.snap.txt
@@ -6,4 +6,4 @@ Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Duration:   <<timestamp>>
 
-Ran all test files.
+Ran test files matching 'handles-nested'.

--- a/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stderr.snap.txt
@@ -1,0 +1,23 @@
+Error: The '.toBeSupported()' matcher is not supported.
+
+   8 | test("is not supported?", () => {
+   9 |   // @ts-expect-error
+> 10 |   expect<string>().type.toBeSupported();
+     |                         ^
+  11 |   // @ts-expect-error
+  12 |   expect<number>().type.not.toBeSupported();
+  13 | });
+
+       at ./__typetests__/matcher-not-supported.tst.ts:10:25
+
+Error: The '.toBeSupported()' matcher is not supported.
+
+  10 |   expect<string>().type.toBeSupported();
+  11 |   // @ts-expect-error
+> 12 |   expect<number>().type.not.toBeSupported();
+     |                             ^
+  13 | });
+  14 | 
+
+       at ./__typetests__/matcher-not-supported.tst.ts:12:29
+

--- a/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stdout.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stdout.snap.txt
@@ -1,0 +1,13 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/matcher-not-supported.tst.ts
+  + is string?
+  × is not supported?
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      1 failed, 1 passed, 2 total
+Assertions: 2 failed, 2 passed, 4 total
+Duration:   <<timestamp>>
+
+Ran test files matching 'matcher-not-supported'.

--- a/tests/validation-expect.test.js
+++ b/tests/validation-expect.test.js
@@ -8,7 +8,7 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
 test("handles nested 'describe()' or 'test()'", async function () {
-  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["handles-nested"]);
 
   await assert.matchSnapshot(normalizeOutput(stdout), {
     fileName: `${testFileName}-handles-nested-stdout`,
@@ -17,6 +17,22 @@ test("handles nested 'describe()' or 'test()'", async function () {
 
   await assert.matchSnapshot(stderr, {
     fileName: `${testFileName}-handles-nested-stderr`,
+    testFileUrl: import.meta.url,
+  });
+
+  assert.equal(exitCode, 1);
+});
+
+test("handles not supported matcher", async function () {
+  const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["matcher-not-supported"]);
+
+  await assert.matchSnapshot(normalizeOutput(stdout), {
+    fileName: `${testFileName}-handles-not-supported-matcher-stdout`,
+    testFileUrl: import.meta.url,
+  });
+
+  await assert.matchSnapshot(stderr, {
+    fileName: `${testFileName}-handles-not-supported-matcher-stderr`,
     testFileUrl: import.meta.url,
   });
 


### PR DESCRIPTION
The typings guard against using matching which are not implemented. In rear cases (e.g. `// @ts-expect-error`) that does not work.

Also nice to remove few lines of older code.