### PR TITLE
feat(expect, output): mark the entire locations of diagnostics

### DIFF
--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -96,7 +96,7 @@ export class ConfigFileOptionsWorker {
             optionDefinition,
           );
         } else {
-          const origin = DiagnosticOrigin.fromJsonNode(property, sourceFile, this.#skipTrivia);
+          const origin = DiagnosticOrigin.fromJsonNode(property.name, sourceFile, this.#skipTrivia);
 
           this.#onDiagnostic(Diagnostic.error(ConfigDiagnosticText.unknownOption(optionName), origin));
         }

--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -75,7 +75,7 @@ export class ConfigFileOptionsWorker {
     for (const property of rootExpression.properties) {
       if (this.#compiler.isPropertyAssignment(property)) {
         if (!this.#isDoubleQuotedString(property.name, sourceFile)) {
-          const origin = DiagnosticOrigin.fromJsonNode(property, sourceFile, this.#skipTrivia);
+          const origin = DiagnosticOrigin.fromJsonNode(property.name, sourceFile, this.#skipTrivia);
 
           this.#onDiagnostic(Diagnostic.error(ConfigDiagnosticText.doubleQuotesExpected(), origin));
           continue;

--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -64,8 +64,12 @@ export class ConfigFileOptionsWorker {
 
     const rootExpression = sourceFile.statements[0]?.expression;
 
-    if (rootExpression == null || !this.#compiler.isObjectLiteralExpression(rootExpression)) {
-      const origin = new DiagnosticOrigin(0, 0, sourceFile);
+    if (!rootExpression) {
+      return;
+    }
+
+    if (!this.#compiler.isObjectLiteralExpression(rootExpression)) {
+      const origin = DiagnosticOrigin.fromJsonNode(rootExpression, sourceFile, this.#skipTrivia);
 
       this.#onDiagnostic(Diagnostic.error("The root value of a configuration file must be an object literal.", origin));
 

--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -43,7 +43,10 @@ export class Diagnostic {
       const text = compiler.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
 
       if (Diagnostic.isTsDiagnosticWithLocation(diagnostic)) {
-        origin = new DiagnosticOrigin(diagnostic.start, diagnostic.start + diagnostic.length, diagnostic.file);
+        // syntax diagnostics may have zero length
+        const diagnosticEnd = diagnostic.start + (diagnostic.length === 0 ? 1 : diagnostic.length);
+
+        origin = new DiagnosticOrigin(diagnostic.start, diagnosticEnd, diagnostic.file);
       }
 
       return new Diagnostic(text, category, origin).add({ code });

--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -43,11 +43,7 @@ export class Diagnostic {
       const text = compiler.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
 
       if (Diagnostic.isTsDiagnosticWithLocation(diagnostic)) {
-        // TODO consider swapping 'end' with 'length' in the 'DiagnosticOrigin' class
-        // that should help handling cases like syntax diagnostics with zero length
-        const diagnosticEnd = diagnostic.start + (diagnostic.length === 0 ? 1 : diagnostic.length);
-
-        origin = new DiagnosticOrigin(diagnostic.start, diagnosticEnd, diagnostic.file);
+        origin = new DiagnosticOrigin(diagnostic.start, diagnostic.start + diagnostic.length, diagnostic.file);
       }
 
       return new Diagnostic(text, category, origin).add({ code });

--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -43,7 +43,8 @@ export class Diagnostic {
       const text = compiler.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
 
       if (Diagnostic.isTsDiagnosticWithLocation(diagnostic)) {
-        // syntax diagnostics may have zero length
+        // TODO consider swapping 'end' with 'length' in the 'DiagnosticOrigin' class
+        // that should help handling cases like syntax diagnostics with zero length
         const diagnosticEnd = diagnostic.start + (diagnostic.length === 0 ? 1 : diagnostic.length);
 
         origin = new DiagnosticOrigin(diagnostic.start, diagnosticEnd, diagnostic.file);

--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -280,7 +280,7 @@ export class Expect {
   }
 
   #onSourceArgumentMustBeProvided(assertion: Assertion, expectResult: ExpectResult) {
-    const origin = DiagnosticOrigin.fromNode(assertion.node);
+    const origin = DiagnosticOrigin.fromNode(assertion.node.expression);
 
     EventEmitter.dispatch([
       "expect:error",

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -29,17 +29,16 @@ export function CodeSpanText(diagnosticOrigin: DiagnosticOrigin) {
     if (index === markedLine) {
       codeSpan.push(
         <Line>
-          <Text color={Color.Red}>{">"}</Text>
-          <Text> </Text>
-          {lineNumberText.padStart(lineNumberMaxWidth)}
-          <Text> </Text>
-          <Text color={Color.Gray}>|</Text> {lineText}
+          {" ".repeat(2)}
+          <Text color={Color.Red}>{lineNumberText.padStart(lineNumberMaxWidth)}</Text>
+          <Text color={Color.Gray}> | </Text>
+          {lineText}
         </Line>,
         <Line>
-          {" ".repeat(lineNumberMaxWidth + 3)}
-          <Text color={Color.Gray}>|</Text>
-          {" ".repeat(markedCharacter + 1)}
-          <Text color={Color.Red}>{"^"}</Text>
+          {" ".repeat(lineNumberMaxWidth + 2)}
+          <Text color={Color.Gray}> | </Text>
+          {" ".repeat(markedCharacter)}
+          <Text color={Color.Red}>{"~".repeat(diagnosticOrigin.end - diagnosticOrigin.start)}</Text>
         </Line>,
       );
     } else {

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -31,12 +31,16 @@ function SquiggleLineText({ gutterWidth, indentWidth = 0, squiggleWidth }: Squig
       {" ".repeat(gutterWidth)}
       <Text color={Color.Gray}>{" | "}</Text>
       {" ".repeat(indentWidth)}
-      <Text color={Color.Red}>{"~".repeat(squiggleWidth)}</Text>
+      <Text color={Color.Red}>{"~".repeat(squiggleWidth === 0 ? 1 : squiggleWidth)}</Text>
     </Line>
   );
 }
 
-export function CodeSpanText(diagnosticOrigin: DiagnosticOrigin) {
+interface CodeSpanTextProps {
+  diagnosticOrigin: DiagnosticOrigin;
+}
+
+export function CodeSpanText({ diagnosticOrigin }: CodeSpanTextProps) {
   const lastLineInFile = diagnosticOrigin.sourceFile.getLineAndCharacterOfPosition(
     diagnosticOrigin.sourceFile.text.length,
   ).line;

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -13,7 +13,7 @@ function CodeLineText({ children, gutterWidth, lineNumberColor = Color.Gray, lin
   return (
     <Line>
       <Text color={lineNumberColor}>{lineNumberText.padStart(gutterWidth)}</Text>
-      <Text color={Color.Gray}> | </Text>
+      <Text color={Color.Gray}>{" | "}</Text>
       {children}
     </Line>
   );
@@ -29,7 +29,7 @@ function SquiggleLineText({ gutterWidth, indentWidth = 0, squiggleWidth }: Squig
   return (
     <Line>
       {" ".repeat(gutterWidth)}
-      <Text color={Color.Gray}> | </Text>
+      <Text color={Color.Gray}>{" | "}</Text>
       {" ".repeat(indentWidth)}
       <Text color={Color.Red}>{"~".repeat(squiggleWidth)}</Text>
     </Line>
@@ -104,7 +104,7 @@ export function CodeSpanText(diagnosticOrigin: DiagnosticOrigin) {
   const location = (
     <Line>
       {" ".repeat(gutterWidth + 2)}
-      <Text color={Color.Gray}> at </Text>
+      <Text color={Color.Gray}>{" at "}</Text>
       <Text color={Color.Cyan}>{Path.relative("", diagnosticOrigin.sourceFile.fileName)}</Text>
       <Text color={Color.Gray}>
         :{String(firstMarkedLine + 1)}:{String(firstMarkedLineCharacter + 1)}

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -3,18 +3,18 @@ import { Path } from "#path";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 
 interface CodeLineTextProps {
-  children: string;
+  lineText: string;
   gutterWidth: number;
   lineNumberColor?: Color;
   lineNumberText: string;
 }
 
-function CodeLineText({ children, gutterWidth, lineNumberColor = Color.Gray, lineNumberText }: CodeLineTextProps) {
+function CodeLineText({ lineText, gutterWidth, lineNumberColor = Color.Gray, lineNumberText }: CodeLineTextProps) {
   return (
     <Line>
       <Text color={lineNumberColor}>{lineNumberText.padStart(gutterWidth)}</Text>
       <Text color={Color.Gray}>{" | "}</Text>
-      {children}
+      {lineText}
     </Line>
   );
 }
@@ -64,9 +64,12 @@ export function CodeSpanText(diagnosticOrigin: DiagnosticOrigin) {
 
     if (index >= firstMarkedLine && index <= lastMarkedLine) {
       codeSpan.push(
-        <CodeLineText gutterWidth={gutterWidth} lineNumberColor={Color.Red} lineNumberText={lineNumberText}>
-          {lineText}
-        </CodeLineText>,
+        <CodeLineText
+          gutterWidth={gutterWidth}
+          lineNumberColor={Color.Red}
+          lineNumberText={lineNumberText}
+          lineText={lineText}
+        />,
       );
 
       if (index === firstMarkedLine) {
@@ -88,11 +91,7 @@ export function CodeSpanText(diagnosticOrigin: DiagnosticOrigin) {
         codeSpan.push(<SquiggleLineText gutterWidth={gutterWidth} squiggleWidth={lineText.length} />);
       }
     } else {
-      codeSpan.push(
-        <CodeLineText gutterWidth={gutterWidth} lineNumberText={lineNumberText}>
-          {lineText}
-        </CodeLineText>,
-      );
+      codeSpan.push(<CodeLineText gutterWidth={gutterWidth} lineNumberText={lineNumberText} lineText={lineText} />);
     }
   }
 

--- a/source/output/diagnosticText.tsx
+++ b/source/output/diagnosticText.tsx
@@ -26,7 +26,7 @@ function DiagnosticText({ diagnostic }: DiagnosticTextProps) {
   const codeSpan = diagnostic.origin ? (
     <Text>
       <Line />
-      <CodeSpanText {...diagnostic.origin} />
+      <CodeSpanText diagnosticOrigin={diagnostic.origin} />
     </Text>
   ) : undefined;
 

--- a/source/runner/TestTreeWorker.ts
+++ b/source/runner/TestTreeWorker.ts
@@ -148,6 +148,7 @@ export class TestTreeWorker {
     if (assertion.isNot ? !matchResult.isMatch : matchResult.isMatch) {
       if (runMode & RunMode.Fail) {
         const text = ["The assertion was supposed to fail, but it passed.", "Consider removing the '.fail' flag."];
+        // TODO consider adding '.failNode' property to 'assertion'
         const origin = DiagnosticOrigin.fromNode((assertion.node.expression as ts.PropertyAccessExpression).name);
 
         EventEmitter.dispatch([

--- a/source/runner/TestTreeWorker.ts
+++ b/source/runner/TestTreeWorker.ts
@@ -148,7 +148,7 @@ export class TestTreeWorker {
     if (assertion.isNot ? !matchResult.isMatch : matchResult.isMatch) {
       if (runMode & RunMode.Fail) {
         const text = ["The assertion was supposed to fail, but it passed.", "Consider removing the '.fail' flag."];
-        const origin = DiagnosticOrigin.fromNode(assertion.node);
+        const origin = DiagnosticOrigin.fromNode((assertion.node.expression as ts.PropertyAccessExpression).name);
 
         EventEmitter.dispatch([
           "expect:error",

--- a/tests/__snapshots__/api-expect-fail-stderr.snap.txt
+++ b/tests/__snapshots__/api-expect-fail-stderr.snap.txt
@@ -4,8 +4,8 @@ Consider removing the '.fail' flag.
 
   2 | 
   3 | expect<string>().type.toBeString();
-> 4 | expect.fail<string>().type.toBeString();
-    | ^
+  4 | expect.fail<string>().type.toBeString();
+    | ~~~~~~~~~~~~~~~~~~~~~
   5 | 
   6 | expect.fail<never>().type.toBeString();
   7 | 
@@ -18,8 +18,8 @@ Consider removing the '.fail' flag.
 
   15 |   test("is string?", () => {
   16 |     expect<string>().type.toBeString();
-> 17 |     expect.fail<string>().type.toBeString();
-     |     ^
+  17 |     expect.fail<string>().type.toBeString();
+     |     ~~~~~~~~~~~~~~~~~~~~~
   18 | 
   19 |     expect.fail<never>().type.toBeVoid();
   20 |   });
@@ -32,8 +32,8 @@ Consider removing the '.fail' flag.
 
   23 | test("is number?", () => {
   24 |   expect<number>().type.toBeNumber();
-> 25 |   expect.fail<number>().type.toBeNumber();
-     |   ^
+  25 |   expect.fail<number>().type.toBeNumber();
+     |   ~~~~~~~~~~~~~~~~~~~~~
   26 | 
   27 |   expect.fail<never>().type.toBeVoid();
   28 | });

--- a/tests/__snapshots__/api-expect-fail-stderr.snap.txt
+++ b/tests/__snapshots__/api-expect-fail-stderr.snap.txt
@@ -5,12 +5,12 @@ Consider removing the '.fail' flag.
   2 | 
   3 | expect<string>().type.toBeString();
   4 | expect.fail<string>().type.toBeString();
-    | ~~~~~~~~~~~~~~~~~~~~~
+    |        ~~~~
   5 | 
   6 | expect.fail<never>().type.toBeString();
   7 | 
 
-      at ./__typetests__/expect-fail.tst.ts:4:1
+      at ./__typetests__/expect-fail.tst.ts:4:8
 
 Error: The assertion was supposed to fail, but it passed.
 
@@ -19,12 +19,12 @@ Consider removing the '.fail' flag.
   15 |   test("is string?", () => {
   16 |     expect<string>().type.toBeString();
   17 |     expect.fail<string>().type.toBeString();
-     |     ~~~~~~~~~~~~~~~~~~~~~
+     |            ~~~~
   18 | 
   19 |     expect.fail<never>().type.toBeVoid();
   20 |   });
 
-       at ./__typetests__/expect-fail.tst.ts:17:5
+       at ./__typetests__/expect-fail.tst.ts:17:12
 
 Error: The assertion was supposed to fail, but it passed.
 
@@ -33,10 +33,10 @@ Consider removing the '.fail' flag.
   23 | test("is number?", () => {
   24 |   expect<number>().type.toBeNumber();
   25 |   expect.fail<number>().type.toBeNumber();
-     |   ~~~~~~~~~~~~~~~~~~~~~
+     |          ~~~~
   26 | 
   27 |   expect.fail<never>().type.toBeVoid();
   28 | });
 
-       at ./__typetests__/expect-fail.tst.ts:25:3
+       at ./__typetests__/expect-fail.tst.ts:25:10
 

--- a/tests/__snapshots__/api-expect-only-fail-stderr.snap.txt
+++ b/tests/__snapshots__/api-expect-only-fail-stderr.snap.txt
@@ -4,8 +4,8 @@ Consider removing the '.fail' flag.
 
   2 | 
   3 | expect<string>().type.toBeString();
-> 4 | expect.only.fail<string>().type.toBeString();
-    | ^
+  4 | expect.only.fail<string>().type.toBeString();
+    | ~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 | 
   6 | expect.only.fail<never>().type.toBeString();
   7 | 
@@ -18,8 +18,8 @@ Consider removing the '.fail' flag.
 
   15 |   test("is skipped?", () => {
   16 |     expect<never>().type.toBeVoid();
-> 17 |     expect.only.fail<string>().type.toBeString();
-     |     ^
+  17 |     expect.only.fail<string>().type.toBeString();
+     |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
   18 | 
   19 |     expect.only.fail<never>().type.toBeVoid();
   20 |   });
@@ -32,8 +32,8 @@ Consider removing the '.fail' flag.
 
   29 | test.only("is number?", () => {
   30 |   expect.skip<string>().type.toBeNumber();
-> 31 |   expect.fail<number>().type.toBeNumber();
-     |   ^
+  31 |   expect.fail<number>().type.toBeNumber();
+     |   ~~~~~~~~~~~~~~~~~~~~~
   32 | 
   33 |   expect.fail<never>().type.toBeVoid();
   34 | });

--- a/tests/__snapshots__/api-expect-only-fail-stderr.snap.txt
+++ b/tests/__snapshots__/api-expect-only-fail-stderr.snap.txt
@@ -5,12 +5,12 @@ Consider removing the '.fail' flag.
   2 | 
   3 | expect<string>().type.toBeString();
   4 | expect.only.fail<string>().type.toBeString();
-    | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    |             ~~~~
   5 | 
   6 | expect.only.fail<never>().type.toBeString();
   7 | 
 
-      at ./__typetests__/expect-only-fail.tst.ts:4:1
+      at ./__typetests__/expect-only-fail.tst.ts:4:13
 
 Error: The assertion was supposed to fail, but it passed.
 
@@ -19,12 +19,12 @@ Consider removing the '.fail' flag.
   15 |   test("is skipped?", () => {
   16 |     expect<never>().type.toBeVoid();
   17 |     expect.only.fail<string>().type.toBeString();
-     |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                 ~~~~
   18 | 
   19 |     expect.only.fail<never>().type.toBeVoid();
   20 |   });
 
-       at ./__typetests__/expect-only-fail.tst.ts:17:5
+       at ./__typetests__/expect-only-fail.tst.ts:17:17
 
 Error: The assertion was supposed to fail, but it passed.
 
@@ -33,10 +33,10 @@ Consider removing the '.fail' flag.
   29 | test.only("is number?", () => {
   30 |   expect.skip<string>().type.toBeNumber();
   31 |   expect.fail<number>().type.toBeNumber();
-     |   ~~~~~~~~~~~~~~~~~~~~~
+     |          ~~~~
   32 | 
   33 |   expect.fail<never>().type.toBeVoid();
   34 | });
 
-       at ./__typetests__/expect-only-fail.tst.ts:31:3
+       at ./__typetests__/expect-only-fail.tst.ts:31:10
 

--- a/tests/__snapshots__/api-expect-skip-fail-stderr.snap.txt
+++ b/tests/__snapshots__/api-expect-skip-fail-stderr.snap.txt
@@ -4,8 +4,8 @@ Consider removing the '.fail' flag.
 
   2 | 
   3 | expect.skip.fail<string>().type.toBeString();
-> 4 | expect.fail<string>().type.toBeString();
-    | ^
+  4 | expect.fail<string>().type.toBeString();
+    | ~~~~~~~~~~~~~~~~~~~~~
   5 | 
   6 | expect.skip
   7 |   .fail(() => {
@@ -18,8 +18,8 @@ Consider removing the '.fail' flag.
 
   13 |   test("is string?", () => {
   14 |     expect.skip.fail<string>().type.toBeString();
-> 15 |     expect.fail<string>().type.toBeString();
-     |     ^
+  15 |     expect.fail<string>().type.toBeString();
+     |     ~~~~~~~~~~~~~~~~~~~~~
   16 |   });
   17 | });
   18 | 
@@ -32,8 +32,8 @@ Consider removing the '.fail' flag.
 
   19 | test("is number?", () => {
   20 |   expect.skip.fail<number>().type.toBeNumber();
-> 21 |   expect.fail<number>().type.toBeNumber();
-     |   ^
+  21 |   expect.fail<number>().type.toBeNumber();
+     |   ~~~~~~~~~~~~~~~~~~~~~
   22 | });
   23 | 
 

--- a/tests/__snapshots__/api-expect-skip-fail-stderr.snap.txt
+++ b/tests/__snapshots__/api-expect-skip-fail-stderr.snap.txt
@@ -5,12 +5,12 @@ Consider removing the '.fail' flag.
   2 | 
   3 | expect.skip.fail<string>().type.toBeString();
   4 | expect.fail<string>().type.toBeString();
-    | ~~~~~~~~~~~~~~~~~~~~~
+    |        ~~~~
   5 | 
   6 | expect.skip
   7 |   .fail(() => {
 
-      at ./__typetests__/expect-skip-fail.tst.ts:4:1
+      at ./__typetests__/expect-skip-fail.tst.ts:4:8
 
 Error: The assertion was supposed to fail, but it passed.
 
@@ -19,12 +19,12 @@ Consider removing the '.fail' flag.
   13 |   test("is string?", () => {
   14 |     expect.skip.fail<string>().type.toBeString();
   15 |     expect.fail<string>().type.toBeString();
-     |     ~~~~~~~~~~~~~~~~~~~~~
+     |            ~~~~
   16 |   });
   17 | });
   18 | 
 
-       at ./__typetests__/expect-skip-fail.tst.ts:15:5
+       at ./__typetests__/expect-skip-fail.tst.ts:15:12
 
 Error: The assertion was supposed to fail, but it passed.
 
@@ -33,9 +33,9 @@ Consider removing the '.fail' flag.
   19 | test("is number?", () => {
   20 |   expect.skip.fail<number>().type.toBeNumber();
   21 |   expect.fail<number>().type.toBeNumber();
-     |   ~~~~~~~~~~~~~~~~~~~~~
+     |          ~~~~
   22 | });
   23 | 
 
-       at ./__typetests__/expect-skip-fail.tst.ts:21:3
+       at ./__typetests__/expect-skip-fail.tst.ts:21:10
 

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
   25 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
   26 | 
-> 27 |     expect<Names>().type.toBe<{ first: string; last: string }>();
-     |                          ^
+  27 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+     |                          ~~~~
   28 |   });
   29 | 
   30 |   test("is NOT identical to target type", () => {
@@ -14,8 +14,8 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
   31 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
   32 | 
-> 33 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
-     |                              ^
+  33 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+     |                              ~~~~
   34 |   });
   35 | 
   36 |   test("is identical to target expression", () => {
@@ -26,8 +26,8 @@ Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
   38 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
   39 | 
-> 40 |     expect<{ first: string; last: string }>().type.toBe(getNames());
-     |                                                    ^
+  40 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+     |                                                    ~~~~
   41 |   });
   42 | 
   43 |   test("is NOT identical to target expression", () => {
@@ -38,8 +38,8 @@ Error: Type '{ first: string; last?: string | undefined; }' is identical to type
 
   44 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
   45 | 
-> 46 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
-     |                                                         ^
+  46 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+     |                                                         ~~~~
   47 |   });
   48 | });
   49 | 
@@ -50,8 +50,8 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
   53 |     expect(getNames()).type.toBe<Names>();
   54 | 
-> 55 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
-     |                             ^
+  55 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+     |                             ~~~~
   56 |   });
   57 | 
   58 |   test("is NOT identical to target type", () => {
@@ -62,8 +62,8 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
   59 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
   60 | 
-> 61 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
-     |                                 ^
+  61 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+     |                                 ~~~~
   62 |   });
   63 | 
   64 |   test("identical to target expression", () => {
@@ -74,8 +74,8 @@ Error: Type '{ height: number; }' is not identical to type 'Size'.
 
   65 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
   66 | 
-> 67 |     expect({ height: 14 }).type.toBe(getSize());
-     |                                 ^
+  67 |     expect({ height: 14 }).type.toBe(getSize());
+     |                                 ~~~~
   68 |   });
   69 | 
   70 |   test("is NOT identical to target expression", () => {
@@ -86,8 +86,8 @@ Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
   71 |     expect({ height: 14 }).type.not.toBe(getSize());
   72 | 
-> 73 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
-     |                                                ^
+  73 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+     |                                                ~~~~
   74 |   });
   75 | });
   76 | 

--- a/tests/__snapshots__/api-toBeAny-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAny-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
    7 |   expect(returnsAny()).type.toBeAny();
    8 | 
->  9 |   expect(returnsString()).type.toBeAny();
-     |                                ^
+   9 |   expect(returnsString()).type.toBeAny();
+     |                                ~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT any?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'any'.
 
   13 |   expect(returnsString()).type.not.toBeAny();
   14 | 
-> 15 |   expect(returnsAny()).type.not.toBeAny();
-     |                                 ^
+  15 |   expect(returnsAny()).type.not.toBeAny();
+     |                                 ~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignable-stderr.snap.txt
@@ -4,8 +4,8 @@ To learn more, visit https://tstyche.org/releases/tstyche-2
 
    8 | describe("received type", () => {
    9 |   test("is assignable expected value?", () => {
-> 10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
-     |                          ^
+  10 |     expect<Names>().type.toBeAssignable({ first: "Rose" });
+     |                          ~~~~~~~~~~~~~~
   11 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: "Smith" });
   12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
   13 | 
@@ -16,8 +16,8 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
   12 |     expect<Names>().type.toBeAssignable({ first: "Rose", last: undefined });
   13 | 
-> 14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
-     |                          ^
+  14 |     expect<Names>().type.toBeAssignable({ middle: "O." });
+     |                          ~~~~~~~~~~~~~~
   15 |   });
   16 | 
   17 |   test("is NOT assignable expected value?", () => {
@@ -28,8 +28,8 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
   18 |     expect<Names>().type.not.toBeAssignable({ middle: "O." });
   19 | 
-> 20 |     expect<Names>().type.not.toBeAssignable({ first: "Rose" });
-     |                              ^
+  20 |     expect<Names>().type.not.toBeAssignable({ first: "Rose" });
+     |                              ~~~~~~~~~~~~~~
   21 |   });
   22 | 
   23 |   test("is assignable expected type?", () => {
@@ -40,8 +40,8 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
   27 |     expect<Names>().type.toBeAssignable<{ first: string; last?: string }>();
   28 | 
-> 29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
-     |                          ^
+  29 |     expect<Names>().type.toBeAssignable<{ middle: string }>();
+     |                          ~~~~~~~~~~~~~~
   30 |   });
   31 | 
   32 |   test("is NOT assignable expected type?", () => {
@@ -52,8 +52,8 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
   33 |     expect<Names>().type.not.toBeAssignable<{ middle: string }>();
   34 | 
-> 35 |     expect<Names>().type.not.toBeAssignable<{ first: string }>();
-     |                              ^
+  35 |     expect<Names>().type.not.toBeAssignable<{ first: string }>();
+     |                              ~~~~~~~~~~~~~~
   36 |   });
   37 | });
   38 | 
@@ -64,8 +64,8 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
   44 |     });
   45 | 
-> 46 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable({
-     |                                                  ^
+  46 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable({
+     |                                                  ~~~~~~~~~~~~~~
   47 |       middle: "O.",
   48 |     });
   49 |   });
@@ -76,8 +76,8 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
   54 |     });
   55 | 
-> 56 |     expect({ first: "Jane" }).type.not.toBeAssignable({ first: "Rose" });
-     |                                        ^
+  56 |     expect({ first: "Jane" }).type.not.toBeAssignable({ first: "Rose" });
+     |                                        ~~~~~~~~~~~~~~
   57 |   });
   58 | 
   59 |   test("is assignable expected type?", () => {
@@ -88,8 +88,8 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
   63 |     }>();
   64 | 
-> 65 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable<{
-     |                                                  ^
+  65 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignable<{
+     |                                                  ~~~~~~~~~~~~~~
   66 |       middle: string;
   67 |     }>();
   68 |   });
@@ -100,8 +100,8 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
   73 |     }>();
   74 | 
-> 75 |     expect({ first: "Jane" }).type.not.toBeAssignable<{ first: string }>();
-     |                                        ^
+  75 |     expect({ first: "Jane" }).type.not.toBeAssignable<{ first: string }>();
+     |                                        ~~~~~~~~~~~~~~
   76 |   });
   77 | });
   78 | 

--- a/tests/__snapshots__/api-toBeAssignableTo-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableTo-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Type '{ first?: string | undefined; }' is not assignable to type '{ first
 
   10 |     expect<{ first: string }>().type.toBeAssignableTo({ first: "Jane" });
   11 | 
-> 12 |     expect<{ first?: string }>().type.toBeAssignableTo({ first: "Jane" });
-     |                                       ^
+  12 |     expect<{ first?: string }>().type.toBeAssignableTo({ first: "Jane" });
+     |                                       ~~~~~~~~~~~~~~~~
   13 |   });
   14 | 
   15 |   test("is NOT assignable to target expression?", () => {
@@ -14,8 +14,8 @@ Error: Type '{ first: string; }' is assignable to type '{ first: string; }'.
 
   18 |     expect<Names>().type.not.toBeAssignableTo({ middle: "O." });
   19 | 
-> 20 |     expect<{ first: string }>().type.not.toBeAssignableTo({ first: "Jane" });
-     |                                          ^
+  20 |     expect<{ first: string }>().type.not.toBeAssignableTo({ first: "Jane" });
+     |                                          ~~~~~~~~~~~~~~~~
   21 |   });
   22 | 
   23 |   test("is assignable to target type?", () => {
@@ -26,8 +26,8 @@ Error: Type 'Names' is not assignable to type '{ middle: string; }'.
 
   25 |     expect<Names>().type.toBeAssignableTo<{ first: string; last?: string }>();
   26 | 
-> 27 |     expect<Names>().type.toBeAssignableTo<{ middle: string }>();
-     |                          ^
+  27 |     expect<Names>().type.toBeAssignableTo<{ middle: string }>();
+     |                          ~~~~~~~~~~~~~~~~
   28 |   });
   29 | 
   30 |   test("is NOT assignable to target type?", () => {
@@ -38,8 +38,8 @@ Error: Type 'Names' is assignable to type '{ first: string; }'.
 
   33 |     expect<Names>().type.not.toBeAssignableTo<{ middle: string }>();
   34 | 
-> 35 |     expect<Names>().type.not.toBeAssignableTo<{ first: string }>();
-     |                              ^
+  35 |     expect<Names>().type.not.toBeAssignableTo<{ first: string }>();
+     |                              ~~~~~~~~~~~~~~~~
   36 |   });
   37 | });
   38 | 
@@ -50,8 +50,8 @@ Error: Type '{ first: string; last: string; }' is not assignable to type '{ firs
 
   41 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose", last: "Smith" });
   42 | 
-> 43 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose" });
-     |                                                  ^
+  43 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo({ first: "Rose" });
+     |                                                  ~~~~~~~~~~~~~~~~
   44 |   });
   45 | 
   46 |   test("is NOT assignable to target expression?", () => {
@@ -62,8 +62,8 @@ Error: Type '{ first: string; }' is assignable to type '{ first: string; }'.
 
   47 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableTo({ first: "Rose" });
   48 | 
-> 49 |     expect({ first: "Jane" }).type.not.toBeAssignableTo({ first: "Rose" });
-     |                                        ^
+  49 |     expect({ first: "Jane" }).type.not.toBeAssignableTo({ first: "Rose" });
+     |                                        ~~~~~~~~~~~~~~~~
   50 |   });
   51 | 
   52 |   test("is assignable to target type?", () => {
@@ -74,8 +74,8 @@ Error: Type '{ first: string; last: string; }' is not assignable to type '{ midd
 
   54 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ first: string; last?: string }>();
   55 | 
-> 56 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ middle: string }>();
-     |                                                  ^
+  56 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableTo<{ middle: string }>();
+     |                                                  ~~~~~~~~~~~~~~~~
   57 |   });
   58 | 
   59 |   test("is NOT assignable to type?", () => {
@@ -86,8 +86,8 @@ Error: Type '{ first: string; }' is assignable to type '{ first: string; }'.
 
   60 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableTo<{ middle: string }>();
   61 | 
-> 62 |     expect({ first: "Jane" }).type.not.toBeAssignableTo<{ first: string }>();
-     |                                        ^
+  62 |     expect({ first: "Jane" }).type.not.toBeAssignableTo<{ first: string }>();
+     |                                        ~~~~~~~~~~~~~~~~
   63 |   });
   64 | });
   65 | 

--- a/tests/__snapshots__/api-toBeAssignableWith-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableWith-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
   12 |     expect<Names>().type.toBeAssignableWith({ first: "Rose", last: undefined });
   13 | 
-> 14 |     expect<Names>().type.toBeAssignableWith({ middle: "O." });
-     |                          ^
+  14 |     expect<Names>().type.toBeAssignableWith({ middle: "O." });
+     |                          ~~~~~~~~~~~~~~~~~~
   15 |   });
   16 | 
   17 |   test("is NOT assignable target expression?", () => {
@@ -14,8 +14,8 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
   18 |     expect<Names>().type.not.toBeAssignableWith({ middle: "O." });
   19 | 
-> 20 |     expect<Names>().type.not.toBeAssignableWith({ first: "Rose" });
-     |                              ^
+  20 |     expect<Names>().type.not.toBeAssignableWith({ first: "Rose" });
+     |                              ~~~~~~~~~~~~~~~~~~
   21 |   });
   22 | 
   23 |   test("is assignable target type?", () => {
@@ -26,8 +26,8 @@ Error: Type 'Names' is not assignable with type '{ middle: string; }'.
 
   27 |     expect<Names>().type.toBeAssignableWith<{ first: string; last?: string }>();
   28 | 
-> 29 |     expect<Names>().type.toBeAssignableWith<{ middle: string }>();
-     |                          ^
+  29 |     expect<Names>().type.toBeAssignableWith<{ middle: string }>();
+     |                          ~~~~~~~~~~~~~~~~~~
   30 |   });
   31 | 
   32 |   test("is NOT assignable target type?", () => {
@@ -38,8 +38,8 @@ Error: Type 'Names' is assignable with type '{ first: string; }'.
 
   33 |     expect<Names>().type.not.toBeAssignableWith<{ middle: string }>();
   34 | 
-> 35 |     expect<Names>().type.not.toBeAssignableWith<{ first: string }>();
-     |                              ^
+  35 |     expect<Names>().type.not.toBeAssignableWith<{ first: string }>();
+     |                              ~~~~~~~~~~~~~~~~~~
   36 |   });
   37 | });
   38 | 
@@ -50,8 +50,8 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
   41 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ first: "Rose", last: "Smith" });
   42 | 
-> 43 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ middle: "O." });
-     |                                                  ^
+  43 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith({ middle: "O." });
+     |                                                  ~~~~~~~~~~~~~~~~~~
   44 |   });
   45 | 
   46 |   test("is NOT assignable target expression?", () => {
@@ -62,8 +62,8 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
   47 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableWith({ middle: "O." });
   48 | 
-> 49 |     expect({ first: "Jane" }).type.not.toBeAssignableWith({ first: "Rose" });
-     |                                        ^
+  49 |     expect({ first: "Jane" }).type.not.toBeAssignableWith({ first: "Rose" });
+     |                                        ~~~~~~~~~~~~~~~~~~
   50 |   });
   51 | 
   52 |   test("is assignable target type?", () => {
@@ -74,8 +74,8 @@ Error: Type '{ first: string; last: string; }' is not assignable with type '{ mi
 
   53 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ first: string; last: string }>();
   54 | 
-> 55 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ middle: string }>();
-     |                                                  ^
+  55 |     expect({ first: "Jane", last: "Swan" }).type.toBeAssignableWith<{ middle: string }>();
+     |                                                  ~~~~~~~~~~~~~~~~~~
   56 |   });
   57 | 
   58 |   test("is NOT assignable type?", () => {
@@ -86,8 +86,8 @@ Error: Type '{ first: string; }' is assignable with type '{ first: string; }'.
 
   59 |     expect({ first: "Jane", last: "Swan" }).type.not.toBeAssignableWith<{ middle: string }>();
   60 | 
-> 61 |     expect({ first: "Jane" }).type.not.toBeAssignableWith<{ first: string }>();
-     |                                        ^
+  61 |     expect({ first: "Jane" }).type.not.toBeAssignableWith<{ first: string }>();
+     |                                        ~~~~~~~~~~~~~~~~~~
   62 |   });
   63 | });
   64 | 

--- a/tests/__snapshots__/api-toBeBigInt-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeBigInt-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'void'.
 
    7 |   expect(returnsBigInt()).type.toBeBigInt();
    8 | 
->  9 |   expect(returnsVoid()).type.toBeBigInt();
-     |                              ^
+   9 |   expect(returnsVoid()).type.toBeBigInt();
+     |                              ~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT bigint?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'bigint'.
 
   13 |   expect(returnsVoid()).type.not.toBeBigInt();
   14 | 
-> 15 |   expect(returnsBigInt()).type.not.toBeBigInt();
-     |                                    ^
+  15 |   expect(returnsBigInt()).type.not.toBeBigInt();
+     |                                    ~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeBoolean-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeBoolean-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
    7 |   expect(returnsBoolean()).type.toBeBoolean();
    8 | 
->  9 |   expect(returnsString()).type.toBeBoolean();
-     |                                ^
+   9 |   expect(returnsString()).type.toBeBoolean();
+     |                                ~~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT boolean?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'boolean'.
 
   13 |   expect(returnsString()).type.not.toBeBoolean();
   14 | 
-> 15 |   expect(returnsBoolean()).type.not.toBeBoolean();
-     |                                     ^
+  15 |   expect(returnsBoolean()).type.not.toBeBoolean();
+     |                                     ~~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeNever-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNever-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
    7 |   expect(returnsNever()).type.toBeNever();
    8 | 
->  9 |   expect(returnsString()).type.toBeNever();
-     |                                ^
+   9 |   expect(returnsString()).type.toBeNever();
+     |                                ~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT never?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'never'.
 
   13 |   expect(returnsString()).type.not.toBeNever();
   14 | 
-> 15 |   expect(returnsNever()).type.not.toBeNever();
-     |                                   ^
+  15 |   expect(returnsNever()).type.not.toBeNever();
+     |                                   ~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeNull-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNull-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'void'.
 
    7 |   expect(returnsNull()).type.toBeNull();
    8 | 
->  9 |   expect(returnsVoid()).type.toBeNull();
-     |                              ^
+   9 |   expect(returnsVoid()).type.toBeNull();
+     |                              ~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT null?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'null'.
 
   13 |   expect(returnsVoid()).type.not.toBeNull();
   14 | 
-> 15 |   expect(returnsNull()).type.not.toBeNull();
-     |                                  ^
+  15 |   expect(returnsNull()).type.not.toBeNull();
+     |                                  ~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeNumber-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNumber-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'void'.
 
    7 |   expect(returnsNumber()).type.toBeNumber();
    8 | 
->  9 |   expect(returnsVoid()).type.toBeNumber();
-     |                              ^
+   9 |   expect(returnsVoid()).type.toBeNumber();
+     |                              ~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT number?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'number'.
 
   13 |   expect(returnsVoid()).type.not.toBeNumber();
   14 | 
-> 15 |   expect(returnsNumber()).type.not.toBeNumber();
-     |                                    ^
+  15 |   expect(returnsNumber()).type.not.toBeNumber();
+     |                                    ~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeString-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeString-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'void'.
 
    7 |   expect(returnsString()).type.toBeString();
    8 | 
->  9 |   expect(returnsVoid()).type.toBeString();
-     |                              ^
+   9 |   expect(returnsVoid()).type.toBeString();
+     |                              ~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT string?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'string'.
 
   13 |   expect(returnsVoid()).type.not.toBeString();
   14 | 
-> 15 |   expect(returnsString()).type.not.toBeString();
-     |                                    ^
+  15 |   expect(returnsString()).type.not.toBeString();
+     |                                    ~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeSymbol-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'void'.
 
    7 |   expect(returnsSymbol()).type.toBeSymbol();
    8 | 
->  9 |   expect(returnsVoid()).type.toBeSymbol();
-     |                              ^
+   9 |   expect(returnsVoid()).type.toBeSymbol();
+     |                              ~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT symbol?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'symbol'.
 
   13 |   expect(returnsVoid()).type.not.toBeSymbol();
   14 | 
-> 15 |   expect(returnsSymbol()).type.not.toBeSymbol();
-     |                                    ^
+  15 |   expect(returnsSymbol()).type.not.toBeSymbol();
+     |                                    ~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeUndefined-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUndefined-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
    7 |   expect(returnsUndefined()).type.toBeUndefined();
    8 | 
->  9 |   expect(returnsString()).type.toBeUndefined();
-     |                                ^
+   9 |   expect(returnsString()).type.toBeUndefined();
+     |                                ~~~~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT undefined?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'undefined'.
 
   13 |   expect(returnsString()).type.not.toBeUndefined();
   14 | 
-> 15 |   expect(returnsUndefined()).type.not.toBeUndefined();
-     |                                       ^
+  15 |   expect(returnsUndefined()).type.not.toBeUndefined();
+     |                                       ~~~~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeUniqueSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUniqueSymbol-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'void'.
 
    9 |   expect(returnsUniqueSymbol()).type.toBeUniqueSymbol();
   10 | 
-> 11 |   expect(returnsVoid()).type.toBeUniqueSymbol();
-     |                              ^
+  11 |   expect(returnsVoid()).type.toBeUniqueSymbol();
+     |                              ~~~~~~~~~~~~~~~~
   12 | });
   13 | 
   14 | test("is NOT unique symbol?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'unique symbol'.
 
   15 |   expect(returnsVoid()).type.not.toBeUniqueSymbol();
   16 | 
-> 17 |   expect(returnsUniqueSymbol()).type.not.toBeUniqueSymbol();
-     |                                          ^
+  17 |   expect(returnsUniqueSymbol()).type.not.toBeUniqueSymbol();
+     |                                          ~~~~~~~~~~~~~~~~
   18 | });
   19 | 
 

--- a/tests/__snapshots__/api-toBeUnknown-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUnknown-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
    7 |   expect(returnsUnknown()).type.toBeUnknown();
    8 | 
->  9 |   expect(returnsString()).type.toBeUnknown();
-     |                                ^
+   9 |   expect(returnsString()).type.toBeUnknown();
+     |                                ~~~~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT unknown?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'unknown'.
 
   13 |   expect(returnsString()).type.not.toBeUnknown();
   14 | 
-> 15 |   expect(returnsUnknown()).type.not.toBeUnknown();
-     |                                     ^
+  15 |   expect(returnsUnknown()).type.not.toBeUnknown();
+     |                                     ~~~~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toBeVoid-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeVoid-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
    7 |   expect(returnsVoid()).type.toBeVoid();
    8 | 
->  9 |   expect(returnsString()).type.toBeVoid();
-     |                                ^
+   9 |   expect(returnsString()).type.toBeVoid();
+     |                                ~~~~~~~~
   10 | });
   11 | 
   12 | test("is NOT void?", () => {
@@ -14,8 +14,8 @@ Error: The source type is 'void'.
 
   13 |   expect(returnsString()).type.not.toBeVoid();
   14 | 
-> 15 |   expect(returnsVoid()).type.not.toBeVoid();
-     |                                  ^
+  15 |   expect(returnsVoid()).type.not.toBeVoid();
+     |                                  ~~~~~~~~
   16 | });
   17 | 
 

--- a/tests/__snapshots__/api-toEqual-stderr.snap.txt
+++ b/tests/__snapshots__/api-toEqual-stderr.snap.txt
@@ -4,8 +4,8 @@ To learn more, visit https://tstyche.org/releases/tstyche-2
 
   14 | 
   15 | test("edge cases", () => {
-> 16 |   expect<any>().type.not.toEqual<never>();
-     |                          ^
+  16 |   expect<any>().type.not.toEqual<never>();
+     |                          ~~~~~~~
   17 |   expect<any>().type.not.toEqual<unknown>();
   18 | 
   19 |   expect(Date).type.toEqual<typeof Date>();
@@ -16,8 +16,8 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
   25 |     expect<Names>().type.toEqual<{ first: string; last?: string }>();
   26 | 
-> 27 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
-     |                          ^
+  27 |     expect<Names>().type.toEqual<{ first: string; last: string }>();
+     |                          ~~~~~~~
   28 |   });
   29 | 
   30 |   test("does NOT equal expected type", () => {
@@ -28,8 +28,8 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
   31 |     expect<Names>().type.not.toEqual<{ first: string; last: string }>();
   32 | 
-> 33 |     expect<Names>().type.not.toEqual<{ first: string; last?: string }>();
-     |                              ^
+  33 |     expect<Names>().type.not.toEqual<{ first: string; last?: string }>();
+     |                              ~~~~~~~
   34 |   });
   35 | 
   36 |   test("equals expected value", () => {
@@ -40,8 +40,8 @@ Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
   38 |     expect<{ first: string; last?: string }>().type.toEqual(getNames());
   39 | 
-> 40 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
-     |                                                    ^
+  40 |     expect<{ first: string; last: string }>().type.toEqual(getNames());
+     |                                                    ~~~~~~~
   41 |   });
   42 | 
   43 |   test("does NOT equal expected value", () => {
@@ -52,8 +52,8 @@ Error: Type '{ first: string; last?: string | undefined; }' is identical to type
 
   44 |     expect<{ first: string; last: string }>().type.not.toEqual(getNames());
   45 | 
-> 46 |     expect<{ first: string; last?: string }>().type.not.toEqual(getNames());
-     |                                                         ^
+  46 |     expect<{ first: string; last?: string }>().type.not.toEqual(getNames());
+     |                                                         ~~~~~~~
   47 |   });
   48 | });
   49 | 
@@ -64,8 +64,8 @@ Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
   53 |     expect(getNames()).type.toEqual<Names>();
   54 | 
-> 55 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
-     |                             ^
+  55 |     expect(getNames()).type.toEqual<{ first: string; last: string }>();
+     |                             ~~~~~~~
   56 |   });
   57 | 
   58 |   test("does NOT equal expected type", () => {
@@ -76,8 +76,8 @@ Error: Type 'Names' is identical to type '{ first: string; last?: string | undef
 
   59 |     expect(getNames()).type.not.toEqual<{ first: string; last: string }>();
   60 | 
-> 61 |     expect(getNames()).type.not.toEqual<{ first: string; last?: string }>();
-     |                                 ^
+  61 |     expect(getNames()).type.not.toEqual<{ first: string; last?: string }>();
+     |                                 ~~~~~~~
   62 |   });
   63 | 
   64 |   test("equals expected value", () => {
@@ -88,8 +88,8 @@ Error: Type '{ height: number; }' is not identical to type 'Size'.
 
   65 |     expect({ height: 14, width: 25 }).type.toEqual(getSize());
   66 | 
-> 67 |     expect({ height: 14 }).type.toEqual(getSize());
-     |                                 ^
+  67 |     expect({ height: 14 }).type.toEqual(getSize());
+     |                                 ~~~~~~~
   68 |   });
   69 | 
   70 |   test("does NOT equal expected value", () => {
@@ -100,8 +100,8 @@ Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
   71 |     expect({ height: 14 }).type.not.toEqual(getSize());
   72 | 
-> 73 |     expect({ height: 14, width: 25 }).type.not.toEqual(getSize());
-     |                                                ^
+  73 |     expect({ height: 14, width: 25 }).type.not.toEqual(getSize());
+     |                                                ~~~~~~~
   74 |   });
   75 | });
   76 | 

--- a/tests/__snapshots__/api-toHaveProperty-stderr.snap.txt
+++ b/tests/__snapshots__/api-toHaveProperty-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Property 'runTest' exists on type 'Worker<Sample>'.
 
   48 |     expect<Worker<Sample>>().type.toHaveProperty("runTest");
   49 | 
-> 50 |     expect<Worker<Sample>>().type.not.toHaveProperty("runTest");
-     |                                       ^
+  50 |     expect<Worker<Sample>>().type.not.toHaveProperty("runTest");
+     |                                       ~~~~~~~~~~~~~~
   51 |   });
   52 | 
   53 |   test("has expected optional string property key", () => {
@@ -14,8 +14,8 @@ Error: Property 'isBusy' exists on type 'Worker<Sample>'.
 
   54 |     expect<Worker<Sample>>().type.toHaveProperty("isBusy");
   55 | 
-> 56 |     expect<Worker<Sample>>().type.not.toHaveProperty("isBusy");
-     |                                       ^
+  56 |     expect<Worker<Sample>>().type.not.toHaveProperty("isBusy");
+     |                                       ~~~~~~~~~~~~~~
   57 |   });
   58 | 
   59 |   test("has expected escaped string property key", () => {
@@ -26,8 +26,8 @@ Error: Property '__check' exists on type 'Worker<Sample>'.
 
   60 |     expect<Worker<Sample>>().type.toHaveProperty("__check");
   61 | 
-> 62 |     expect<Worker<Sample>>().type.not.toHaveProperty("__check");
-     |                                       ^
+  62 |     expect<Worker<Sample>>().type.not.toHaveProperty("__check");
+     |                                       ~~~~~~~~~~~~~~
   63 |   });
   64 | 
   65 |   test("does NOT have expected string property key", () => {
@@ -38,8 +38,8 @@ Error: Property 'endTest' does not exist on type 'Worker<Sample>'.
 
   66 |     expect<Worker<Sample>>().type.not.toHaveProperty("endTest");
   67 | 
-> 68 |     expect<Worker<Sample>>().type.toHaveProperty("endTest");
-     |                                   ^
+  68 |     expect<Worker<Sample>>().type.toHaveProperty("endTest");
+     |                                   ~~~~~~~~~~~~~~
   69 |   });
   70 | 
   71 |   test("has expected number property key", () => {
@@ -50,8 +50,8 @@ Error: Property '123' exists on type 'Worker<Sample>'.
 
   72 |     expect<Worker<Sample>>().type.toHaveProperty(123);
   73 | 
-> 74 |     expect<Worker<Sample>>().type.not.toHaveProperty(123);
-     |                                       ^
+  74 |     expect<Worker<Sample>>().type.not.toHaveProperty(123);
+     |                                       ~~~~~~~~~~~~~~
   75 |   });
   76 | 
   77 |   test("has expected optional number property key", () => {
@@ -62,8 +62,8 @@ Error: Property '789' exists on type 'Worker<Sample>'.
 
   78 |     expect<Worker<Sample>>().type.toHaveProperty(789);
   79 | 
-> 80 |     expect<Worker<Sample>>().type.not.toHaveProperty(789);
-     |                                       ^
+  80 |     expect<Worker<Sample>>().type.not.toHaveProperty(789);
+     |                                       ~~~~~~~~~~~~~~
   81 |   });
   82 | 
   83 |   test("does NOT have expected number property key", () => {
@@ -74,8 +74,8 @@ Error: Property '456' does not exist on type 'Worker<Sample>'.
 
   84 |     expect<Worker<Sample>>().type.not.toHaveProperty(456);
   85 | 
-> 86 |     expect<Worker<Sample>>().type.toHaveProperty(456);
-     |                                   ^
+  86 |     expect<Worker<Sample>>().type.toHaveProperty(456);
+     |                                   ~~~~~~~~~~~~~~
   87 |   });
   88 | 
   89 |   test("has expected symbol property key", () => {
@@ -86,8 +86,8 @@ Error: Property '[kOne]' exists on type 'Worker<Sample>'.
 
   90 |     expect<Worker<Sample>>().type.toHaveProperty(kOne);
   91 | 
-> 92 |     expect<Worker<Sample>>().type.not.toHaveProperty(kOne);
-     |                                       ^
+  92 |     expect<Worker<Sample>>().type.not.toHaveProperty(kOne);
+     |                                       ~~~~~~~~~~~~~~
   93 |   });
   94 | 
   95 |   test("has expected global symbol property key", () => {
@@ -98,8 +98,8 @@ Error: Property '[kTwo]' exists on type 'Worker<Sample>'.
 
    96 |     expect<Worker<Sample>>().type.toHaveProperty(kTwo);
    97 | 
->  98 |     expect<Worker<Sample>>().type.not.toHaveProperty(kTwo);
-      |                                       ^
+   98 |     expect<Worker<Sample>>().type.not.toHaveProperty(kTwo);
+      |                                       ~~~~~~~~~~~~~~
    99 |   });
   100 | 
   101 |   test("does NOT have expected symbol property key", () => {
@@ -110,8 +110,8 @@ Error: Property '[kFour]' does not exist on type 'Worker<Sample>'.
 
   102 |     expect<Worker<Sample>>().type.not.toHaveProperty(kFour);
   103 | 
-> 104 |     expect<Worker<Sample>>().type.toHaveProperty(kFour);
-      |                                   ^
+  104 |     expect<Worker<Sample>>().type.toHaveProperty(kFour);
+      |                                   ~~~~~~~~~~~~~~
   105 |   });
   106 | 
   107 |   test("has expected numeric enum property key", () => {
@@ -122,8 +122,8 @@ Error: Property '0' exists on type 'Worker<Sample>'.
 
   108 |     expect<Worker<Sample>>().type.toHaveProperty(E1.A);
   109 | 
-> 110 |     expect<Worker<Sample>>().type.not.toHaveProperty(E1.A);
-      |                                       ^
+  110 |     expect<Worker<Sample>>().type.not.toHaveProperty(E1.A);
+      |                                       ~~~~~~~~~~~~~~
   111 |   });
   112 | 
   113 |   test("does NOT have expected numeric enum property key", () => {
@@ -134,8 +134,8 @@ Error: Property '1' does not exist on type 'Worker<Sample>'.
 
   114 |     expect<Worker<Sample>>().type.not.toHaveProperty(E1.B);
   115 | 
-> 116 |     expect<Worker<Sample>>().type.toHaveProperty(E1.B);
-      |                                   ^
+  116 |     expect<Worker<Sample>>().type.toHaveProperty(E1.B);
+      |                                   ~~~~~~~~~~~~~~
   117 |   });
   118 | 
   119 |   test("has expected string enum property key", () => {
@@ -146,8 +146,8 @@ Error: Property 'B' exists on type 'Worker<Sample>'.
 
   120 |     expect<Worker<Sample>>().type.toHaveProperty(E2.B);
   121 | 
-> 122 |     expect<Worker<Sample>>().type.not.toHaveProperty(E2.B);
-      |                                       ^
+  122 |     expect<Worker<Sample>>().type.not.toHaveProperty(E2.B);
+      |                                       ~~~~~~~~~~~~~~
   123 |   });
   124 | 
   125 |   test("does NOT have expected string enum property key", () => {
@@ -158,8 +158,8 @@ Error: Property 'A' does not exist on type 'Worker<Sample>'.
 
   126 |     expect<Worker<Sample>>().type.not.toHaveProperty(E2.A);
   127 | 
-> 128 |     expect<Worker<Sample>>().type.toHaveProperty(E2.A);
-      |                                   ^
+  128 |     expect<Worker<Sample>>().type.toHaveProperty(E2.A);
+      |                                   ~~~~~~~~~~~~~~
   129 |   });
   130 | });
   131 | 
@@ -170,8 +170,8 @@ Error: Property 'A' exists on type 'typeof E1'.
 
   134 |     expect<typeof E1>().type.toHaveProperty("A");
   135 | 
-> 136 |     expect<typeof E1>().type.not.toHaveProperty("A");
-      |                                  ^
+  136 |     expect<typeof E1>().type.not.toHaveProperty("A");
+      |                                  ~~~~~~~~~~~~~~
   137 |   });
   138 | 
   139 |   test("does NOT have expected property key", () => {
@@ -182,8 +182,8 @@ Error: Property 'F' does not exist on type 'typeof E1'.
 
   140 |     expect<typeof E1>().type.not.toHaveProperty("F");
   141 | 
-> 142 |     expect<typeof E1>().type.toHaveProperty("F");
-      |                              ^
+  142 |     expect<typeof E1>().type.toHaveProperty("F");
+      |                              ~~~~~~~~~~~~~~
   143 |   });
   144 | });
   145 | 
@@ -194,8 +194,8 @@ Error: Property 'radius' exists on type 'ColorfulCircle'.
 
   158 |     expect<ColorfulCircle>().type.toHaveProperty("radius");
   159 | 
-> 160 |     expect<ColorfulCircle>().type.not.toHaveProperty("radius");
-      |                                       ^
+  160 |     expect<ColorfulCircle>().type.not.toHaveProperty("radius");
+      |                                       ~~~~~~~~~~~~~~
   161 |   });
   162 | 
   163 |   test("does NOT have expected property key", () => {
@@ -206,8 +206,8 @@ Error: Property 'shade' does not exist on type 'ColorfulCircle'.
 
   164 |     expect<ColorfulCircle>().type.not.toHaveProperty("shade");
   165 | 
-> 166 |     expect<ColorfulCircle>().type.toHaveProperty("shade");
-      |                                   ^
+  166 |     expect<ColorfulCircle>().type.toHaveProperty("shade");
+      |                                   ~~~~~~~~~~~~~~
   167 |   });
   168 | });
   169 | 
@@ -218,8 +218,8 @@ Error: Property 'runTest' exists on type '{ 123: number; 0: boolean; B: null; __
 
   172 |     expect(sample).type.toHaveProperty("runTest");
   173 | 
-> 174 |     expect(sample).type.not.toHaveProperty("runTest");
-      |                             ^
+  174 |     expect(sample).type.not.toHaveProperty("runTest");
+      |                             ~~~~~~~~~~~~~~
   175 |   });
   176 | 
   177 |   test("has expected escaped string property key", () => {
@@ -230,8 +230,8 @@ Error: Property '__check' exists on type '{ 123: number; 0: boolean; B: null; __
 
   178 |     expect(sample).type.toHaveProperty("__check");
   179 | 
-> 180 |     expect(sample).type.not.toHaveProperty("__check");
-      |                             ^
+  180 |     expect(sample).type.not.toHaveProperty("__check");
+      |                             ~~~~~~~~~~~~~~
   181 |   });
   182 | 
   183 |   test("does NOT have expected string property key", () => {
@@ -242,8 +242,8 @@ Error: Property 'endTest' does not exist on type '{ 123: number; 0: boolean; B: 
 
   184 |     expect(sample).type.not.toHaveProperty("endTest");
   185 | 
-> 186 |     expect(sample).type.toHaveProperty("endTest");
-      |                         ^
+  186 |     expect(sample).type.toHaveProperty("endTest");
+      |                         ~~~~~~~~~~~~~~
   187 |   });
   188 | 
   189 |   test("has expected number property key", () => {
@@ -254,8 +254,8 @@ Error: Property '123' exists on type '{ 123: number; 0: boolean; B: null; __chec
 
   190 |     expect(sample).type.toHaveProperty(123);
   191 | 
-> 192 |     expect(sample).type.not.toHaveProperty(123);
-      |                             ^
+  192 |     expect(sample).type.not.toHaveProperty(123);
+      |                             ~~~~~~~~~~~~~~
   193 |   });
   194 | 
   195 |   test("does NOT have expected number property key", () => {
@@ -266,8 +266,8 @@ Error: Property '456' does not exist on type '{ 123: number; 0: boolean; B: null
 
   196 |     expect(sample).type.not.toHaveProperty(456);
   197 | 
-> 198 |     expect(sample).type.toHaveProperty(456);
-      |                         ^
+  198 |     expect(sample).type.toHaveProperty(456);
+      |                         ~~~~~~~~~~~~~~
   199 |   });
   200 | 
   201 |   test("has expected symbol property key", () => {
@@ -278,8 +278,8 @@ Error: Property '[kOne]' exists on type '{ 123: number; 0: boolean; B: null; __c
 
   202 |     expect(sample).type.toHaveProperty(kOne);
   203 | 
-> 204 |     expect(sample).type.not.toHaveProperty(kOne);
-      |                             ^
+  204 |     expect(sample).type.not.toHaveProperty(kOne);
+      |                             ~~~~~~~~~~~~~~
   205 |   });
   206 | 
   207 |   test("has expected global symbol property key", () => {
@@ -290,8 +290,8 @@ Error: Property '[kTwo]' exists on type '{ 123: number; 0: boolean; B: null; __c
 
   208 |     expect(sample).type.toHaveProperty(kTwo);
   209 | 
-> 210 |     expect(sample).type.not.toHaveProperty(kTwo);
-      |                             ^
+  210 |     expect(sample).type.not.toHaveProperty(kTwo);
+      |                             ~~~~~~~~~~~~~~
   211 |   });
   212 | 
   213 |   test("does NOT have expected symbol property key", () => {
@@ -302,8 +302,8 @@ Error: Property '[kFour]' does not exist on type '{ 123: number; 0: boolean; B: 
 
   214 |     expect(sample).type.not.toHaveProperty(kFour);
   215 | 
-> 216 |     expect(sample).type.toHaveProperty(kFour);
-      |                         ^
+  216 |     expect(sample).type.toHaveProperty(kFour);
+      |                         ~~~~~~~~~~~~~~
   217 |   });
   218 | 
   219 |   test("has expected numeric enum property key", () => {
@@ -314,8 +314,8 @@ Error: Property '0' exists on type '{ 123: number; 0: boolean; B: null; __check:
 
   220 |     expect(sample).type.toHaveProperty(E1.A);
   221 | 
-> 222 |     expect(sample).type.not.toHaveProperty(E1.A);
-      |                             ^
+  222 |     expect(sample).type.not.toHaveProperty(E1.A);
+      |                             ~~~~~~~~~~~~~~
   223 |   });
   224 | 
   225 |   test("does NOT have expected numeric enum property key", () => {
@@ -326,8 +326,8 @@ Error: Property '1' does not exist on type '{ 123: number; 0: boolean; B: null; 
 
   226 |     expect(sample).type.not.toHaveProperty(E1.B);
   227 | 
-> 228 |     expect(sample).type.toHaveProperty(E1.B);
-      |                         ^
+  228 |     expect(sample).type.toHaveProperty(E1.B);
+      |                         ~~~~~~~~~~~~~~
   229 |   });
   230 | 
   231 |   test("has expected string enum property key", () => {
@@ -338,8 +338,8 @@ Error: Property 'B' exists on type '{ 123: number; 0: boolean; B: null; __check:
 
   232 |     expect(sample).type.toHaveProperty(E2.B);
   233 | 
-> 234 |     expect(sample).type.not.toHaveProperty(E2.B);
-      |                             ^
+  234 |     expect(sample).type.not.toHaveProperty(E2.B);
+      |                             ~~~~~~~~~~~~~~
   235 |   });
   236 | 
   237 |   test("does NOT have expected string enum property key", () => {
@@ -350,8 +350,8 @@ Error: Property 'A' does not exist on type '{ 123: number; 0: boolean; B: null; 
 
   238 |     expect(sample).type.not.toHaveProperty(E2.A);
   239 | 
-> 240 |     expect(sample).type.toHaveProperty(E2.A);
-      |                         ^
+  240 |     expect(sample).type.toHaveProperty(E2.A);
+      |                         ~~~~~~~~~~~~~~
   241 |   });
   242 | });
   243 | 

--- a/tests/__snapshots__/api-toMatch-stderr.snap.txt
+++ b/tests/__snapshots__/api-toMatch-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Type '{ a: string; b?: number | undefined; }' does not match type '{ b: n
 
   47 |     expect<{ a: string; b?: number }>().type.toMatch<{ b?: number }>();
   48 | 
-> 49 |     expect<{ a: string; b?: number }>().type.toMatch<{ b: number }>();
-     |                                              ^
+  49 |     expect<{ a: string; b?: number }>().type.toMatch<{ b: number }>();
+     |                                              ~~~~~~~
   50 |   });
   51 | 
   52 |   test("does NOT match expected type", () => {
@@ -14,8 +14,8 @@ Error: Type '{ a: string; }' does not match type '{ a: string; b?: number | unde
 
   56 |     expect<{ a: string }>().type.not.toMatch<{ a: string; b?: number }>();
   57 | 
-> 58 |     expect<{ a: string }>().type.toMatch<{ a: string; b?: number }>();
-     |                                  ^
+  58 |     expect<{ a: string }>().type.toMatch<{ a: string; b?: number }>();
+     |                                  ~~~~~~~
   59 |   });
   60 | 
   61 |   test("matches expected value", () => {
@@ -26,8 +26,8 @@ Error: Type '{ first: string; }' does not match type 'Names'.
 
   63 |     expect<{ first: string; last?: string }>().type.toMatch(getNames());
   64 | 
-> 65 |     expect<{ first: string }>().type.toMatch(getNames());
-     |                                      ^
+  65 |     expect<{ first: string }>().type.toMatch(getNames());
+     |                                      ~~~~~~~
   66 |   });
   67 | 
   68 |   test("does NOT match expected value", () => {
@@ -38,8 +38,8 @@ Error: Type '{ first?: string | undefined; }' does not match type 'Names'.
 
   69 |     expect<{ first?: string }>().type.not.toMatch(getNames());
   70 | 
-> 71 |     expect<{ first?: string }>().type.toMatch(getNames());
-     |                                       ^
+  71 |     expect<{ first?: string }>().type.toMatch(getNames());
+     |                                       ~~~~~~~
   72 |   });
   73 | });
   74 | 
@@ -50,8 +50,8 @@ Error: Type 'Names' does not match type '{ last: string; }'.
 
   82 |     expect(getNames()).type.toMatch<{ last?: string }>();
   83 | 
-> 84 |     expect(getNames()).type.toMatch<{ last: string }>();
-     |                             ^
+  84 |     expect(getNames()).type.toMatch<{ last: string }>();
+     |                             ~~~~~~~
   85 |   });
   86 | 
   87 |   test("does NOT match expected type", () => {
@@ -62,8 +62,8 @@ Error: Type 'Names' does not match type '{ last: string; }'.
 
   89 | 
   90 |     expect(getNames()).type.not.toMatch<{ last: string }>();
-> 91 |     expect(getNames()).type.toMatch<{ last: string }>();
-     |                             ^
+  91 |     expect(getNames()).type.toMatch<{ last: string }>();
+     |                             ~~~~~~~
   92 |   });
   93 | 
   94 |   test("matches expected value", () => {
@@ -74,8 +74,8 @@ Error: Type '{ last: string; }' does not match type 'Names'.
 
    98 |     expect({ first: "One", last: "Two" }).type.toMatch(getNames());
    99 | 
-> 100 |     expect({ last: "Two" }).type.toMatch(getNames());
-      |                                  ^
+  100 |     expect({ last: "Two" }).type.toMatch(getNames());
+      |                                  ~~~~~~~
   101 |   });
   102 | 
   103 |   test("does NOT match expected value", () => {
@@ -86,8 +86,8 @@ Error: Type '{ first: string; }' does match type 'Names'.
 
   104 |     expect({ last: "Two" }).type.not.toMatch(getNames());
   105 | 
-> 106 |     expect({ first: "One" }).type.not.toMatch(getNames());
-      |                                       ^
+  106 |     expect({ first: "One" }).type.not.toMatch(getNames());
+      |                                       ~~~~~~~
   107 |   });
   108 | });
   109 | 

--- a/tests/__snapshots__/api-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/api-toRaiseError-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Expression raised a type error.
 
    6 | test("expression raises a type error", () => {
    7 |   expect(one("pass")).type.toRaiseError();
->  8 |   expect(one("fail")).type.not.toRaiseError();
-     |                                ^
+   8 |   expect(one("fail")).type.not.toRaiseError();
+     |                                ~~~~~~~~~~~~
    9 | });
   10 | 
   11 | test("expression does not raise a type error", () => {
@@ -16,8 +16,8 @@ Error: Expression raised a type error.
 
        6 | test("expression raises a type error", () => {
        7 |   expect(one("pass")).type.toRaiseError();
-    >  8 |   expect(one("fail")).type.not.toRaiseError();
-         |              ^
+       8 |   expect(one("fail")).type.not.toRaiseError();
+         |              ~~~~~~
        9 | });
       10 | 
       11 | test("expression does not raise a type error", () => {
@@ -28,8 +28,8 @@ Error: Expression did not raise a type error.
 
   11 | test("expression does not raise a type error", () => {
   12 |   expect(one()).type.not.toRaiseError();
-> 13 |   expect(one()).type.toRaiseError();
-     |                      ^
+  13 |   expect(one()).type.toRaiseError();
+     |                      ~~~~~~~~~~~~
   14 | });
   15 | 
   16 | test("type expression raises a type error", () => {
@@ -40,8 +40,8 @@ Error: Type expression raised a type error.
 
   16 | test("type expression raises a type error", () => {
   17 |   expect<One>().type.toRaiseError();
-> 18 |   expect<One>().type.not.toRaiseError();
-     |                          ^
+  18 |   expect<One>().type.not.toRaiseError();
+     |                          ~~~~~~~~~~~~
   19 | });
   20 | 
   21 | test("type expression does not raise a type error", () => {
@@ -54,8 +54,8 @@ Error: Type expression raised a type error.
 
       16 | test("type expression raises a type error", () => {
       17 |   expect<One>().type.toRaiseError();
-    > 18 |   expect<One>().type.not.toRaiseError();
-         |          ^
+      18 |   expect<One>().type.not.toRaiseError();
+         |          ~~~
       19 | });
       20 | 
       21 | test("type expression does not raise a type error", () => {
@@ -66,8 +66,8 @@ Error: Type expression did not raise a type error.
 
   21 | test("type expression does not raise a type error", () => {
   22 |   expect<One<string>>().type.not.toRaiseError();
-> 23 |   expect<One<string>>().type.toRaiseError();
-     |                              ^
+  23 |   expect<One<string>>().type.toRaiseError();
+     |                              ~~~~~~~~~~~~
   24 | });
   25 | 
   26 | test("expression raises multiple type errors", () => {
@@ -78,8 +78,8 @@ Error: Expression raised 3 type errors.
 
   34 |     one("2");
   35 |     one("3");
-> 36 |   }).type.not.toRaiseError();
-     |               ^
+  36 |   }).type.not.toRaiseError();
+     |               ~~~~~~~~~~~~
   37 | });
   38 | 
   39 | test("expression raises a type error with matching message", () => {
@@ -92,8 +92,8 @@ Error: Expression raised 3 type errors.
 
       31 |   }).type.toRaiseError();
       32 |   expect(() => {
-    > 33 |     one("1");
-         |         ^
+      33 |     one("1");
+         |         ~~~
       34 |     one("2");
       35 |     one("3");
       36 |   }).type.not.toRaiseError();
@@ -104,8 +104,8 @@ Error: Expression raised 3 type errors.
 
       32 |   expect(() => {
       33 |     one("1");
-    > 34 |     one("2");
-         |         ^
+      34 |     one("2");
+         |         ~~~
       35 |     one("3");
       36 |   }).type.not.toRaiseError();
       37 | });
@@ -116,8 +116,8 @@ Error: Expression raised 3 type errors.
 
       33 |     one("1");
       34 |     one("2");
-    > 35 |     one("3");
-         |         ^
+      35 |     one("3");
+         |         ~~~
       36 |   }).type.not.toRaiseError();
       37 | });
       38 | 
@@ -128,8 +128,8 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
   39 | test("expression raises a type error with matching message", () => {
   40 |   expect(one("pass")).type.toRaiseError("Expected 0 arguments");
-> 41 |   expect(one("fail")).type.not.toRaiseError("Expected 0 arguments");
-     |                                ^
+  41 |   expect(one("fail")).type.not.toRaiseError("Expected 0 arguments");
+     |                                ~~~~~~~~~~~~
   42 | });
   43 | 
   44 | test("expression raises a type error with matching message passed as a template literal", () => {
@@ -142,8 +142,8 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
       39 | test("expression raises a type error with matching message", () => {
       40 |   expect(one("pass")).type.toRaiseError("Expected 0 arguments");
-    > 41 |   expect(one("fail")).type.not.toRaiseError("Expected 0 arguments");
-         |              ^
+      41 |   expect(one("fail")).type.not.toRaiseError("Expected 0 arguments");
+         |              ~~~~~~
       42 | });
       43 | 
       44 | test("expression raises a type error with matching message passed as a template literal", () => {
@@ -154,8 +154,8 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
   44 | test("expression raises a type error with matching message passed as a template literal", () => {
   45 |   expect(one("pass")).type.toRaiseError(`Expected 0 arguments`);
-> 46 |   expect(one("fail")).type.not.toRaiseError(`Expected 0 arguments`);
-     |                                ^
+  46 |   expect(one("fail")).type.not.toRaiseError(`Expected 0 arguments`);
+     |                                ~~~~~~~~~~~~
   47 | });
   48 | 
   49 | test("expression raises type error with not matching message", () => {
@@ -168,8 +168,8 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
       44 | test("expression raises a type error with matching message passed as a template literal", () => {
       45 |   expect(one("pass")).type.toRaiseError(`Expected 0 arguments`);
-    > 46 |   expect(one("fail")).type.not.toRaiseError(`Expected 0 arguments`);
-         |              ^
+      46 |   expect(one("fail")).type.not.toRaiseError(`Expected 0 arguments`);
+         |              ~~~~~~
       47 | });
       48 | 
       49 | test("expression raises type error with not matching message", () => {
@@ -180,8 +180,8 @@ Error: Expression did not raise a type error matching substring 'Expected 2 argu
 
   49 | test("expression raises type error with not matching message", () => {
   50 |   expect(one("pass")).type.not.toRaiseError("Expected 2 arguments");
-> 51 |   expect(one("fail")).type.toRaiseError("Expected 2 arguments");
-     |                            ^
+  51 |   expect(one("fail")).type.toRaiseError("Expected 2 arguments");
+     |                            ~~~~~~~~~~~~
   52 | });
   53 | 
   54 | test("type expression raises a type error with matching message", () => {
@@ -194,8 +194,8 @@ Error: Expression did not raise a type error matching substring 'Expected 2 argu
 
       49 | test("expression raises type error with not matching message", () => {
       50 |   expect(one("pass")).type.not.toRaiseError("Expected 2 arguments");
-    > 51 |   expect(one("fail")).type.toRaiseError("Expected 2 arguments");
-         |              ^
+      51 |   expect(one("fail")).type.toRaiseError("Expected 2 arguments");
+         |              ~~~~~~
       52 | });
       53 | 
       54 | test("type expression raises a type error with matching message", () => {
@@ -206,8 +206,8 @@ Error: Type expression raised a type error matching substring 'requires 1 type a
 
   54 | test("type expression raises a type error with matching message", () => {
   55 |   expect<One>().type.toRaiseError("requires 1 type argument");
-> 56 |   expect<One>().type.not.toRaiseError("requires 1 type argument");
-     |                          ^
+  56 |   expect<One>().type.not.toRaiseError("requires 1 type argument");
+     |                          ~~~~~~~~~~~~
   57 | });
   58 | 
   59 | test("type expression raises a type error with matching message passed as a template literal", () => {
@@ -220,8 +220,8 @@ Error: Type expression raised a type error matching substring 'requires 1 type a
 
       54 | test("type expression raises a type error with matching message", () => {
       55 |   expect<One>().type.toRaiseError("requires 1 type argument");
-    > 56 |   expect<One>().type.not.toRaiseError("requires 1 type argument");
-         |          ^
+      56 |   expect<One>().type.not.toRaiseError("requires 1 type argument");
+         |          ~~~
       57 | });
       58 | 
       59 | test("type expression raises a type error with matching message passed as a template literal", () => {
@@ -232,8 +232,8 @@ Error: Type expression raised a type error matching substring 'requires 1 type a
 
   59 | test("type expression raises a type error with matching message passed as a template literal", () => {
   60 |   expect<One>().type.toRaiseError(`requires 1 type argument`);
-> 61 |   expect<One>().type.not.toRaiseError(`requires 1 type argument`);
-     |                          ^
+  61 |   expect<One>().type.not.toRaiseError(`requires 1 type argument`);
+     |                          ~~~~~~~~~~~~
   62 | });
   63 | 
   64 | test("type expression raises a type error with not matching message", () => {
@@ -246,8 +246,8 @@ Error: Type expression raised a type error matching substring 'requires 1 type a
 
       59 | test("type expression raises a type error with matching message passed as a template literal", () => {
       60 |   expect<One>().type.toRaiseError(`requires 1 type argument`);
-    > 61 |   expect<One>().type.not.toRaiseError(`requires 1 type argument`);
-         |          ^
+      61 |   expect<One>().type.not.toRaiseError(`requires 1 type argument`);
+         |          ~~~
       62 | });
       63 | 
       64 | test("type expression raises a type error with not matching message", () => {
@@ -258,8 +258,8 @@ Error: Type expression did not raise a type error matching substring 'requires t
 
   64 | test("type expression raises a type error with not matching message", () => {
   65 |   expect<One>().type.not.toRaiseError("requires type argument");
-> 66 |   expect<One>().type.toRaiseError("requires type argument");
-     |                      ^
+  66 |   expect<One>().type.toRaiseError("requires type argument");
+     |                      ~~~~~~~~~~~~
   67 | });
   68 | 
   69 | test("expression raises a type error with expected code", () => {
@@ -272,8 +272,8 @@ Error: Type expression did not raise a type error matching substring 'requires t
 
       64 | test("type expression raises a type error with not matching message", () => {
       65 |   expect<One>().type.not.toRaiseError("requires type argument");
-    > 66 |   expect<One>().type.toRaiseError("requires type argument");
-         |          ^
+      66 |   expect<One>().type.toRaiseError("requires type argument");
+         |          ~~~
       67 | });
       68 | 
       69 | test("expression raises a type error with expected code", () => {
@@ -284,8 +284,8 @@ Error: Expression raised a type error with code 2554.
 
   69 | test("expression raises a type error with expected code", () => {
   70 |   expect(one("pass")).type.toRaiseError(2554);
-> 71 |   expect(one("fail")).type.not.toRaiseError(2554);
-     |                                ^
+  71 |   expect(one("fail")).type.not.toRaiseError(2554);
+     |                                ~~~~~~~~~~~~
   72 | });
   73 | 
   74 | test("expression raises a type error with not expected code", () => {
@@ -298,8 +298,8 @@ Error: Expression raised a type error with code 2554.
 
       69 | test("expression raises a type error with expected code", () => {
       70 |   expect(one("pass")).type.toRaiseError(2554);
-    > 71 |   expect(one("fail")).type.not.toRaiseError(2554);
-         |              ^
+      71 |   expect(one("fail")).type.not.toRaiseError(2554);
+         |              ~~~~~~
       72 | });
       73 | 
       74 | test("expression raises a type error with not expected code", () => {
@@ -310,8 +310,8 @@ Error: Expression did not raise a type error with code 2544.
 
   74 | test("expression raises a type error with not expected code", () => {
   75 |   expect(one("pass")).type.not.toRaiseError(2544);
-> 76 |   expect(one("fail")).type.toRaiseError(2544);
-     |                            ^
+  76 |   expect(one("fail")).type.toRaiseError(2544);
+     |                            ~~~~~~~~~~~~
   77 | });
   78 | 
   79 | declare function two<T>(): void;
@@ -324,8 +324,8 @@ Error: Expression did not raise a type error with code 2544.
 
       74 | test("expression raises a type error with not expected code", () => {
       75 |   expect(one("pass")).type.not.toRaiseError(2544);
-    > 76 |   expect(one("fail")).type.toRaiseError(2544);
-         |              ^
+      76 |   expect(one("fail")).type.toRaiseError(2544);
+         |              ~~~~~~
       77 | });
       78 | 
       79 | declare function two<T>(): void;
@@ -336,8 +336,8 @@ Error: Expression raised a type error matching substring 'Argument of type 'numb
 
   92 |     two(1000);
   93 |     two<string>("fail");
-> 94 |   }).type.not.toRaiseError(
-     |               ^
+  94 |   }).type.not.toRaiseError(
+     |               ~~~~~~~~~~~~
   95 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
   96 |     "Expected 0 arguments",
   97 |   );
@@ -350,8 +350,8 @@ Error: Expression raised a type error matching substring 'Argument of type 'numb
 
       90 | 
       91 |   expect(() => {
-    > 92 |     two(1000);
-         |         ^
+      92 |     two(1000);
+         |         ~~~~
       93 |     two<string>("fail");
       94 |   }).type.not.toRaiseError(
       95 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
@@ -362,8 +362,8 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
   92 |     two(1000);
   93 |     two<string>("fail");
-> 94 |   }).type.not.toRaiseError(
-     |               ^
+  94 |   }).type.not.toRaiseError(
+     |               ~~~~~~~~~~~~
   95 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
   96 |     "Expected 0 arguments",
   97 |   );
@@ -376,8 +376,8 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
       91 |   expect(() => {
       92 |     two(1000);
-    > 93 |     two<string>("fail");
-         |                 ^
+      93 |     two<string>("fail");
+         |                 ~~~~~~
       94 |   }).type.not.toRaiseError(
       95 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
       96 |     "Expected 0 arguments",
@@ -388,8 +388,8 @@ Error: Expression did not raise a type error matching substring 'Expected 0 argu
 
   110 |     two(1000);
   111 |     two<string>("fail");
-> 112 |   }).type.toRaiseError(
-      |           ^
+  112 |   }).type.toRaiseError(
+      |           ~~~~~~~~~~~~
   113 |     "Expected 0 arguments",
   114 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
   115 |   );
@@ -402,8 +402,8 @@ Error: Expression did not raise a type error matching substring 'Expected 0 argu
 
       108 | 
       109 |   expect(() => {
-    > 110 |     two(1000);
-          |         ^
+      110 |     two(1000);
+          |         ~~~~
       111 |     two<string>("fail");
       112 |   }).type.toRaiseError(
       113 |     "Expected 0 arguments",
@@ -414,8 +414,8 @@ Error: Expression did not raise a type error matching substring 'Argument of typ
 
   110 |     two(1000);
   111 |     two<string>("fail");
-> 112 |   }).type.toRaiseError(
-      |           ^
+  112 |   }).type.toRaiseError(
+      |           ~~~~~~~~~~~~
   113 |     "Expected 0 arguments",
   114 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
   115 |   );
@@ -428,8 +428,8 @@ Error: Expression did not raise a type error matching substring 'Argument of typ
 
       109 |   expect(() => {
       110 |     two(1000);
-    > 111 |     two<string>("fail");
-          |                 ^
+      111 |     two<string>("fail");
+          |                 ~~~~~~
       112 |   }).type.toRaiseError(
       113 |     "Expected 0 arguments",
       114 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
@@ -440,8 +440,8 @@ Error: Expression raised a type error with code 2345.
 
   125 |     two(1000);
   126 |     two<string>("fail");
-> 127 |   }).type.not.toRaiseError(2345, 2554);
-      |               ^
+  127 |   }).type.not.toRaiseError(2345, 2554);
+      |               ~~~~~~~~~~~~
   128 | });
   129 | 
   130 | test("expression raises multiple type errors with not expected codes", () => {
@@ -454,8 +454,8 @@ Error: Expression raised a type error with code 2345.
 
       123 | 
       124 |   expect(() => {
-    > 125 |     two(1000);
-          |         ^
+      125 |     two(1000);
+          |         ~~~~
       126 |     two<string>("fail");
       127 |   }).type.not.toRaiseError(2345, 2554);
       128 | });
@@ -466,8 +466,8 @@ Error: Expression raised a type error with code 2554.
 
   125 |     two(1000);
   126 |     two<string>("fail");
-> 127 |   }).type.not.toRaiseError(2345, 2554);
-      |               ^
+  127 |   }).type.not.toRaiseError(2345, 2554);
+      |               ~~~~~~~~~~~~
   128 | });
   129 | 
   130 | test("expression raises multiple type errors with not expected codes", () => {
@@ -480,8 +480,8 @@ Error: Expression raised a type error with code 2554.
 
       124 |   expect(() => {
       125 |     two(1000);
-    > 126 |     two<string>("fail");
-          |                 ^
+      126 |     two<string>("fail");
+          |                 ~~~~~~
       127 |   }).type.not.toRaiseError(2345, 2554);
       128 | });
       129 | 
@@ -492,8 +492,8 @@ Error: Expression did not raise a type error with code 2554.
 
   132 |     two(1111);
   133 |     two<string>("pass");
-> 134 |   }).type.toRaiseError(2554, 2345);
-      |           ^
+  134 |   }).type.toRaiseError(2554, 2345);
+      |           ~~~~~~~~~~~~
   135 | 
   136 |   expect(() => {
   137 |     two(1000);
@@ -506,8 +506,8 @@ Error: Expression did not raise a type error with code 2554.
 
       130 | test("expression raises multiple type errors with not expected codes", () => {
       131 |   expect(() => {
-    > 132 |     two(1111);
-          |         ^
+      132 |     two(1111);
+          |         ~~~~
       133 |     two<string>("pass");
       134 |   }).type.toRaiseError(2554, 2345);
       135 | 
@@ -518,8 +518,8 @@ Error: Expression did not raise a type error with code 2345.
 
   132 |     two(1111);
   133 |     two<string>("pass");
-> 134 |   }).type.toRaiseError(2554, 2345);
-      |           ^
+  134 |   }).type.toRaiseError(2554, 2345);
+      |           ~~~~~~~~~~~~
   135 | 
   136 |   expect(() => {
   137 |     two(1000);
@@ -532,8 +532,8 @@ Error: Expression did not raise a type error with code 2345.
 
       131 |   expect(() => {
       132 |     two(1111);
-    > 133 |     two<string>("pass");
-          |                 ^
+      133 |     two<string>("pass");
+          |                 ~~~~~~
       134 |   }).type.toRaiseError(2554, 2345);
       135 | 
       136 |   expect(() => {
@@ -544,8 +544,8 @@ Error: Expression raised a type error matching substring 'Argument of type 'numb
 
   149 |     two(1000);
   150 |     two<string>("fail");
-> 151 |   }).type.not.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'", 2554);
-      |               ^
+  151 |   }).type.not.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'", 2554);
+      |               ~~~~~~~~~~~~
   152 | });
   153 | 
   154 | test("expression raises multiple type errors with not matching messages and not expected codes", () => {
@@ -558,8 +558,8 @@ Error: Expression raised a type error matching substring 'Argument of type 'numb
 
       147 | 
       148 |   expect(() => {
-    > 149 |     two(1000);
-          |         ^
+      149 |     two(1000);
+          |         ~~~~
       150 |     two<string>("fail");
       151 |   }).type.not.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'", 2554);
       152 | });
@@ -570,8 +570,8 @@ Error: Expression raised a type error with code 2554.
 
   149 |     two(1000);
   150 |     two<string>("fail");
-> 151 |   }).type.not.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'", 2554);
-      |               ^
+  151 |   }).type.not.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'", 2554);
+      |               ~~~~~~~~~~~~
   152 | });
   153 | 
   154 | test("expression raises multiple type errors with not matching messages and not expected codes", () => {
@@ -584,8 +584,8 @@ Error: Expression raised a type error with code 2554.
 
       148 |   expect(() => {
       149 |     two(1000);
-    > 150 |     two<string>("fail");
-          |                 ^
+      150 |     two<string>("fail");
+          |                 ~~~~~~
       151 |   }).type.not.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'", 2554);
       152 | });
       153 | 
@@ -596,8 +596,8 @@ Error: Expression did not raise a type error with code 2554.
 
   156 |     two(1111);
   157 |     two<string>("pass");
-> 158 |   }).type.toRaiseError(2554, "Argument of type 'number' is not assignable to parameter of type 'string'");
-      |           ^
+  158 |   }).type.toRaiseError(2554, "Argument of type 'number' is not assignable to parameter of type 'string'");
+      |           ~~~~~~~~~~~~
   159 | 
   160 |   expect(() => {
   161 |     two(1000);
@@ -610,8 +610,8 @@ Error: Expression did not raise a type error with code 2554.
 
       154 | test("expression raises multiple type errors with not matching messages and not expected codes", () => {
       155 |   expect(() => {
-    > 156 |     two(1111);
-          |         ^
+      156 |     two(1111);
+          |         ~~~~
       157 |     two<string>("pass");
       158 |   }).type.toRaiseError(2554, "Argument of type 'number' is not assignable to parameter of type 'string'");
       159 | 
@@ -622,8 +622,8 @@ Error: Expression did not raise a type error matching substring 'Argument of typ
 
   156 |     two(1111);
   157 |     two<string>("pass");
-> 158 |   }).type.toRaiseError(2554, "Argument of type 'number' is not assignable to parameter of type 'string'");
-      |           ^
+  158 |   }).type.toRaiseError(2554, "Argument of type 'number' is not assignable to parameter of type 'string'");
+      |           ~~~~~~~~~~~~
   159 | 
   160 |   expect(() => {
   161 |     two(1000);
@@ -636,8 +636,8 @@ Error: Expression did not raise a type error matching substring 'Argument of typ
 
       155 |   expect(() => {
       156 |     two(1111);
-    > 157 |     two<string>("pass");
-          |                 ^
+      157 |     two<string>("pass");
+          |                 ~~~~~~
       158 |   }).type.toRaiseError(2554, "Argument of type 'number' is not assignable to parameter of type 'string'");
       159 | 
       160 |   expect(() => {
@@ -648,8 +648,8 @@ Error: Expected only 1 type error, but 2 were raised.
 
   168 |     two(1111);
   169 |     two<string>("pass");
-> 170 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
-      |           ^
+  170 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
+      |           ~~~~~~~~~~~~
   171 | });
   172 | 
   173 | test("expression raises more type errors than expected codes", () => {
@@ -662,8 +662,8 @@ Error: Expected only 1 type error, but 2 were raised.
 
       166 | test("expression raises more type errors than expected messages", () => {
       167 |   expect(() => {
-    > 168 |     two(1111);
-          |         ^
+      168 |     two(1111);
+          |         ~~~~
       169 |     two<string>("pass");
       170 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
       171 | });
@@ -674,8 +674,8 @@ Error: Expected only 1 type error, but 2 were raised.
 
       167 |   expect(() => {
       168 |     two(1111);
-    > 169 |     two<string>("pass");
-          |                 ^
+      169 |     two<string>("pass");
+          |                 ~~~~~~
       170 |   }).type.toRaiseError("Argument of type 'number' is not assignable to parameter of type 'string'");
       171 | });
       172 | 
@@ -686,8 +686,8 @@ Error: Expected only 1 type error, but 2 were raised.
 
   175 |     two(1111);
   176 |     two<string>("pass");
-> 177 |   }).type.toRaiseError(2345);
-      |           ^
+  177 |   }).type.toRaiseError(2345);
+      |           ~~~~~~~~~~~~
   178 | });
   179 | 
   180 | test("expression raises only one type error, but several messages are expected", () => {
@@ -700,8 +700,8 @@ Error: Expected only 1 type error, but 2 were raised.
 
       173 | test("expression raises more type errors than expected codes", () => {
       174 |   expect(() => {
-    > 175 |     two(1111);
-          |         ^
+      175 |     two(1111);
+          |         ~~~~
       176 |     two<string>("pass");
       177 |   }).type.toRaiseError(2345);
       178 | });
@@ -712,8 +712,8 @@ Error: Expected only 1 type error, but 2 were raised.
 
       174 |   expect(() => {
       175 |     two(1111);
-    > 176 |     two<string>("pass");
-          |                 ^
+      176 |     two<string>("pass");
+          |                 ~~~~~~
       177 |   }).type.toRaiseError(2345);
       178 | });
       179 | 
@@ -724,8 +724,8 @@ Error: Expected 3 type errors, but only 1 was raised.
 
   181 |   expect(() => {
   182 |     two(1111);
-> 183 |   }).type.toRaiseError(
-      |           ^
+  183 |   }).type.toRaiseError(
+      |           ~~~~~~~~~~~~
   184 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
   185 |     "Expected 0 arguments",
   186 |     "Expected 2 arguments",
@@ -738,8 +738,8 @@ Error: Expected 3 type errors, but only 1 was raised.
 
       180 | test("expression raises only one type error, but several messages are expected", () => {
       181 |   expect(() => {
-    > 182 |     two(1111);
-          |         ^
+      182 |     two(1111);
+          |         ~~~~
       183 |   }).type.toRaiseError(
       184 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
       185 |     "Expected 0 arguments",
@@ -750,8 +750,8 @@ Error: Expected 3 type errors, but only 2 were raised.
 
   192 |     two(1111);
   193 |     two<string>("pass");
-> 194 |   }).type.toRaiseError(
-      |           ^
+  194 |   }).type.toRaiseError(
+      |           ~~~~~~~~~~~~
   195 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
   196 |     "Expected 0 arguments",
   197 |     "Expected 2 arguments",
@@ -764,8 +764,8 @@ Error: Expected 3 type errors, but only 2 were raised.
 
       190 | test("expression raises less type errors than expected messages", () => {
       191 |   expect(() => {
-    > 192 |     two(1111);
-          |         ^
+      192 |     two(1111);
+          |         ~~~~
       193 |     two<string>("pass");
       194 |   }).type.toRaiseError(
       195 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
@@ -776,8 +776,8 @@ Error: Expected 3 type errors, but only 2 were raised.
 
       191 |   expect(() => {
       192 |     two(1111);
-    > 193 |     two<string>("pass");
-          |                 ^
+      193 |     two<string>("pass");
+          |                 ~~~~~~
       194 |   }).type.toRaiseError(
       195 |     "Argument of type 'number' is not assignable to parameter of type 'string'",
       196 |     "Expected 0 arguments",
@@ -788,8 +788,8 @@ Error: Expected 3 type errors, but only 1 was raised.
 
   202 |   expect(() => {
   203 |     two<string>("pass");
-> 204 |   }).type.toRaiseError(2345, 2554, 2554);
-      |           ^
+  204 |   }).type.toRaiseError(2345, 2554, 2554);
+      |           ~~~~~~~~~~~~
   205 | });
   206 | 
   207 | test("expression raises less type errors than expected codes", () => {
@@ -802,8 +802,8 @@ Error: Expected 3 type errors, but only 1 was raised.
 
       201 | test("expression raises only one type error, but several codes are expected", () => {
       202 |   expect(() => {
-    > 203 |     two<string>("pass");
-          |                 ^
+      203 |     two<string>("pass");
+          |                 ~~~~~~
       204 |   }).type.toRaiseError(2345, 2554, 2554);
       205 | });
       206 | 
@@ -814,8 +814,8 @@ Error: Expected 3 type errors, but only 2 were raised.
 
   209 |     two(1111);
   210 |     two<string>("pass");
-> 211 |   }).type.toRaiseError(2345, 2554, 2554);
-      |           ^
+  211 |   }).type.toRaiseError(2345, 2554, 2554);
+      |           ~~~~~~~~~~~~
   212 | });
   213 | 
 
@@ -827,8 +827,8 @@ Error: Expected 3 type errors, but only 2 were raised.
 
       207 | test("expression raises less type errors than expected codes", () => {
       208 |   expect(() => {
-    > 209 |     two(1111);
-          |         ^
+      209 |     two(1111);
+          |         ~~~~
       210 |     two<string>("pass");
       211 |   }).type.toRaiseError(2345, 2554, 2554);
       212 | });
@@ -839,8 +839,8 @@ Error: Expected 3 type errors, but only 2 were raised.
 
       208 |   expect(() => {
       209 |     two(1111);
-    > 210 |     two<string>("pass");
-          |                 ^
+      210 |     two<string>("pass");
+          |                 ~~~~~~
       211 |   }).type.toRaiseError(2345, 2554, 2554);
       212 | });
       213 | 

--- a/tests/__snapshots__/config-failFast---failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-false-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 
@@ -14,8 +14,8 @@ Error: The source type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
-> 4 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  4 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 
@@ -25,8 +25,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<string>().type.not.toBeString();
-    |                             ^
+  3 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   4 |   expect<string>().type.not.toBeString();
   5 | });
   6 | 
@@ -37,8 +37,8 @@ Error: The source type is 'string'.
 
   2 | test("is string?", () => {
   3 |   expect<string>().type.not.toBeString();
-> 4 |   expect<string>().type.not.toBeString();
-    |                             ^
+  4 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 

--- a/tests/__snapshots__/config-failFast---failFast-isNumber---failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-isNumber---failFast-false-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 
@@ -14,8 +14,8 @@ Error: The source type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
-> 4 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  4 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 

--- a/tests/__snapshots__/config-failFast---failFast-isString-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-isString-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<string>().type.not.toBeString();
-    |                             ^
+  3 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   4 |   expect<string>().type.not.toBeString();
   5 | });
   6 | 

--- a/tests/__snapshots__/config-failFast---failFast-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 

--- a/tests/__snapshots__/config-failFast---failFast-true-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-true-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 

--- a/tests/__snapshots__/config-failFast-failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-failFast-false-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 
@@ -14,8 +14,8 @@ Error: The source type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
-> 4 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  4 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 
@@ -25,8 +25,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<string>().type.not.toBeString();
-    |                             ^
+  3 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   4 |   expect<string>().type.not.toBeString();
   5 | });
   6 | 
@@ -37,8 +37,8 @@ Error: The source type is 'string'.
 
   2 | test("is string?", () => {
   3 |   expect<string>().type.not.toBeString();
-> 4 |   expect<string>().type.not.toBeString();
-    |                             ^
+  4 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 

--- a/tests/__snapshots__/config-failFast-failFast-true-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-failFast-true-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 

--- a/tests/__snapshots__/config-failFast-isNumber---failFast-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-isNumber---failFast-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 

--- a/tests/__snapshots__/config-failFast-overrides-failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-overrides-failFast-false-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 

--- a/tests/__snapshots__/config-failFast-overrides-failFast-true-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-overrides-failFast-true-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  3 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   4 |   expect<number>().type.not.toBeNumber();
   5 | });
   6 | 
@@ -14,8 +14,8 @@ Error: The source type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
-> 4 |   expect<number>().type.not.toBeNumber();
-    |                             ^
+  4 |   expect<number>().type.not.toBeNumber();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 
@@ -25,8 +25,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<string>().type.not.toBeString();
-    |                             ^
+  3 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   4 |   expect<string>().type.not.toBeString();
   5 | });
   6 | 
@@ -37,8 +37,8 @@ Error: The source type is 'string'.
 
   2 | test("is string?", () => {
   3 |   expect<string>().type.not.toBeString();
-> 4 |   expect<string>().type.not.toBeString();
-    |                             ^
+  4 |   expect<string>().type.not.toBeString();
+    |                             ~~~~~~~~~~
   5 | });
   6 | 
 

--- a/tests/__snapshots__/feature-watch-config-file-has-an-error-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-config-file-has-an-error-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |   "failFast": "no",
-    |               ^
+  2 |   "failFast": "no",
+    |               ~~~~
   3 |   "testFileMatch": [
   4 |     "**/isNumber.*"
   5 |   ]
@@ -13,8 +13,8 @@ Error: Option 'failFast' requires a value of type boolean.
 Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |   "failFast": "yes",
-    |               ^
+  2 |   "failFast": "yes",
+    |               ~~~~~
   3 |   "testFileMatch": [
   4 |     "**/isString.*"
   5 |   ]
@@ -25,8 +25,8 @@ Error: Option 'failFast' requires a value of type boolean.
 Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |   "failFast": "ok",
-    |               ^
+  2 |   "failFast": "ok",
+    |               ~~~~
   3 |   "testFileMatch": [
   4 |     "**/isString.*"
   5 |   ]

--- a/tests/__snapshots__/feature-watch-failFast-option-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-failFast-option-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<string>().type.toBeNumber();
-    |                         ^
+  3 |   expect<string>().type.toBeNumber();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 
@@ -13,8 +13,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<string>().type.toBeNumber();
-    |                         ^
+  3 |   expect<string>().type.toBeNumber();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 

--- a/tests/__snapshots__/feature-watch-multiple-test-files-are-added-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-multiple-test-files-are-added-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<number>().type.toBeString();
-    |                         ^
+  3 |   expect<number>().type.toBeString();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 

--- a/tests/__snapshots__/feature-watch-multiple-test-files-are-changed-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-multiple-test-files-are-changed-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
-> 3 |   expect<string>().type.toBeNumber();
-    |                         ^
+  3 |   expect<string>().type.toBeNumber();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 
@@ -13,8 +13,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<number>().type.toBeString();
-    |                         ^
+  3 |   expect<number>().type.toBeString();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 

--- a/tests/__snapshots__/feature-watch-single-test-file-is-added-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-single-test-file-is-added-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<number>().type.toBeString();
-    |                         ^
+  3 |   expect<number>().type.toBeString();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 

--- a/tests/__snapshots__/feature-watch-single-test-file-is-changed-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-single-test-file-is-changed-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The source type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
-> 3 |   expect<number>().type.toBeString();
-    |                         ^
+  3 |   expect<number>().type.toBeString();
+    |                         ~~~~~~~~~~
   4 | });
   5 | 
 

--- a/tests/__snapshots__/validation-configFile-single-quoted-list-values.snap.txt
+++ b/tests/__snapshots__/validation-configFile-single-quoted-list-values.snap.txt
@@ -1,8 +1,8 @@
 Error: String literal with double quotes expected.
 
   1 | {
-> 2 |   "target": ['4.8']
-    |              ^
+  2 |   "target": ['4.8']
+    |              ~~~~~
   3 | }
 
       at ./tstyche.config.json:2:14

--- a/tests/__snapshots__/validation-configFile-single-quoted-option-names.snap.txt
+++ b/tests/__snapshots__/validation-configFile-single-quoted-option-names.snap.txt
@@ -2,7 +2,7 @@ Error: String literal with double quotes expected.
 
   1 | {
   2 |   'failFast': true
-    |   ~~~~~~~~~~~~~~~~
+    |   ~~~~~~~~~~
   3 | }
 
       at ./tstyche.config.json:2:3

--- a/tests/__snapshots__/validation-configFile-single-quoted-option-names.snap.txt
+++ b/tests/__snapshots__/validation-configFile-single-quoted-option-names.snap.txt
@@ -1,8 +1,8 @@
 Error: String literal with double quotes expected.
 
   1 | {
-> 2 |   'failFast': true
-    |   ^
+  2 |   'failFast': true
+    |   ~~~~~~~~~~~~~~~~
   3 | }
 
       at ./tstyche.config.json:2:3

--- a/tests/__snapshots__/validation-configFile-single-quoted-option-values.snap.txt
+++ b/tests/__snapshots__/validation-configFile-single-quoted-option-values.snap.txt
@@ -1,8 +1,8 @@
 Error: String literal with double quotes expected.
 
   1 | {
-> 2 |   "rootPath": '../'
-    |               ^
+  2 |   "rootPath": '../'
+    |               ~~~~~
   3 | }
 
       at ./tstyche.config.json:2:15

--- a/tests/__snapshots__/validation-configFile-syntax-error.snap.txt
+++ b/tests/__snapshots__/validation-configFile-syntax-error.snap.txt
@@ -3,7 +3,7 @@ Error: '}' expected. ts(1005)
   1 | {
   2 |   'failFast': true
   3 | 
-    | 
+    | ~
 
       at ./tstyche.config.json:3:1
 

--- a/tests/__snapshots__/validation-configFile-syntax-error.snap.txt
+++ b/tests/__snapshots__/validation-configFile-syntax-error.snap.txt
@@ -2,8 +2,8 @@ Error: '}' expected. ts(1005)
 
   1 | {
   2 |   'failFast': true
-> 3 | 
-    | ^
+  3 | 
+    | 
 
       at ./tstyche.config.json:3:1
 

--- a/tests/__snapshots__/validation-configFile-tabs-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-configFile-tabs-wrong-option-value-type-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |  "failFast": "always",
-    |              ^
+  2 |  "failFast": "always",
+    |              ~~~~~~~~
   3 |  "rootPath": true
   4 | }
   5 | 
@@ -13,8 +13,8 @@ Error: Option 'rootPath' requires a value of type string.
 
   1 | {
   2 |  "failFast": "always",
-> 3 |  "rootPath": true
-    |              ^
+  3 |  "rootPath": true
+    |              ~~~~
   4 | }
   5 | 
 

--- a/tests/__snapshots__/validation-configFile-unknown-options-stderr.snap.txt
+++ b/tests/__snapshots__/validation-configFile-unknown-options-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Unknown option 'cache'.
 
   1 | {
-> 2 |   "cache": "all",
-    |   ^
+  2 |   "cache": "all",
+    |   ~~~~~~~~~~~~~~
   3 |   "silent": true,
   4 |   "testFileMatch": [
   5 |     "**/packages/*/__typetests__/*.test.ts"
@@ -14,8 +14,8 @@ Error: Unknown option 'silent'.
 
   1 | {
   2 |   "cache": "all",
-> 3 |   "silent": true,
-    |   ^
+  3 |   "silent": true,
+    |   ~~~~~~~~~~~~~~
   4 |   "testFileMatch": [
   5 |     "**/packages/*/__typetests__/*.test.ts"
   6 |   ]

--- a/tests/__snapshots__/validation-configFile-unknown-options-stderr.snap.txt
+++ b/tests/__snapshots__/validation-configFile-unknown-options-stderr.snap.txt
@@ -2,7 +2,7 @@ Error: Unknown option 'cache'.
 
   1 | {
   2 |   "cache": "all",
-    |   ~~~~~~~~~~~~~~
+    |   ~~~~~~~
   3 |   "silent": true,
   4 |   "testFileMatch": [
   5 |     "**/packages/*/__typetests__/*.test.ts"
@@ -15,7 +15,7 @@ Error: Unknown option 'silent'.
   1 | {
   2 |   "cache": "all",
   3 |   "silent": true,
-    |   ~~~~~~~~~~~~~~
+    |   ~~~~~~~~
   4 |   "testFileMatch": [
   5 |     "**/packages/*/__typetests__/*.test.ts"
   6 |   ]

--- a/tests/__snapshots__/validation-configFile-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-configFile-wrong-option-value-type-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |   "failFast": "always",
-    |               ^
+  2 |   "failFast": "always",
+    |               ~~~~~~~~
   3 |   "rootPath": true
   4 | }
 
@@ -12,8 +12,8 @@ Error: Option 'rootPath' requires a value of type string.
 
   1 | {
   2 |   "failFast": "always",
-> 3 |   "rootPath": true
-    |               ^
+  3 |   "rootPath": true
+    |               ~~~~
   4 | }
 
       at ./tstyche.config.json:3:15

--- a/tests/__snapshots__/validation-configFile-wrong-root-value.snap.txt
+++ b/tests/__snapshots__/validation-configFile-wrong-root-value.snap.txt
@@ -1,7 +1,7 @@
 Error: The root value of a configuration file must be an object literal.
 
-> 1 | [
-    | ^
+  1 | [
+    | 
   2 |   {
   3 |     "failFast": true
   4 |   }

--- a/tests/__snapshots__/validation-configFile-wrong-root-value.snap.txt
+++ b/tests/__snapshots__/validation-configFile-wrong-root-value.snap.txt
@@ -1,11 +1,15 @@
 Error: The root value of a configuration file must be an object literal.
 
   1 | [
-    | 
+    | ~
   2 |   {
+    | ~~~
   3 |     "failFast": true
+    | ~~~~~~~~~~~~~~~~~~~~
   4 |   }
+    | ~~~
   5 | ]
+    | ~
 
       at ./tstyche.config.json:1:1
 

--- a/tests/__snapshots__/validation-describe-handles-expect-stderr.snap.txt
+++ b/tests/__snapshots__/validation-describe-handles-expect-stderr.snap.txt
@@ -3,7 +3,7 @@ Error: 'expect()' cannot be nested within 'describe()'.
    6 | 
    7 | describe("nested 'expect()' is handled?", () => {
    8 |   expect<never>().type.toBeNever();
-     |   ~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |   expect<null>().type.toBeNull();
   10 | 
   11 |   test("is number?", () => {
@@ -15,7 +15,7 @@ Error: 'expect()' cannot be nested within 'describe()'.
    7 | describe("nested 'expect()' is handled?", () => {
    8 |   expect<never>().type.toBeNever();
    9 |   expect<null>().type.toBeNull();
-     |   ~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 | 
   11 |   test("is number?", () => {
   12 |     expect<number>().type.toBeNumber();

--- a/tests/__snapshots__/validation-describe-handles-expect-stderr.snap.txt
+++ b/tests/__snapshots__/validation-describe-handles-expect-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: 'expect()' cannot be nested within 'describe()'.
 
    6 | 
    7 | describe("nested 'expect()' is handled?", () => {
->  8 |   expect<never>().type.toBeNever();
-     |   ^
+   8 |   expect<never>().type.toBeNever();
+     |   ~~~~~~~~~~~~~~~
    9 |   expect<null>().type.toBeNull();
   10 | 
   11 |   test("is number?", () => {
@@ -14,8 +14,8 @@ Error: 'expect()' cannot be nested within 'describe()'.
 
    7 | describe("nested 'expect()' is handled?", () => {
    8 |   expect<never>().type.toBeNever();
->  9 |   expect<null>().type.toBeNull();
-     |   ^
+   9 |   expect<null>().type.toBeNull();
+     |   ~~~~~~~~~~~~~~
   10 | 
   11 |   test("is number?", () => {
   12 |     expect<number>().type.toBeNumber();

--- a/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
@@ -3,9 +3,11 @@ Error: 'describe()' cannot be nested within 'expect()'.
   2 | 
   3 | expect(() => {
   4 |   describe("cannot be nested", () => {
-    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     //
+    | ~~~~~~
   6 |   });
+    | ~~~~
   7 | 
 
       at ./__typetests__/handles-nested.tst.ts:4:3
@@ -15,9 +17,11 @@ Error: 'it()' cannot be nested within 'expect()'.
    6 |   });
    7 | 
    8 |   it("cannot be nested", () => {
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     //
+     | ~~~~~~
   10 |   });
+     | ~~~~
   11 | 
 
        at ./__typetests__/handles-nested.tst.ts:8:3
@@ -27,9 +31,11 @@ Error: 'test()' cannot be nested within 'expect()'.
   10 |   });
   11 | 
   12 |   test("cannot be nested", () => {
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   13 |     //
+     | ~~~~~~
   14 |   });
+     | ~~~~
   15 | 
 
        at ./__typetests__/handles-nested.tst.ts:12:3

--- a/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: 'describe()' cannot be nested within 'expect()'.
 
   2 | 
   3 | expect(() => {
-> 4 |   describe("cannot be nested", () => {
-    |   ^
+  4 |   describe("cannot be nested", () => {
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     //
   6 |   });
   7 | 
@@ -14,8 +14,8 @@ Error: 'it()' cannot be nested within 'expect()'.
 
    6 |   });
    7 | 
->  8 |   it("cannot be nested", () => {
-     |   ^
+   8 |   it("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     //
   10 |   });
   11 | 
@@ -26,8 +26,8 @@ Error: 'test()' cannot be nested within 'expect()'.
 
   10 |   });
   11 | 
-> 12 |   test("cannot be nested", () => {
-     |   ^
+  12 |   test("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   13 |     //
   14 |   });
   15 | 

--- a/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: The '.toBeSupported()' matcher is not supported.
 
    8 | test("is not supported?", () => {
    9 |   // @ts-expect-error
-> 10 |   expect<string>().type.toBeSupported();
-     |                         ^
+  10 |   expect<string>().type.toBeSupported();
+     |                         ~~~~~~~~~~~~~
   11 |   // @ts-expect-error
   12 |   expect<number>().type.not.toBeSupported();
   13 | });
@@ -14,8 +14,8 @@ Error: The '.toBeSupported()' matcher is not supported.
 
   10 |   expect<string>().type.toBeSupported();
   11 |   // @ts-expect-error
-> 12 |   expect<number>().type.not.toBeSupported();
-     |                             ^
+  12 |   expect<number>().type.not.toBeSupported();
+     |                             ~~~~~~~~~~~~~
   13 | });
   14 | 
 

--- a/tests/__snapshots__/validation-failFast-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-failFast-wrong-option-value-type-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'failFast' requires a value of type boolean.
 
   1 | {
-> 2 |   "failFast": "never"
-    |               ^
+  2 |   "failFast": "never"
+    |               ~~~~~~~
   3 | }
 
       at ./tstyche.config.json:2:15

--- a/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
@@ -3,9 +3,11 @@ Error: 'describe()' cannot be nested within 'it()'.
   2 | 
   3 | it("is string?", () => {
   4 |   describe("nested describe is handled?", () => {
-    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     expect<number>().type.toBeNumber();
+    | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   6 |   });
+    | ~~~~
   7 | 
 
       at ./__typetests__/handles-nested.tst.ts:4:3
@@ -15,9 +17,11 @@ Error: 'it()' cannot be nested within 'it()'.
    6 |   });
    7 | 
    8 |   it("nested it is handled?", () => {
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     expect<never>().type.toBeNever();
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 |   });
+     | ~~~~
   11 | 
 
        at ./__typetests__/handles-nested.tst.ts:8:3

--- a/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: 'describe()' cannot be nested within 'it()'.
 
   2 | 
   3 | it("is string?", () => {
-> 4 |   describe("nested describe is handled?", () => {
-    |   ^
+  4 |   describe("nested describe is handled?", () => {
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     expect<number>().type.toBeNumber();
   6 |   });
   7 | 
@@ -14,8 +14,8 @@ Error: 'it()' cannot be nested within 'it()'.
 
    6 |   });
    7 | 
->  8 |   it("nested it is handled?", () => {
-     |   ^
+   8 |   it("nested it is handled?", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     expect<never>().type.toBeNever();
   10 |   });
   11 | 

--- a/tests/__snapshots__/validation-rootPath-path-does-not-exist.snap.txt
+++ b/tests/__snapshots__/validation-rootPath-path-does-not-exist.snap.txt
@@ -1,8 +1,8 @@
 Error: The specified path '<<cwd>>/tests/__fixtures__/.generated/validation-rootPath/nope' does not exist.
 
   1 | {
-> 2 |   "rootPath": "../nope"
-    |               ^
+  2 |   "rootPath": "../nope"
+    |               ~~~~~~~~~
   3 | }
 
       at ./config/tstyche.json:2:15

--- a/tests/__snapshots__/validation-rootPath-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-rootPath-wrong-option-value-type-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'rootPath' requires a value of type string.
 
   1 | {
-> 2 |   "rootPath": true
-    |               ^
+  2 |   "rootPath": true
+    |               ~~~~
   3 | }
 
       at ./tstyche.config.json:2:15

--- a/tests/__snapshots__/validation-runner-tsconfig-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-runner-tsconfig-errors-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Compiler option 'strict' requires a value of type boolean. ts(5024)
 
   2 |   "compilerOptions": {
   3 |     "noEmitOnError": true,
-> 4 |     "strict": "yes",
-    |               ^
+  4 |     "strict": "yes",
+    |               ~~~~~
   5 |     "strictNullChecks": true
   6 |   },
   7 |   "extends": "../../tsconfig.json",

--- a/tests/__snapshots__/validation-syntax-errors-syntax-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-syntax-errors-syntax-errors-stderr.snap.txt
@@ -27,7 +27,7 @@ Error: ')' expected. ts(1005)
   16 | 
   17 | test("is broken?"
   18 | 
-     | 
+     | ~
 
        at ./__typetests__/dummy.test.ts:18:1
 

--- a/tests/__snapshots__/validation-syntax-errors-syntax-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-syntax-errors-syntax-errors-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Expression expected. ts(1109)
 
   4 | 
   5 | test("is syntax error?", () => {
-> 6 |   one(());
-    |        ^
+  6 |   one(());
+    |        ~
   7 | });
   8 | 
   9 | test("is syntax error?", () => {
@@ -14,8 +14,8 @@ Error: Argument expression expected. ts(1135)
 
    9 | test("is syntax error?", () => {
   10 |   one(
-> 11 | });
-     | ^
+  11 | });
+     | ~
   12 | 
   13 | test("is skipped?", () => {
   14 |   expect(one("abc")).type.toBeVoid();
@@ -26,8 +26,8 @@ Error: ')' expected. ts(1005)
 
   16 | 
   17 | test("is broken?"
-> 18 | 
-     | ^
+  18 | 
+     | 
 
        at ./__typetests__/dummy.test.ts:18:1
 

--- a/tests/__snapshots__/validation-target-wrong-list-item-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-target-wrong-list-item-type-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Item of the 'target' list must be of type string.
 
   2 |   "target": [
   3 |     "4.8",
-> 4 |     5
-    |     ^
+  4 |     5
+    |     ~
   5 |   ]
   6 | }
 

--- a/tests/__snapshots__/validation-target-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-target-wrong-option-value-type-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'target' requires a value of type list.
 
   1 | {
-> 2 |   "target": "current"
-    |             ^
+  2 |   "target": "current"
+    |             ~~~~~~~~~
   3 | }
 
       at ./tstyche.config.json:2:13

--- a/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
@@ -3,9 +3,11 @@ Error: 'describe()' cannot be nested within 'test()'.
   2 | 
   3 | test("is string?", () => {
   4 |   describe("nested describe is handled?", () => {
-    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     expect<number>().type.toBeNumber();
+    | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   6 |   });
+    | ~~~~
   7 | 
 
       at ./__typetests__/handles-nested.tst.ts:4:3
@@ -15,9 +17,11 @@ Error: 'test()' cannot be nested within 'test()'.
    6 |   });
    7 | 
    8 |   test("nested test is handled?", () => {
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     expect<never>().type.toBeNever();
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 |   });
+     | ~~~~
   11 | 
 
        at ./__typetests__/handles-nested.tst.ts:8:3

--- a/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: 'describe()' cannot be nested within 'test()'.
 
   2 | 
   3 | test("is string?", () => {
-> 4 |   describe("nested describe is handled?", () => {
-    |   ^
+  4 |   describe("nested describe is handled?", () => {
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     expect<number>().type.toBeNumber();
   6 |   });
   7 | 
@@ -14,8 +14,8 @@ Error: 'test()' cannot be nested within 'test()'.
 
    6 |   });
    7 | 
->  8 |   test("nested test is handled?", () => {
-     |   ^
+   8 |   test("nested test is handled?", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     expect<never>().type.toBeNever();
   10 |   });
   11 | 

--- a/tests/__snapshots__/validation-testFileMatch-cannot-start-with-0.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-cannot-start-with-0.snap.txt
@@ -4,8 +4,8 @@ The test files are only collected within the 'rootPath' directory.
 
   1 | {
   2 |   "testFileMatch": [
-> 3 |     "/feature"
-    |     ^
+  3 |     "/feature"
+    |     ~~~~~~~~~~
   4 |   ]
   5 | }
 

--- a/tests/__snapshots__/validation-testFileMatch-cannot-start-with-1.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-cannot-start-with-1.snap.txt
@@ -4,8 +4,8 @@ The test files are only collected within the 'rootPath' directory.
 
   1 | {
   2 |   "testFileMatch": [
-> 3 |     "../feature"
-    |     ^
+  3 |     "../feature"
+    |     ~~~~~~~~~~~~
   4 |   ]
   5 | }
 

--- a/tests/__snapshots__/validation-testFileMatch-wrong-list-item-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-wrong-list-item-type-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Item of the 'testFileMatch' list must be of type string.
 
   2 |   "testFileMatch": [
   3 |     "examples/*",
-> 4 |     false
-    |     ^
+  4 |     false
+    |     ~~~~~
   5 |   ]
   6 | }
 

--- a/tests/__snapshots__/validation-testFileMatch-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-wrong-option-value-type-stderr.snap.txt
@@ -1,8 +1,8 @@
 Error: Option 'testFileMatch' requires a value of type list.
 
   1 | {
-> 2 |   "testFileMatch": "feature"
-    |                    ^
+  2 |   "testFileMatch": "feature"
+    |                    ~~~~~~~~~
   3 | }
 
       at ./tstyche.config.json:2:20

--- a/tests/__snapshots__/validation-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBe-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBe<{ test: void }>();
-    |     ^
+  5 |     expect().type.toBe<{ test: void }>();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -14,8 +14,8 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toBe();
-     |                                   ^
+  11 |     expect<{ test: void }>().type.toBe();
+     |                                   ~~~~
   12 |   });
   13 | });
   14 | 

--- a/tests/__snapshots__/validation-toBeAny-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAny-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeAny();
-    |     ^
+  5 |     expect().type.toBeAny();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignable-stderr.snap.txt
@@ -4,8 +4,8 @@ To learn more, visit https://tstyche.org/releases/tstyche-2
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeAssignable<{ test: void }>();
-    |                   ^
+  5 |     expect().type.toBeAssignable<{ test: void }>();
+    |                   ~~~~~~~~~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -16,8 +16,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeAssignable<{ test: void }>();
-    |     ^
+  5 |     expect().type.toBeAssignable<{ test: void }>();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -28,8 +28,8 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toBeAssignable();
-     |                                   ^
+  11 |     expect<{ test: void }>().type.toBeAssignable();
+     |                                   ~~~~~~~~~~~~~~
   12 |   });
   13 | });
   14 | 

--- a/tests/__snapshots__/validation-toBeAssignableTo-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableTo-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeAssignableTo<{ test: void }>();
-    |     ^
+  5 |     expect().type.toBeAssignableTo<{ test: void }>();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -14,8 +14,8 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toBeAssignableTo();
-     |                                   ^
+  11 |     expect<{ test: void }>().type.toBeAssignableTo();
+     |                                   ~~~~~~~~~~~~~~~~
   12 |   });
   13 | });
   14 | 

--- a/tests/__snapshots__/validation-toBeAssignableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableWith-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeAssignableWith<{ test: void }>();
-    |     ^
+  5 |     expect().type.toBeAssignableWith<{ test: void }>();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -14,8 +14,8 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toBeAssignableWith();
-     |                                   ^
+  11 |     expect<{ test: void }>().type.toBeAssignableWith();
+     |                                   ~~~~~~~~~~~~~~~~~~
   12 |   });
   13 | });
   14 | 

--- a/tests/__snapshots__/validation-toBeBigInt-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeBigInt-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeBigInt();
-    |     ^
+  5 |     expect().type.toBeBigInt();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeBoolean-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeBoolean-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeBoolean();
-    |     ^
+  5 |     expect().type.toBeBoolean();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeNever-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeNever-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeNever();
-    |     ^
+  5 |     expect().type.toBeNever();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeNull-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeNull-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeNull();
-    |     ^
+  5 |     expect().type.toBeNull();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeNumber-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeNumber-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeNumber();
-    |     ^
+  5 |     expect().type.toBeNumber();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeString-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeString-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeString();
-    |     ^
+  5 |     expect().type.toBeString();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeSymbol-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeSymbol();
-    |     ^
+  5 |     expect().type.toBeSymbol();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeUndefined-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeUndefined-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeUndefined();
-    |     ^
+  5 |     expect().type.toBeUndefined();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeUniqueSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeUniqueSymbol-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeUniqueSymbol();
-    |     ^
+  5 |     expect().type.toBeUniqueSymbol();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeUnknown-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeUnknown-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeUnknown();
-    |     ^
+  5 |     expect().type.toBeUnknown();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toBeVoid-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeVoid-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toBeVoid();
-    |     ^
+  5 |     expect().type.toBeVoid();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 

--- a/tests/__snapshots__/validation-toEqual-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toEqual-stderr.snap.txt
@@ -4,8 +4,8 @@ To learn more, visit https://tstyche.org/releases/tstyche-2
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toEqual<{ test: void }>();
-    |                   ^
+  5 |     expect().type.toEqual<{ test: void }>();
+    |                   ~~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -16,8 +16,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toEqual<{ test: void }>();
-    |     ^
+  5 |     expect().type.toEqual<{ test: void }>();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -28,8 +28,8 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toEqual();
-     |                                   ^
+  11 |     expect<{ test: void }>().type.toEqual();
+     |                                   ~~~~~~~
   12 |   });
   13 | });
   14 | 

--- a/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toHaveProperty("runTest");
-    |     ^
+  5 |     expect().type.toHaveProperty("runTest");
+    |     ~~~~~~
   6 |   });
   7 | 
   8 |   test("must be of an object type", () => {
@@ -14,8 +14,8 @@ Error: An argument for 'source' must be of an object type, received: '"sample"'.
 
    7 | 
    8 |   test("must be of an object type", () => {
->  9 |     expect("sample").type.toHaveProperty("runTest");
-     |            ^
+   9 |     expect("sample").type.toHaveProperty("runTest");
+     |            ~~~~~~~~
   10 |   });
   11 | });
   12 | 
@@ -26,8 +26,8 @@ Error: A type argument for 'Source' must be of an object type, received: 'any'.
 
   15 |     expect<{}>().type.not.toHaveProperty("abc");
   16 | 
-> 17 |     expect<any>().type.toHaveProperty("runTest");
-     |            ^
+  17 |     expect<any>().type.toHaveProperty("runTest");
+     |            ~~~
   18 |     expect<never>().type.toHaveProperty("runTest");
   19 |     expect(null).type.toHaveProperty("runTest");
   20 |     expect<"one" | "two">().type.toHaveProperty("runTest");
@@ -38,8 +38,8 @@ Error: A type argument for 'Source' must be of an object type, received: 'never'
 
   16 | 
   17 |     expect<any>().type.toHaveProperty("runTest");
-> 18 |     expect<never>().type.toHaveProperty("runTest");
-     |            ^
+  18 |     expect<never>().type.toHaveProperty("runTest");
+     |            ~~~~~
   19 |     expect(null).type.toHaveProperty("runTest");
   20 |     expect<"one" | "two">().type.toHaveProperty("runTest");
   21 |   });
@@ -50,8 +50,8 @@ Error: An argument for 'source' must be of an object type, received: 'null'.
 
   17 |     expect<any>().type.toHaveProperty("runTest");
   18 |     expect<never>().type.toHaveProperty("runTest");
-> 19 |     expect(null).type.toHaveProperty("runTest");
-     |            ^
+  19 |     expect(null).type.toHaveProperty("runTest");
+     |            ~~~~
   20 |     expect<"one" | "two">().type.toHaveProperty("runTest");
   21 |   });
   22 | });
@@ -62,8 +62,8 @@ Error: A type argument for 'Source' must be of an object type, received: '"one" 
 
   18 |     expect<never>().type.toHaveProperty("runTest");
   19 |     expect(null).type.toHaveProperty("runTest");
-> 20 |     expect<"one" | "two">().type.toHaveProperty("runTest");
-     |            ^
+  20 |     expect<"one" | "two">().type.toHaveProperty("runTest");
+     |            ~~~~~~~~~~~~~
   21 |   });
   22 | });
   23 | 
@@ -74,8 +74,8 @@ Error: An argument for 'key' must be provided.
 
   25 |   test("must be provided", () => {
   26 |     // @ts-expect-error testing purpose
-> 27 |     expect<{ test: () => void }>().type.toHaveProperty();
-     |                                         ^
+  27 |     expect<{ test: () => void }>().type.toHaveProperty();
+     |                                         ~~~~~~~~~~~~~~
   28 |   });
   29 | 
   30 |   test("must be of type 'string | number | symbol'", () => {
@@ -86,8 +86,8 @@ Error: An argument for 'key' must be of type 'string | number | symbol', receive
 
   30 |   test("must be of type 'string | number | symbol'", () => {
   31 |     // @ts-expect-error testing purpose
-> 32 |     expect<{ test: () => void }>().type.toHaveProperty(["test"]);
-     |                                                        ^
+  32 |     expect<{ test: () => void }>().type.toHaveProperty(["test"]);
+     |                                                        ~~~~~~~~
   33 |   });
   34 | });
   35 | 

--- a/tests/__snapshots__/validation-toMatch-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toMatch-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toMatch<{ test: void }>();
-    |     ^
+  5 |     expect().type.toMatch<{ test: void }>();
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -14,8 +14,8 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
    9 | describe("argument for 'target'", () => {
   10 |   test("must be provided", () => {
-> 11 |     expect<{ test: void }>().type.toMatch();
-     |                                   ^
+  11 |     expect<{ test: void }>().type.toMatch();
+     |                                   ~~~~~~~
   12 |   });
   13 | });
   14 | 

--- a/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
   3 | describe("argument for 'source'", () => {
   4 |   test("must be provided", () => {
-> 5 |     expect().type.toRaiseError("one");
-    |     ^
+  5 |     expect().type.toRaiseError("one");
+    |     ~~~~~~
   6 |   });
   7 | });
   8 | 
@@ -14,8 +14,8 @@ Error: An argument for 'target' must be of type 'string | number', received: 'tr
 
   14 |   test("must be of type 'string | number'", () => {
   15 |     // @ts-expect-error testing purpose
-> 16 |     expect(check(123)).type.toRaiseError(true, [2345]);
-     |                                          ^
+  16 |     expect(check(123)).type.toRaiseError(true, [2345]);
+     |                                          ~~~~
   17 |   });
   18 | });
   19 | 
@@ -26,8 +26,8 @@ Error: An argument for 'target' must be of type 'string | number', received: 'nu
 
   14 |   test("must be of type 'string | number'", () => {
   15 |     // @ts-expect-error testing purpose
-> 16 |     expect(check(123)).type.toRaiseError(true, [2345]);
-     |                                                ^
+  16 |     expect(check(123)).type.toRaiseError(true, [2345]);
+     |                                                ~~~~~~
   17 |   });
   18 | });
   19 | 

--- a/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Expected 2 arguments, but got 1. ts(2554)
 
   12 | 
   13 | describe("reported type error?", () => {
-> 14 |   test("with type error");
-     |   ^
+  14 |   test("with type error");
+     |   ~~~~
   15 | 
   16 |   test("looks at this test?", () => {
   17 |     expect<number>().type.toBeNumber();

--- a/tests/__snapshots__/validation-type-errors-matcher-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-matcher-level-errors-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Expected 0 arguments, but got 1. ts(2554)
 
    5 | 
    6 | test("has matcher type error?", () => {
->  7 |   expect(one()).type.toBeVoid(true);
-     |                               ^
+   7 |   expect(one()).type.toBeVoid(true);
+     |                               ~~~~
    8 | });
    9 | 
   10 | test("has assertion type error?", () => {
@@ -14,8 +14,8 @@ Error: Expected 0 arguments, but got 1. ts(2554)
 
   11 |   expect(one("pass")).type.toRaiseError();
   12 | 
-> 13 |   expect(one("fail")).type.toBeVoid();
-     |              ^
+  13 |   expect(one("fail")).type.toBeVoid();
+     |              ~~~~~~
   14 | });
   15 | 
 

--- a/tests/__snapshots__/validation-type-errors-test-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-test-level-errors-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Property 'toBeString' does not exist on type 'Modifier'. ts(2339)
 
   10 | 
   11 | test("reported type error?", () => {
-> 12 |   expect<string>().toBeString();
-     |                    ^
+  12 |   expect<string>().toBeString();
+     |                    ~~~~~~~~~~
   13 | });
   14 | 
 

--- a/tests/__snapshots__/validation-type-errors-top-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-top-level-errors-stderr.snap.txt
@@ -2,8 +2,8 @@ Error: Type 'string' is not assignable to type 'number'. ts(2322)
 
    5 | });
    6 | 
->  7 | const a: number = "nine";
-     |       ^
+   7 | const a: number = "nine";
+     |       ~
    8 | 
    9 | if (a > 9) {
   10 |   //
@@ -14,8 +14,8 @@ Error: Argument of type 'number' is not assignable to parameter of type 'string'
 
   11 | }
   12 | 
-> 13 | test(284963, () => {
-     |      ^
+  13 | test(284963, () => {
+     |      ~~~~~~
   14 |   expect<string>().type.toBeString();
   15 | });
   16 | 


### PR DESCRIPTION
For better visibility, the entire locations of diagnostics can be marked (similar to `tsc`).

Like this:

<img width="635" alt="Screenshot 2024-06-29 at 10 35 29" src="https://github.com/tstyche/tstyche/assets/72159681/d9f7b665-e032-484b-90ec-ff8fb5730a35">
