### PR TITLE
fix(config): allow empty config file

### DIFF
--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -64,7 +64,11 @@ export class ConfigFileOptionsWorker {
 
     const rootExpression = sourceFile.statements[0]?.expression;
 
-    if (rootExpression == null || !this.#compiler.isObjectLiteralExpression(rootExpression)) {
+    if (!rootExpression) {
+      return;
+    }
+
+    if (!this.#compiler.isObjectLiteralExpression(rootExpression)) {
       const origin = new DiagnosticOrigin(0, 0, sourceFile);
 
       this.#onDiagnostic(Diagnostic.error("The root value of a configuration file must be an object literal.", origin));

--- a/tests/config-configFile.test.js
+++ b/tests/config-configFile.test.js
@@ -4,12 +4,6 @@ import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "
 import { normalizeOutput } from "./__utilities__/output.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
 
-const isStringTestText = `import { expect, test } from "tstyche";
-test("is string?", () => {
-  expect<string>().type.toBeString();
-});
-`;
-
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
@@ -54,13 +48,33 @@ describe("'tstyche.config.json' file", function () {
     const config = { $schema: "https://tstyche.org/schemas/config.json" };
 
     await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"]);
 
     assert.doesNotMatch(stdout, /schema/);
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
+  test("empty config file is allowed", async function () {
+    const configText = `// {
+//   "failFast": true,
+//   "testFileMatch": ["**/*.tst.*"]
+// }
+`;
+
+    await writeFixture(fixtureUrl, {
+      ["tstyche.config.json"]: configText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"]);
+
+    assert.matchObject(stdout, {
+      failFast: false,
+    });
+
     assert.equal(stderr, "");
     assert.equal(exitCode, 0);
   });


### PR DESCRIPTION
Split from #238.

Empty config file (eg. with all lines commented out) must be allowed. 