### PR TITLE
feat(watch): wrap around sync `fs.watch`

### DIFF
--- a/source/watch/FileWatcher.ts
+++ b/source/watch/FileWatcher.ts
@@ -1,13 +1,13 @@
 import { Path } from "#path";
 import { type WatchHandler, Watcher } from "./Watcher.js";
 
-export type FileWatchHandler = () => void | Promise<void>;
+export type FileWatchHandler = () => void;
 
 export class FileWatcher extends Watcher {
   constructor(targetPath: string, onChanged: FileWatchHandler) {
-    const onChangedFile: WatchHandler = async (filePath) => {
+    const onChangedFile: WatchHandler = (filePath) => {
       if (filePath === targetPath) {
-        await onChanged();
+        onChanged();
       }
     };
 

--- a/source/watch/Watcher.ts
+++ b/source/watch/Watcher.ts
@@ -1,20 +1,18 @@
-import { existsSync } from "node:fs";
-import fs from "node:fs/promises";
+import { type FSWatcher, existsSync, watch } from "node:fs";
 import { Path } from "#path";
 
-export type WatchHandler = (filePath: string) => void | Promise<void>;
+export type WatchHandler = (filePath: string) => void;
 
 export interface WatcherOptions {
   recursive?: boolean;
 }
 
 export class Watcher {
-  #abortController = new AbortController();
   #onChanged: WatchHandler;
   #onRemoved: WatchHandler;
   #recursive: boolean | undefined;
   #targetPath: string;
-  #watcher: AsyncIterable<{ filename?: string | null }> | undefined;
+  #watcher: FSWatcher | undefined;
 
   constructor(targetPath: string, onChanged: WatchHandler, onRemoved?: WatchHandler, options?: WatcherOptions) {
     this.#targetPath = targetPath;
@@ -24,28 +22,26 @@ export class Watcher {
   }
 
   close(): void {
-    this.#abortController.abort();
+    this.#watcher?.close();
   }
 
-  async watch(): Promise<void> {
-    this.#watcher = fs.watch(this.#targetPath, { recursive: this.#recursive, signal: this.#abortController.signal });
+  watch(): Promise<void> {
+    this.#watcher = watch(this.#targetPath, { recursive: this.#recursive }, (_eventType, fileName) => {
+      if (fileName != null) {
+        const filePath = Path.resolve(this.#targetPath, fileName);
 
-    try {
-      for await (const event of this.#watcher) {
-        if (event.filename != null) {
-          const filePath = Path.resolve(this.#targetPath, event.filename);
-
-          if (existsSync(filePath)) {
-            await this.#onChanged(filePath);
-          } else {
-            await this.#onRemoved(filePath);
-          }
+        if (existsSync(filePath)) {
+          this.#onChanged(filePath);
+        } else {
+          this.#onRemoved(filePath);
         }
       }
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        // the watcher was aborted
-      }
-    }
+    });
+
+    return new Promise((resolve) => {
+      this.#watcher?.on("close", () => {
+        resolve();
+      });
+    });
   }
 }


### PR DESCRIPTION
There is no need to wrap around the async `fs.watch` and I don’t like semantics of caching an error which is not an error. Always possible to bring this back, if it would appear useful.