### PR TITLE
refactor(expect): add the `ExpectDiagnosticText` class

### DIFF
--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -264,7 +264,7 @@ export class Expect {
     const receivedTypeText = this.#typeChecker.typeToString(this.#getType(node));
 
     const text = this.#compiler.isTypeNode(node)
-      ? ExpectDiagnosticText.typeArgumentMustBe("Source", expectedText, receivedTypeText)
+      ? ExpectDiagnosticText.typeArgumentMustBeOf("Source", expectedText, receivedTypeText)
       : ExpectDiagnosticText.argumentMustBeOf("source", expectedText, receivedTypeText);
 
     const origin = DiagnosticOrigin.fromNode(node);

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -4,7 +4,7 @@ export class ExpectDiagnosticText {
   }
 
   static argumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
-    return `An argument for '${argumentNameText}' must be ${expectedText}, received: '${receivedTypeText}'.`;
+    return `An argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
   }
 
   static argumentMustBeProvided(argumentNameText: string): string {
@@ -15,7 +15,7 @@ export class ExpectDiagnosticText {
     return `The '.${matcherNameText}()' matcher is not supported.`;
   }
 
-  static typeArgumentMustBe(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
-    return `A type argument for '${argumentNameText}' must be ${expectedText}, received: '${receivedTypeText}'.`;
+  static typeArgumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
+    return `A type argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
   }
 }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -1,0 +1,21 @@
+export class ExpectDiagnosticText {
+  static argumentOrTypeArgumentMustBeProvided(argumentNameText: string, typeArgumentNameText: string): string {
+    return `An argument for '${argumentNameText}' or type argument for '${typeArgumentNameText}' must be provided.`;
+  }
+
+  static argumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
+    return `An argument for '${argumentNameText}' must be ${expectedText}, received: '${receivedTypeText}'.`;
+  }
+
+  static argumentMustBeProvided(argumentNameText: string): string {
+    return `An argument for '${argumentNameText}' must be provided.`;
+  }
+
+  static matcherIsNotSupported(matcherNameText: string): string {
+    return `The '.${matcherNameText}()' matcher is not supported.`;
+  }
+
+  static typeArgumentMustBe(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
+    return `A type argument for '${argumentNameText}' must be ${expectedText}, received: '${receivedTypeText}'.`;
+  }
+}


### PR DESCRIPTION
Moving messages to `ExpectDiagnosticText` class.