### PR TITLE
feat(diagnostic): show related diagnostics, when provided by TypeScript

### DIFF
--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -5,8 +5,8 @@ import { DiagnosticCategory } from "./enums.js";
 export class Diagnostic {
   category: DiagnosticCategory;
   code: string | undefined;
-  related: Array<Diagnostic> | undefined;
   origin: DiagnosticOrigin | undefined;
+  related: Array<Diagnostic> | undefined;
   text: string | Array<string>;
 
   constructor(text: string | Array<string>, category: DiagnosticCategory, origin?: DiagnosticOrigin) {
@@ -15,7 +15,11 @@ export class Diagnostic {
     this.origin = origin;
   }
 
-  add(options: { code?: string; origin?: DiagnosticOrigin; related?: Array<Diagnostic> }): this {
+  add(options: {
+    code?: string | undefined;
+    origin?: DiagnosticOrigin | undefined;
+    related?: Array<Diagnostic> | undefined;
+  }): this {
     if (options.code != null) {
       this.code = options.code;
     }
@@ -46,7 +50,13 @@ export class Diagnostic {
         origin = new DiagnosticOrigin(diagnostic.start, diagnostic.start + diagnostic.length, diagnostic.file);
       }
 
-      return new Diagnostic(text, category, origin).add({ code });
+      let related: Array<Diagnostic> | undefined;
+
+      if (diagnostic.relatedInformation != null) {
+        related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation, compiler);
+      }
+
+      return new Diagnostic(text, category, origin).add({ code, related });
     });
   }
 

--- a/tests/__snapshots__/validation-configFile-syntax-error.snap.txt
+++ b/tests/__snapshots__/validation-configFile-syntax-error.snap.txt
@@ -7,3 +7,12 @@ Error: '}' expected. ts(1005)
 
       at ./tstyche.config.json:3:1
 
+    The parser expected to find a '}' to match the '{' token here. ts(1007)
+
+      1 | {
+        | ~
+      2 |   'failFast': true
+      3 | 
+
+          at ./tstyche.config.json:1:1
+

--- a/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
@@ -10,3 +10,15 @@ Error: Expected 2 arguments, but got 1. ts(2554)
 
        at ./__typetests__/describe-level.tst.ts:14:3
 
+    An argument for 'callback' was not provided. ts(6210)
+
+      36 |      * @param callback - The function with a code snippet and assertions.
+      37 |      */
+      38 |     (name: string, callback: () => void | Promise<void>): void;
+         |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      39 |     /**
+      40 |      * Marks a test as focused.
+      41 |      *
+
+           at ./../../../build/index.d.ts:38:20
+


### PR DESCRIPTION
When provided by TypeScript, related diagnostics should be added to the error messages.