### PR TITLE
refactor(expect): move all messages to the `ExpectDiagnosticText` class

### DIFF
--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -289,9 +289,8 @@ export class Expect {
 
   #onKeyArgumentMustBeOfType(node: ts.Expression | ts.TypeNode, expectResult: ExpectResult) {
     const expectedText = "type 'string | number | symbol'";
-    const receivedTypeText = this.#typeChecker.typeToString(this.#getType(node));
 
-    const text = ExpectDiagnosticText.argumentMustBeOf("key", expectedText, receivedTypeText);
+    const text = ExpectDiagnosticText.argumentMustBeOf("key", expectedText);
     const origin = DiagnosticOrigin.fromNode(node);
 
     this.#onDiagnostic(Diagnostic.error(text, origin), expectResult);
@@ -306,11 +305,10 @@ export class Expect {
 
   #onSourceArgumentMustBeFunctionOrClassType(node: ts.Expression | ts.TypeNode, expectResult: ExpectResult) {
     const expectedText = "a function or class type";
-    const receivedTypeText = this.#typeChecker.typeToString(this.#getType(node));
 
     const text = this.#compiler.isTypeNode(node)
-      ? ExpectDiagnosticText.typeArgumentMustBeOf("Source", expectedText, receivedTypeText)
-      : ExpectDiagnosticText.argumentMustBeOf("source", expectedText, receivedTypeText);
+      ? ExpectDiagnosticText.typeArgumentMustBeOf("Source", expectedText)
+      : ExpectDiagnosticText.argumentMustBeOf("source", expectedText);
 
     const origin = DiagnosticOrigin.fromNode(node);
 
@@ -319,11 +317,10 @@ export class Expect {
 
   #onSourceArgumentMustBeObjectType(node: ts.Expression | ts.TypeNode, expectResult: ExpectResult) {
     const expectedText = "an object type";
-    const receivedTypeText = this.#typeChecker.typeToString(this.#getType(node));
 
     const text = this.#compiler.isTypeNode(node)
-      ? ExpectDiagnosticText.typeArgumentMustBeOf("Source", expectedText, receivedTypeText)
-      : ExpectDiagnosticText.argumentMustBeOf("source", expectedText, receivedTypeText);
+      ? ExpectDiagnosticText.typeArgumentMustBeOf("Source", expectedText)
+      : ExpectDiagnosticText.argumentMustBeOf("source", expectedText);
 
     const origin = DiagnosticOrigin.fromNode(node);
 
@@ -339,11 +336,10 @@ export class Expect {
 
   #onTargetArgumentMustBeObjectType(node: ts.Expression | ts.TypeNode, expectResult: ExpectResult) {
     const expectedText = "an object type";
-    const receivedTypeText = this.#typeChecker.typeToString(this.#getType(node));
 
     const text = this.#compiler.isTypeNode(node)
-      ? ExpectDiagnosticText.typeArgumentMustBeOf("Target", expectedText, receivedTypeText)
-      : ExpectDiagnosticText.argumentMustBeOf("target", expectedText, receivedTypeText);
+      ? ExpectDiagnosticText.typeArgumentMustBeOf("Target", expectedText)
+      : ExpectDiagnosticText.argumentMustBeOf("target", expectedText);
 
     const origin = DiagnosticOrigin.fromNode(node);
 
@@ -368,9 +364,8 @@ export class Expect {
 
       if (!this.#isStringOrNumberLiteralType(receivedType)) {
         const expectedText = "type 'string | number'";
-        const receivedTypeText = this.#typeChecker.typeToString(receivedType);
 
-        const text = ExpectDiagnosticText.argumentMustBeOf("target", expectedText, receivedTypeText);
+        const text = ExpectDiagnosticText.argumentMustBeOf("target", expectedText);
         const origin = DiagnosticOrigin.fromNode(node);
 
         diagnostics.push(Diagnostic.error(text, origin));

--- a/source/expect/Expect.ts
+++ b/source/expect/Expect.ts
@@ -85,10 +85,7 @@ export class Expect {
     switch (matcherNameText) {
       case "toBeAssignable":
       case "toEqual": {
-        const text = [
-          `The '.${matcherNameText}()' matcher is deprecated and will be removed in TSTyche 3.`,
-          "To learn more, visit https://tstyche.org/releases/tstyche-2",
-        ];
+        const text = ExpectDiagnosticText.matcherIsDeprecated(matcherNameText);
         const origin = DiagnosticOrigin.fromNode(assertion.matcherName);
 
         EventEmitter.dispatch(["deprecation:info", { diagnostics: [Diagnostic.warning(text, origin)] }]);
@@ -341,10 +338,13 @@ export class Expect {
   }
 
   #onTargetArgumentMustBeObjectType(node: ts.Expression | ts.TypeNode, expectResult: ExpectResult) {
-    const sourceText = this.#compiler.isTypeNode(node) ? "A type argument for 'Target'" : "An argument for 'target'";
+    const expectedText = "an object type";
     const receivedTypeText = this.#typeChecker.typeToString(this.#getType(node));
 
-    const text = `${sourceText} must be of an object type, received: '${receivedTypeText}'.`;
+    const text = this.#compiler.isTypeNode(node)
+      ? ExpectDiagnosticText.typeArgumentMustBeOf("Target", expectedText, receivedTypeText)
+      : ExpectDiagnosticText.argumentMustBeOf("target", expectedText, receivedTypeText);
+
     const origin = DiagnosticOrigin.fromNode(node);
 
     EventEmitter.dispatch(["expect:error", { diagnostics: [Diagnostic.error(text, origin)], result: expectResult }]);

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -34,12 +34,8 @@ export class ExpectDiagnosticText {
     return `Overload ${indexText} of ${countText}, '${signatureText}', gave the following error.`;
   }
 
-  static #pluralize(text: string, count: number) {
-    return `${text}${count === 1 ? "" : "s"}`;
-  }
-
   static raisedTypeError(count = 1): string {
-    return `The raised type ${ExpectDiagnosticText.#pluralize("error", count)}:`;
+    return `The raised type error${count === 1 ? "" : "s"}:`;
   }
 
   static typeArgumentMustBeOf(argumentNameText: string, expectedText: string): string {
@@ -109,7 +105,7 @@ export class ExpectDiagnosticText {
       countText = count > targetCount ? String(count) : `only ${String(count)}`;
     }
 
-    return `${isTypeNode ? "Type" : "Expression type"} raised ${countText} type ${ExpectDiagnosticText.#pluralize("error", count)}.`;
+    return `${isTypeNode ? "Type" : "Expression type"} raised ${countText} type error${count === 1 ? "" : "s"}.`;
   }
 
   static typeRaisedMatchingError(isTypeNode: boolean): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -25,4 +25,8 @@ export class ExpectDiagnosticText {
   static typeArgumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
     return `A type argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
   }
+
+  static typeIs(typeText: string): string {
+    return `The type is '${typeText}'.`;
+  }
 }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -3,11 +3,8 @@ export class ExpectDiagnosticText {
     return `An argument for '${argumentNameText}' or type argument for '${typeArgumentNameText}' must be provided.`;
   }
 
-  static argumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): Array<string> {
-    return [
-      `An argument for '${argumentNameText}' must be of ${expectedText}.`,
-      `Received type '${receivedTypeText}'.`,
-    ];
+  static argumentMustBeOf(argumentNameText: string, expectedText: string): string {
+    return `An argument for '${argumentNameText}' must be of ${expectedText}.`;
   }
 
   static argumentMustBeProvided(argumentNameText: string): string {
@@ -29,11 +26,8 @@ export class ExpectDiagnosticText {
     return `Overload ${indexText} of ${countText}, '${signatureText}', gave the following error.`;
   }
 
-  static typeArgumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): Array<string> {
-    return [
-      `A type argument for '${argumentNameText}' must be of ${expectedText}.`,
-      `Received type '${receivedTypeText}'.`,
-    ];
+  static typeArgumentMustBeOf(argumentNameText: string, expectedText: string): string {
+    return `A type argument for '${argumentNameText}' must be of ${expectedText}.`;
   }
 
   static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -42,28 +42,30 @@ export class ExpectDiagnosticText {
     return `A type argument for '${argumentNameText}' must be of ${expectedText}.`;
   }
 
-  static typeDidNotRaiseError(isTypeNode: boolean, options?: { expectedText?: string }): string {
-    const text = [`${isTypeNode ? "Type" : "Expression type"} did not raise a type error`];
-
-    if (options?.expectedText != null) {
-      text.push(" ", options.expectedText);
-    }
-
-    text.push(".");
-
-    return text.join("");
+  static typeDidNotRaiseError(isTypeNode: boolean): string {
+    return `${isTypeNode ? "Type" : "Expression type"} did not raise a type error.`;
   }
 
-  static typeRaisedError(isTypeNode: boolean, options?: { expectedText?: string }): string {
-    const text = [`${isTypeNode ? "Type" : "Expression type"} raised a type error`];
+  static typeDidNotRaiseMatchingError(isTypeNode: boolean): string {
+    return `${isTypeNode ? "Type" : "Expression type"} did not raise a matching type error.`;
+  }
 
-    if (options?.expectedText != null) {
-      text.push(" ", options.expectedText);
+  static typeRaisedError(
+    isTypeNode: boolean,
+    options?: { count?: number; expectedText?: string; targetCount?: number },
+  ): string {
+    const count = options?.count ?? 1;
+    let countText = "a";
+
+    if (options?.targetCount != null && (count > 1 || options.targetCount > 1)) {
+      countText = count > options.targetCount ? String(count) : `only ${String(count)}`;
     }
 
-    text.push(".");
+    return `${isTypeNode ? "Type" : "Expression type"} raised ${countText} type error${count === 1 ? "" : "s"}.`;
+  }
 
-    return text.join("");
+  static typeRaisedMatchingError(isTypeNode: boolean): string {
+    return `${isTypeNode ? "Type" : "Expression type"} raised a matching type error.`;
   }
 
   static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -50,6 +50,54 @@ export class ExpectDiagnosticText {
     return `${isTypeNode ? "Type" : "Expression type"} did not raise a matching type error.`;
   }
 
+  static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {
+    return `Type '${typeText}' does not have property '${propertyNameText}'.`;
+  }
+
+  static typeDoesMatch(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' does match type '${targetTypeText}'.`;
+  }
+
+  static typeDoesNotMatch(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' does not match type '${targetTypeText}'.`;
+  }
+
+  static typeHasProperty(typeText: string, propertyNameText: string): string {
+    return `Type '${typeText}' has property '${propertyNameText}'.`;
+  }
+
+  static typeIs(typeText: string): string {
+    return `Type is '${typeText}'.`;
+  }
+
+  static typeIsAssignableTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is assignable to type '${targetTypeText}'.`;
+  }
+
+  static typeIsAssignableWith(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is assignable with type '${targetTypeText}'.`;
+  }
+
+  static typeIsIdenticalTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is identical to type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotAssignableTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not assignable to type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotAssignableWith(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotCompatibleWith(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not compatible with type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotIdenticalTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not identical to type '${targetTypeText}'.`;
+  }
+
   static typeRaisedError(
     isTypeNode: boolean,
     options?: { count?: number; expectedText?: string; targetCount?: number },
@@ -68,56 +116,8 @@ export class ExpectDiagnosticText {
     return `${isTypeNode ? "Type" : "Expression type"} raised a matching type error.`;
   }
 
-  static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {
-    return `Type '${typeText}' does not have property '${propertyNameText}'.`;
-  }
-
-  static typeHasProperty(typeText: string, propertyNameText: string): string {
-    return `Type '${typeText}' has property '${propertyNameText}'.`;
-  }
-
   static typeRequiresProperty(typeText: string, propertyNameText: string): string {
     return `Type '${typeText}' requires property '${propertyNameText}'.`;
-  }
-
-  static typeDoesMatch(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' does match type '${targetTypeText}'.`;
-  }
-
-  static typeDoesNotMatch(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' does not match type '${targetTypeText}'.`;
-  }
-
-  static typeIs(typeText: string): string {
-    return `Type is '${typeText}'.`;
-  }
-
-  static typeIsAssignableTo(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is assignable to type '${targetTypeText}'.`;
-  }
-
-  static typeIsNotAssignableTo(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is not assignable to type '${targetTypeText}'.`;
-  }
-
-  static typeIsAssignableWith(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is assignable with type '${targetTypeText}'.`;
-  }
-
-  static typeIsIdenticalTo(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is identical to type '${targetTypeText}'.`;
-  }
-
-  static typeIsNotIdenticalTo(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is not identical to type '${targetTypeText}'.`;
-  }
-
-  static typeIsNotAssignableWith(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`;
-  }
-
-  static typeIsNotCompatibleWith(sourceTypeText: string, targetTypeText: string): string {
-    return `Type '${sourceTypeText}' is not compatible with type '${targetTypeText}'.`;
   }
 
   static typesOfPropertyAreNotCompatible(propertyNameText: string): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -38,12 +38,36 @@ export class ExpectDiagnosticText {
     return `Type '${typeText}' requires property '${propertyNameText}'.`;
   }
 
+  static typeDoesMatch(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' does match type '${targetTypeText}'.`;
+  }
+
+  static typeDoesNotMatch(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' does not match type '${targetTypeText}'.`;
+  }
+
   static typeIs(typeText: string): string {
     return `The type is '${typeText}'.`;
   }
 
+  static typeIsAssignableTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is assignable to type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotAssignableTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not assignable to type '${targetTypeText}'.`;
+  }
+
   static typeIsAssignableWith(sourceTypeText: string, targetTypeText: string): string {
     return `Type '${sourceTypeText}' is assignable with type '${targetTypeText}'.`;
+  }
+
+  static typeIsIdenticalTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is identical to type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotIdenticalTo(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not identical to type '${targetTypeText}'.`;
   }
 
   static typeIsNotAssignableWith(sourceTypeText: string, targetTypeText: string): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -34,8 +34,12 @@ export class ExpectDiagnosticText {
     return `Overload ${indexText} of ${countText}, '${signatureText}', gave the following error.`;
   }
 
+  static #pluralize(text: string, count: number) {
+    return `${text}${count === 1 ? "" : "s"}`;
+  }
+
   static raisedTypeError(count = 1): string {
-    return `The raised type error${count === 1 ? "" : "s"}:`;
+    return `The raised type ${ExpectDiagnosticText.#pluralize("error", count)}:`;
   }
 
   static typeArgumentMustBeOf(argumentNameText: string, expectedText: string): string {
@@ -105,7 +109,7 @@ export class ExpectDiagnosticText {
       countText = count > targetCount ? String(count) : `only ${String(count)}`;
     }
 
-    return `${isTypeNode ? "Type" : "Expression type"} raised ${countText} type error${count === 1 ? "" : "s"}.`;
+    return `${isTypeNode ? "Type" : "Expression type"} raised ${countText} type ${ExpectDiagnosticText.#pluralize("error", count)}.`;
   }
 
   static typeRaisedMatchingError(isTypeNode: boolean): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -98,15 +98,11 @@ export class ExpectDiagnosticText {
     return `Type '${sourceTypeText}' is not identical to type '${targetTypeText}'.`;
   }
 
-  static typeRaisedError(
-    isTypeNode: boolean,
-    options?: { count?: number; expectedText?: string; targetCount?: number },
-  ): string {
-    const count = options?.count ?? 1;
+  static typeRaisedError(isTypeNode: boolean, count: number, targetCount: number): string {
     let countText = "a";
 
-    if (options?.targetCount != null && (count > 1 || options.targetCount > 1)) {
-      countText = count > options.targetCount ? String(count) : `only ${String(count)}`;
+    if (count > 1 || targetCount > 1) {
+      countText = count > targetCount ? String(count) : `only ${String(count)}`;
     }
 
     return `${isTypeNode ? "Type" : "Expression type"} raised ${countText} type error${count === 1 ? "" : "s"}.`;

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -26,6 +26,14 @@ export class ExpectDiagnosticText {
     return `A type argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
   }
 
+  static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {
+    return `Type '${typeText}' does not have property '${propertyNameText}'.`;
+  }
+
+  static typeHasProperty(typeText: string, propertyNameText: string): string {
+    return `Type '${typeText}' has property '${propertyNameText}'.`;
+  }
+
   static typeIs(typeText: string): string {
     return `The type is '${typeText}'.`;
   }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -11,6 +11,14 @@ export class ExpectDiagnosticText {
     return `An argument for '${argumentNameText}' must be provided.`;
   }
 
+  static componentAcceptsProps(isTypeNode: boolean): string {
+    return `${isTypeNode ? "Component type" : "Component"} accepts props of the given type.`;
+  }
+
+  static componentDoesNotAcceptProps(isTypeNode: boolean): string {
+    return `${isTypeNode ? "Component type" : "Component"} does not accept props of the given type.`;
+  }
+
   static matcherIsDeprecated(matcherNameText: string): Array<string> {
     return [
       `The '.${matcherNameText}()' matcher is deprecated and will be removed in TSTyche 3.`,

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -34,6 +34,10 @@ export class ExpectDiagnosticText {
     return `Type '${typeText}' has property '${propertyNameText}'.`;
   }
 
+  static typeRequiresProperty(typeText: string, propertyNameText: string): string {
+    return `Type '${typeText}' requires property '${propertyNameText}'.`;
+  }
+
   static typeIs(typeText: string): string {
     return `The type is '${typeText}'.`;
   }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -11,6 +11,13 @@ export class ExpectDiagnosticText {
     return `An argument for '${argumentNameText}' must be provided.`;
   }
 
+  static matcherIsDeprecated(matcherNameText: string): Array<string> {
+    return [
+      `The '.${matcherNameText}()' matcher is deprecated and will be removed in TSTyche 3.`,
+      "To learn more, visit https://tstyche.org/releases/tstyche-2",
+    ];
+  }
+
   static matcherIsNotSupported(matcherNameText: string): string {
     return `The '.${matcherNameText}()' matcher is not supported.`;
   }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -41,4 +41,20 @@ export class ExpectDiagnosticText {
   static typeIs(typeText: string): string {
     return `The type is '${typeText}'.`;
   }
+
+  static typeIsAssignableWith(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is assignable with type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotAssignableWith(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`;
+  }
+
+  static typeIsNotCompatibleWith(sourceTypeText: string, targetTypeText: string): string {
+    return `Type '${sourceTypeText}' is not compatible with type '${targetTypeText}'.`;
+  }
+
+  static typesOfPropertyAreNotCompatible(propertyNameText: string): string {
+    return `Types of property '${propertyNameText}' are not compatible.`;
+  }
 }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -47,7 +47,7 @@ export class ExpectDiagnosticText {
   }
 
   static typeIs(typeText: string): string {
-    return `The type is '${typeText}'.`;
+    return `Type is '${typeText}'.`;
   }
 
   static typeIsAssignableTo(sourceTypeText: string, targetTypeText: string): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -22,6 +22,10 @@ export class ExpectDiagnosticText {
     return `The '.${matcherNameText}()' matcher is not supported.`;
   }
 
+  static overloadGaveTheFollowingError(indexText: string, countText: string, signatureText: string): string {
+    return `Overload ${indexText} of ${countText}, '${signatureText}', gave the following error.`;
+  }
+
   static typeArgumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
     return `A type argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
   }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -3,8 +3,11 @@ export class ExpectDiagnosticText {
     return `An argument for '${argumentNameText}' or type argument for '${typeArgumentNameText}' must be provided.`;
   }
 
-  static argumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
-    return `An argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
+  static argumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): Array<string> {
+    return [
+      `An argument for '${argumentNameText}' must be of ${expectedText}.`,
+      `Received type '${receivedTypeText}'.`,
+    ];
   }
 
   static argumentMustBeProvided(argumentNameText: string): string {
@@ -26,8 +29,11 @@ export class ExpectDiagnosticText {
     return `Overload ${indexText} of ${countText}, '${signatureText}', gave the following error.`;
   }
 
-  static typeArgumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): string {
-    return `A type argument for '${argumentNameText}' must be of ${expectedText}, received: '${receivedTypeText}'.`;
+  static typeArgumentMustBeOf(argumentNameText: string, expectedText: string, receivedTypeText: string): Array<string> {
+    return [
+      `A type argument for '${argumentNameText}' must be of ${expectedText}.`,
+      `Received type '${receivedTypeText}'.`,
+    ];
   }
 
   static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -38,6 +38,30 @@ export class ExpectDiagnosticText {
     return `A type argument for '${argumentNameText}' must be of ${expectedText}.`;
   }
 
+  static typeDidNotRaiseError(isTypeNode: boolean, expectedText?: string): string {
+    const text = [`${isTypeNode ? "Type" : "Expression type"} did not raise a type error`];
+
+    if (expectedText != null) {
+      text.push(" ", expectedText);
+    }
+
+    text.push(".");
+
+    return text.join("");
+  }
+
+  static typeRaisedError(isTypeNode: boolean, expectedText?: string): string {
+    const text = [`${isTypeNode ? "Type" : "Expression type"} raised a type error`];
+
+    if (expectedText != null) {
+      text.push(" ", expectedText);
+    }
+
+    text.push(".");
+
+    return text.join("");
+  }
+
   static typeDoesNotHaveProperty(typeText: string, propertyNameText: string): string {
     return `Type '${typeText}' does not have property '${propertyNameText}'.`;
   }

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -34,15 +34,19 @@ export class ExpectDiagnosticText {
     return `Overload ${indexText} of ${countText}, '${signatureText}', gave the following error.`;
   }
 
+  static raisedTypeError(count = 1): string {
+    return `The raised type error${count === 1 ? "" : "s"}:`;
+  }
+
   static typeArgumentMustBeOf(argumentNameText: string, expectedText: string): string {
     return `A type argument for '${argumentNameText}' must be of ${expectedText}.`;
   }
 
-  static typeDidNotRaiseError(isTypeNode: boolean, expectedText?: string): string {
+  static typeDidNotRaiseError(isTypeNode: boolean, options?: { expectedText?: string }): string {
     const text = [`${isTypeNode ? "Type" : "Expression type"} did not raise a type error`];
 
-    if (expectedText != null) {
-      text.push(" ", expectedText);
+    if (options?.expectedText != null) {
+      text.push(" ", options.expectedText);
     }
 
     text.push(".");
@@ -50,11 +54,11 @@ export class ExpectDiagnosticText {
     return text.join("");
   }
 
-  static typeRaisedError(isTypeNode: boolean, expectedText?: string): string {
+  static typeRaisedError(isTypeNode: boolean, options?: { expectedText?: string }): string {
     const text = [`${isTypeNode ? "Type" : "Expression type"} raised a type error`];
 
-    if (expectedText != null) {
-      text.push(" ", expectedText);
+    if (options?.expectedText != null) {
+      text.push(" ", options.expectedText);
     }
 
     text.push(".");

--- a/source/expect/PrimitiveTypeMatcher.ts
+++ b/source/expect/PrimitiveTypeMatcher.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 import { Diagnostic } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchResult, TypeChecker } from "./types.js";
 
 export class PrimitiveTypeMatcher {
@@ -14,7 +15,7 @@ export class PrimitiveTypeMatcher {
   #explain(sourceType: ts.Type) {
     const sourceTypeText = this.typeChecker.typeToString(sourceType);
 
-    return [Diagnostic.error(`The source type is '${sourceTypeText}'.`)];
+    return [Diagnostic.error(ExpectDiagnosticText.typeIs(sourceTypeText))];
   }
 
   match(sourceType: ts.Type): MatchResult {

--- a/source/expect/RelationMatcherBase.ts
+++ b/source/expect/RelationMatcherBase.ts
@@ -1,33 +1,16 @@
 import type ts from "typescript";
-import { Diagnostic } from "#diagnostic";
+import type { Diagnostic } from "#diagnostic";
 import type { MatchResult, Relation, TypeChecker } from "./types.js";
 
 export abstract class RelationMatcherBase {
-  abstract relation: Relation;
-  abstract relationExplanationText: string;
-  relationExplanationVerb = "is";
-  typeChecker: TypeChecker;
+  protected abstract relation: Relation;
+  protected typeChecker: TypeChecker;
 
   constructor(typeChecker: TypeChecker) {
     this.typeChecker = typeChecker;
   }
 
-  protected explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic> {
-    const sourceTypeText = this.typeChecker.typeToString(sourceType);
-    const targetTypeText = this.typeChecker.typeToString(targetType);
-
-    return isNot
-      ? [
-          Diagnostic.error(
-            `Type '${sourceTypeText}' ${this.relationExplanationVerb} ${this.relationExplanationText} type '${targetTypeText}'.`,
-          ),
-        ]
-      : [
-          Diagnostic.error(
-            `Type '${sourceTypeText}' ${this.relationExplanationVerb} not ${this.relationExplanationText} type '${targetTypeText}'.`,
-          ),
-        ];
-  }
+  abstract explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic>;
 
   match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
     const isMatch = this.typeChecker.isTypeRelatedTo(sourceType, targetType, this.relation);

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -40,10 +40,9 @@ export class ToAcceptProps {
     let signatureIndex = 0;
 
     for (const signature of source.signatures) {
-      const sourceText = this.#compiler.isTypeNode(source.node) ? "Component type" : "Component";
       const introText = isNot
-        ? `${sourceText} accepts props of the given type.`
-        : `${sourceText} does not accept props of the given type.`;
+        ? ExpectDiagnosticText.componentAcceptsProps(this.#compiler.isTypeNode(source.node))
+        : ExpectDiagnosticText.componentDoesNotAcceptProps(this.#compiler.isTypeNode(source.node));
 
       const { explanations, isMatch } = this.#explainProperties(signature, target, isNot);
 

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -151,7 +151,7 @@ export class ToAcceptProps {
             origin,
             text: [
               ...text,
-              `Type '${sourceTypeText}' is not compatible with type '${targetTypeText}'.`,
+              ExpectDiagnosticText.typeIsNotCompatibleWith(sourceTypeText, targetTypeText),
               ExpectDiagnosticText.typeDoesNotHaveProperty(sourceTypeText, targetPropertyName),
             ],
           });
@@ -165,7 +165,7 @@ export class ToAcceptProps {
             origin,
             text: [
               ...text,
-              `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`,
+              ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
               ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, targetPropertyName),
             ],
           });
@@ -186,9 +186,9 @@ export class ToAcceptProps {
             origin,
             text: [
               ...text,
-              `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`,
-              `Types of property '${targetPropertyName}' are incompatible.`,
-              `Type '${sourcePropertyTypeText}' is not assignable with type '${targetPropertyTypeText}'.`,
+              ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
+              ExpectDiagnosticText.typesOfPropertyAreNotCompatible(targetPropertyName),
+              ExpectDiagnosticText.typeIsNotAssignableWith(sourcePropertyTypeText, targetPropertyTypeText),
             ],
           });
         }
@@ -207,7 +207,7 @@ export class ToAcceptProps {
               origin,
               text: [
                 ...text,
-                `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`,
+                ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
                 ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, sourcePropertyName),
               ],
             });
@@ -220,7 +220,7 @@ export class ToAcceptProps {
 
         explanations.push({
           origin,
-          text: [...text, `Type '${sourceTypeText}' is assignable with type '${targetTypeText}'.`],
+          text: [...text, ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)],
         });
 
         return { explanations, isMatch: true };
@@ -235,8 +235,8 @@ export class ToAcceptProps {
       for (const sourceType of sourceParameterType.types) {
         const { explanations, isMatch } = explain(sourceType, target.type, [
           isNot
-            ? `Type '${sourceTypeText}' is assignable with type '${targetTypeText}'.`
-            : `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`,
+            ? ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)
+            : ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
         ]);
 
         if (isMatch === true) {

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchResult, TypeChecker } from "./types.js";
 
 interface Explanation {
@@ -151,7 +152,7 @@ export class ToAcceptProps {
             text: [
               ...text,
               `Type '${sourceTypeText}' is not compatible with type '${targetTypeText}'.`,
-              `Type '${sourceTypeText}' does not have property '${targetPropertyName}'.`,
+              ExpectDiagnosticText.typeDoesNotHaveProperty(sourceTypeText, targetPropertyName),
             ],
           });
           continue;

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -55,7 +55,11 @@ export class ToAcceptProps {
       for (const { origin, text } of explanations) {
         if (source.signatures.length > 1) {
           const signatureText = this.#typeChecker.signatureToString(signature, source.node);
-          const overloadText = `Overload ${signatureIndex + 1} of ${source.signatures.length}, '${signatureText}', gave the following error.`;
+          const overloadText = ExpectDiagnosticText.overloadGaveTheFollowingError(
+            String(signatureIndex + 1),
+            String(source.signatures.length),
+            signatureText,
+          );
 
           diagnostics.push(Diagnostic.error([introText, overloadText, ...text], origin));
         } else {

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -166,7 +166,7 @@ export class ToAcceptProps {
             text: [
               ...text,
               `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`,
-              `Type '${sourceTypeText}' requires property '${targetPropertyName}' .`,
+              ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, targetPropertyName),
             ],
           });
 
@@ -208,7 +208,7 @@ export class ToAcceptProps {
               text: [
                 ...text,
                 `Type '${sourceTypeText}' is not assignable with type '${targetTypeText}'.`,
-                `Type '${sourceTypeText}' requires property '${sourcePropertyName}' .`,
+                ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, sourcePropertyName),
               ],
             });
           }

--- a/source/expect/ToBe.ts
+++ b/source/expect/ToBe.ts
@@ -1,6 +1,17 @@
+import type ts from "typescript";
+import { Diagnostic } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
 
 export class ToBe extends RelationMatcherBase {
   relation = this.typeChecker.relation.identity;
-  relationExplanationText = "identical to";
+
+  override explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic> {
+    const sourceTypeText = this.typeChecker.typeToString(sourceType);
+    const targetTypeText = this.typeChecker.typeToString(targetType);
+
+    return isNot
+      ? [Diagnostic.error(ExpectDiagnosticText.typeIsIdenticalTo(sourceTypeText, targetTypeText))]
+      : [Diagnostic.error(ExpectDiagnosticText.typeIsNotIdenticalTo(sourceTypeText, targetTypeText))];
+  }
 }

--- a/source/expect/ToBeAssignableTo.ts
+++ b/source/expect/ToBeAssignableTo.ts
@@ -1,6 +1,17 @@
+import type ts from "typescript";
+import { Diagnostic } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
 
 export class ToBeAssignableTo extends RelationMatcherBase {
   relation = this.typeChecker.relation.assignable;
-  relationExplanationText = "assignable to";
+
+  override explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic> {
+    const sourceTypeText = this.typeChecker.typeToString(sourceType);
+    const targetTypeText = this.typeChecker.typeToString(targetType);
+
+    return isNot
+      ? [Diagnostic.error(ExpectDiagnosticText.typeIsAssignableTo(sourceTypeText, targetTypeText))]
+      : [Diagnostic.error(ExpectDiagnosticText.typeIsNotAssignableTo(sourceTypeText, targetTypeText))];
+  }
 }

--- a/source/expect/ToBeAssignableWith.ts
+++ b/source/expect/ToBeAssignableWith.ts
@@ -1,10 +1,21 @@
 import type ts from "typescript";
+import { Diagnostic } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
 import type { MatchResult } from "./types.js";
 
 export class ToBeAssignableWith extends RelationMatcherBase {
   relation = this.typeChecker.relation.assignable;
   relationExplanationText = "assignable with";
+
+  override explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic> {
+    const sourceTypeText = this.typeChecker.typeToString(sourceType);
+    const targetTypeText = this.typeChecker.typeToString(targetType);
+
+    return isNot
+      ? [Diagnostic.error(ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText))]
+      : [Diagnostic.error(ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText))];
+  }
 
   override match(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): MatchResult {
     const isMatch = this.typeChecker.isTypeRelatedTo(targetType, sourceType, this.relation);

--- a/source/expect/ToHaveProperty.ts
+++ b/source/expect/ToHaveProperty.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchResult, TypeChecker } from "./types.js";
 
 export interface ToHavePropertyTarget {
@@ -18,19 +19,19 @@ export class ToHaveProperty {
 
   #explain(sourceType: ts.Type, target: ToHavePropertyTarget, isNot: boolean) {
     const sourceTypeText = this.typeChecker.typeToString(sourceType);
-    let targetArgumentText: string;
+    let propertyNameText: string;
 
     if (this.#isStringOrNumberLiteralType(target.type)) {
-      targetArgumentText = String(target.type.value);
+      propertyNameText = String(target.type.value);
     } else {
-      targetArgumentText = `[${this.compiler.unescapeLeadingUnderscores(target.type.symbol.escapedName)}]`;
+      propertyNameText = `[${this.compiler.unescapeLeadingUnderscores(target.type.symbol.escapedName)}]`;
     }
 
     const origin = DiagnosticOrigin.fromNode(target.node);
 
     return isNot
-      ? [Diagnostic.error(`Type '${sourceTypeText}' has property '${targetArgumentText}'.`, origin)]
-      : [Diagnostic.error(`Type '${sourceTypeText}' does not have property '${targetArgumentText}'.`, origin)];
+      ? [Diagnostic.error(ExpectDiagnosticText.typeHasProperty(sourceTypeText, propertyNameText), origin)]
+      : [Diagnostic.error(ExpectDiagnosticText.typeDoesNotHaveProperty(sourceTypeText, propertyNameText), origin)];
   }
 
   #isStringOrNumberLiteralType(type: ts.Type): type is ts.StringLiteralType | ts.NumberLiteralType {

--- a/source/expect/ToMatch.ts
+++ b/source/expect/ToMatch.ts
@@ -1,7 +1,17 @@
+import type ts from "typescript";
+import { Diagnostic } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
 
 export class ToMatch extends RelationMatcherBase {
   relation = this.typeChecker.relation.subtype;
-  relationExplanationText = "match";
-  override relationExplanationVerb = "does";
+
+  override explain(sourceType: ts.Type, targetType: ts.Type, isNot: boolean): Array<Diagnostic> {
+    const sourceTypeText = this.typeChecker.typeToString(sourceType);
+    const targetTypeText = this.typeChecker.typeToString(targetType);
+
+    return isNot
+      ? [Diagnostic.error(ExpectDiagnosticText.typeDoesMatch(sourceTypeText, targetTypeText))]
+      : [Diagnostic.error(ExpectDiagnosticText.typeDoesNotMatch(sourceTypeText, targetTypeText))];
+  }
 }

--- a/source/expect/ToRaiseError.ts
+++ b/source/expect/ToRaiseError.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 import { Diagnostic } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchResult, TypeChecker } from "./types.js";
 
 export interface ToRaiseErrorSource {
@@ -21,19 +22,21 @@ export class ToRaiseError {
     targetTypes: Array<ts.StringLiteralType | ts.NumberLiteralType>,
     isNot: boolean,
   ) {
-    const sourceText = this.compiler.isTypeNode(source.node) ? "Type expression" : "Expression";
+    const sourceText = this.compiler.isTypeNode(source.node) ? "Type" : "Expression type";
 
     if (source.diagnostics.length === 0) {
-      return [Diagnostic.error(`${sourceText} did not raise a type error.`)];
+      const text = ExpectDiagnosticText.typeDidNotRaiseError(this.compiler.isTypeNode(source.node));
+
+      return [Diagnostic.error(text)];
     }
 
     if (source.diagnostics.length !== targetTypes.length) {
-      const foundText =
+      const countText =
         source.diagnostics.length > targetTypes.length
           ? String(source.diagnostics.length)
           : `only ${String(source.diagnostics.length)}`;
 
-      const text = `${sourceText} raised ${foundText} type error${source.diagnostics.length === 1 ? "" : "s"}.`;
+      const text = `${sourceText} raised ${countText} type error${source.diagnostics.length === 1 ? "" : "s"}.`;
 
       const related = [
         Diagnostic.error(`The raised type error${source.diagnostics.length === 1 ? "" : "s"}:`),
@@ -55,8 +58,8 @@ export class ToRaiseError {
             : `with code ${String(argument.value)}`;
 
           const text = isNot
-            ? `${sourceText} raised a type error ${expectedText}.`
-            : `${sourceText} did not raise a type error ${expectedText}.`;
+            ? ExpectDiagnosticText.typeRaisedError(this.compiler.isTypeNode(source.node), expectedText)
+            : ExpectDiagnosticText.typeDidNotRaiseError(this.compiler.isTypeNode(source.node), expectedText);
 
           const related = [
             Diagnostic.error("The raised type error:"),

--- a/source/expect/ToRaiseError.ts
+++ b/source/expect/ToRaiseError.ts
@@ -39,7 +39,7 @@ export class ToRaiseError {
       const text = `${sourceText} raised ${countText} type error${source.diagnostics.length === 1 ? "" : "s"}.`;
 
       const related = [
-        Diagnostic.error(`The raised type error${source.diagnostics.length === 1 ? "" : "s"}:`),
+        Diagnostic.error(ExpectDiagnosticText.raisedTypeError(source.diagnostics.length)),
         ...Diagnostic.fromDiagnostics(source.diagnostics, this.compiler),
       ];
 
@@ -58,11 +58,11 @@ export class ToRaiseError {
             : `with code ${String(argument.value)}`;
 
           const text = isNot
-            ? ExpectDiagnosticText.typeRaisedError(this.compiler.isTypeNode(source.node), expectedText)
-            : ExpectDiagnosticText.typeDidNotRaiseError(this.compiler.isTypeNode(source.node), expectedText);
+            ? ExpectDiagnosticText.typeRaisedError(this.compiler.isTypeNode(source.node), { expectedText })
+            : ExpectDiagnosticText.typeDidNotRaiseError(this.compiler.isTypeNode(source.node), { expectedText });
 
           const related = [
-            Diagnostic.error("The raised type error:"),
+            Diagnostic.error(ExpectDiagnosticText.raisedTypeError()),
             ...Diagnostic.fromDiagnostics([diagnostic], this.compiler),
           ];
 

--- a/source/expect/ToRaiseError.ts
+++ b/source/expect/ToRaiseError.ts
@@ -32,9 +32,8 @@ export class ToRaiseError {
 
     if (source.diagnostics.length !== targetTypes.length) {
       const count = source.diagnostics.length;
-      const targetCount = targetTypes.length;
 
-      const text = ExpectDiagnosticText.typeRaisedError(isTypeNode, { count, targetCount });
+      const text = ExpectDiagnosticText.typeRaisedError(isTypeNode, count, targetTypes.length);
 
       const related = [
         Diagnostic.error(ExpectDiagnosticText.raisedTypeError(count)),

--- a/tests/__snapshots__/api-toAcceptProps-class-components-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-class-components-stderr.snap.txt
@@ -128,7 +128,7 @@ Type 'SecondProps' is assignable with type '{ one: string; two: boolean; }'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{}'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   79 |   test("property is required in props type", () => {
   80 |     expect(Second).type.not.toAcceptProps({});
@@ -143,7 +143,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   82 | 
   83 |     expect(Second).type.not.toAcceptProps({ two: true });
@@ -158,7 +158,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   86 |     const secondProps = { two: true };
   87 |     expect(Second).type.not.toAcceptProps(secondProps);
@@ -173,7 +173,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   90 |     const two = true;
   91 |     expect(Second).type.not.toAcceptProps({ two });
@@ -248,7 +248,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   105 | 
   106 |     expect(Second).type.not.toAcceptProps({ three: 123 });
@@ -278,7 +278,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   109 |     const secondProps = { three: 123 };
   110 |     expect(Second).type.not.toAcceptProps(secondProps);
@@ -324,7 +324,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   112 | 
   113 |     expect(Second).type.not.toAcceptProps({ two: "no", three: 123 });
@@ -746,7 +746,7 @@ Type 'SecondProps' is assignable with type '{ one: string; two: boolean; }'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{}'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   201 |   test("property is required in props type", () => {
   202 |     expect<Second>().type.not.toAcceptProps<{}>();
@@ -761,7 +761,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one?: string | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   204 | 
   205 |     expect<Second>().type.not.toAcceptProps<{ one?: string }>();
@@ -776,7 +776,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two?: boolean | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   207 | 
   208 |     expect<Second>().type.not.toAcceptProps<{ two?: boolean }>();
@@ -791,7 +791,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   210 | 
   211 |     expect<Second>().type.not.toAcceptProps<{ two: boolean }>();
@@ -806,7 +806,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   214 |     type SecondPropsSample = { two: boolean };
   215 |     expect<Second>().type.not.toAcceptProps<SecondPropsSample>();
@@ -821,7 +821,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one?: string | undefined; two?: boolean | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   217 | 
   218 |     expect<Second>().type.not.toAcceptProps<{ one?: string; two?: boolean }>();
@@ -926,7 +926,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three?: number | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   238 | 
   239 |     expect<Second>().type.not.toAcceptProps<{ three?: number }>();
@@ -956,7 +956,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   241 | 
   242 |     expect<Second>().type.not.toAcceptProps<{ three: number }>();
@@ -986,7 +986,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   245 |     type SecondPropsSample = { three: number };
   246 |     expect<Second>().type.not.toAcceptProps<SecondPropsSample>();
@@ -1032,7 +1032,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three?: number | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   248 | 
   249 |     expect<Second>().type.not.toAcceptProps<{ two: string; three?: number }>();
@@ -1078,7 +1078,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   251 | 
   252 |     expect<Second>().type.not.toAcceptProps<{ two: string; three: number }>();

--- a/tests/__snapshots__/api-toAcceptProps-class-components-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-class-components-stderr.snap.txt
@@ -293,7 +293,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   112 | 
@@ -354,7 +354,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   119 | 
@@ -385,7 +385,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   122 | 
@@ -446,7 +446,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   133 |   test("property type is not assignable to prop type", () => {
@@ -462,7 +462,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   137 |     const firstProps = { one: 1 };
@@ -478,7 +478,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   140 | 
@@ -494,7 +494,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   143 | 
@@ -510,7 +510,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   143 | 
@@ -526,7 +526,7 @@ Type 'boolean | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   147 |     const secondProps = { one: 1, two: 2 };
@@ -542,7 +542,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   147 |     const secondProps = { one: 1, two: 2 };
@@ -558,7 +558,7 @@ Type 'boolean | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   151 |     const two = 2;
@@ -574,7 +574,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   151 |     const two = 2;
@@ -1001,7 +1001,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three?: number | undefined; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   248 | 
@@ -1047,7 +1047,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   251 | 
@@ -1093,7 +1093,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three?: number | undefined; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   254 | 
@@ -1124,7 +1124,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   257 | 
@@ -1185,7 +1185,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one?: number | undefined; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number | undefined'.
 
   268 |   test("property type is not assignable to prop type", () => {
@@ -1201,7 +1201,7 @@ Type 'string | undefined' is not assignable with type 'number | undefined'.
 Error: Component type does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   271 | 
@@ -1217,7 +1217,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type 'FirstPropsSample'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   275 |     type FirstPropsSample = { one: number };
@@ -1233,7 +1233,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   278 | 
@@ -1249,7 +1249,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two?: number | undefined; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   281 | 
@@ -1265,7 +1265,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two?: number | undefined; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number | undefined'.
 
   281 | 
@@ -1281,7 +1281,7 @@ Type 'boolean | undefined' is not assignable with type 'number | undefined'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   284 | 
@@ -1297,7 +1297,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   284 | 
@@ -1313,7 +1313,7 @@ Type 'boolean | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   288 |     type SecondPropsSample = { one: number; two: number };
@@ -1329,7 +1329,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   288 |     type SecondPropsSample = { one: number; two: number };

--- a/tests/__snapshots__/api-toAcceptProps-function-components-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-function-components-stderr.snap.txt
@@ -293,7 +293,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   91 | 
@@ -354,7 +354,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
    98 | 
@@ -385,7 +385,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   101 | 
@@ -446,7 +446,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   112 |   test("property type is not assignable to prop type", () => {
@@ -462,7 +462,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   116 |     const firstProps = { one: 1 };
@@ -478,7 +478,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   119 | 
@@ -494,7 +494,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   122 | 
@@ -510,7 +510,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   122 | 
@@ -526,7 +526,7 @@ Type 'boolean | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   126 |     const secondProps = { one: 1, two: 2 };
@@ -542,7 +542,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   126 |     const secondProps = { one: 1, two: 2 };
@@ -558,7 +558,7 @@ Type 'boolean | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   130 |     const two = 2;
@@ -574,7 +574,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   130 |     const two = 2;
@@ -1001,7 +1001,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three?: number | undefined; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   227 | 
@@ -1047,7 +1047,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   230 | 
@@ -1093,7 +1093,7 @@ Type 'SecondProps' requires property 'one'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three?: number | undefined; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   233 | 
@@ -1124,7 +1124,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: string; two: string; three: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'string'.
 
   236 | 
@@ -1185,7 +1185,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one?: number | undefined; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number | undefined'.
 
   247 |   test("property type is not assignable to prop type", () => {
@@ -1201,7 +1201,7 @@ Type 'string | undefined' is not assignable with type 'number | undefined'.
 Error: Component type does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   250 | 
@@ -1217,7 +1217,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'FirstProps' is not assignable with type 'FirstPropsSample'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   254 |     type FirstPropsSample = { one: number };
@@ -1233,7 +1233,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   257 | 
@@ -1249,7 +1249,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two?: number | undefined; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   260 | 
@@ -1265,7 +1265,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two?: number | undefined; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number | undefined'.
 
   260 | 
@@ -1281,7 +1281,7 @@ Type 'boolean | undefined' is not assignable with type 'number | undefined'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   263 | 
@@ -1297,7 +1297,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one: number; two: number; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   263 | 
@@ -1313,7 +1313,7 @@ Type 'boolean | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string | undefined' is not assignable with type 'number'.
 
   267 |     type SecondPropsSample = { one: number; two: number };
@@ -1329,7 +1329,7 @@ Type 'string | undefined' is not assignable with type 'number'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'boolean | undefined' is not assignable with type 'number'.
 
   267 |     type SecondPropsSample = { one: number; two: number };

--- a/tests/__snapshots__/api-toAcceptProps-function-components-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-function-components-stderr.snap.txt
@@ -128,7 +128,7 @@ Type 'SecondProps' is assignable with type '{ one: string; two: boolean; }'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{}'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   58 |   test("property is required in props type", () => {
   59 |     expect(Second).type.not.toAcceptProps({});
@@ -143,7 +143,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   61 | 
   62 |     expect(Second).type.not.toAcceptProps({ two: true });
@@ -158,7 +158,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   65 |     const secondProps = { two: true };
   66 |     expect(Second).type.not.toAcceptProps(secondProps);
@@ -173,7 +173,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   69 |     const two = true;
   70 |     expect(Second).type.not.toAcceptProps({ two });
@@ -248,7 +248,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   84 | 
   85 |     expect(Second).type.not.toAcceptProps({ three: 123 });
@@ -278,7 +278,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   88 |     const secondProps = { three: 123 };
   89 |     expect(Second).type.not.toAcceptProps(secondProps);
@@ -324,7 +324,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   91 | 
   92 |     expect(Second).type.not.toAcceptProps({ two: "no", three: 123 });
@@ -746,7 +746,7 @@ Type 'SecondProps' is assignable with type '{ one: string; two: boolean; }'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{}'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   180 |   test("property is required in props type", () => {
   181 |     expect<Second>().type.not.toAcceptProps<{}>();
@@ -761,7 +761,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one?: string | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   183 | 
   184 |     expect<Second>().type.not.toAcceptProps<{ one?: string }>();
@@ -776,7 +776,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two?: boolean | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   186 | 
   187 |     expect<Second>().type.not.toAcceptProps<{ two?: boolean }>();
@@ -791,7 +791,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: boolean; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   189 | 
   190 |     expect<Second>().type.not.toAcceptProps<{ two: boolean }>();
@@ -806,7 +806,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   193 |     type SecondPropsSample = { two: boolean };
   194 |     expect<Second>().type.not.toAcceptProps<SecondPropsSample>();
@@ -821,7 +821,7 @@ Type 'SecondProps' requires property 'one' .
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ one?: string | undefined; two?: boolean | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   196 | 
   197 |     expect<Second>().type.not.toAcceptProps<{ one?: string; two?: boolean }>();
@@ -926,7 +926,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three?: number | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   217 | 
   218 |     expect<Second>().type.not.toAcceptProps<{ three?: number }>();
@@ -956,7 +956,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   220 | 
   221 |     expect<Second>().type.not.toAcceptProps<{ three: number }>();
@@ -986,7 +986,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type 'SecondPropsSample'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   224 |     type SecondPropsSample = { three: number };
   225 |     expect<Second>().type.not.toAcceptProps<SecondPropsSample>();
@@ -1032,7 +1032,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three?: number | undefined; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   227 | 
   228 |     expect<Second>().type.not.toAcceptProps<{ two: string; three?: number }>();
@@ -1078,7 +1078,7 @@ Type 'SecondProps' does not have property 'three'.
 Error: Component type does not accept props of the given type.
 
 Type 'SecondProps' is not assignable with type '{ two: string; three: number; }'.
-Type 'SecondProps' requires property 'one' .
+Type 'SecondProps' requires property 'one'.
 
   230 | 
   231 |     expect<Second>().type.not.toAcceptProps<{ two: string; three: number }>();

--- a/tests/__snapshots__/api-toAcceptProps-overloaded-components-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-overloaded-components-stderr.snap.txt
@@ -96,7 +96,7 @@ Error: Component does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ one: boolean; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string' is not assignable with type 'boolean'.
 
   45 |   test("property type is not assignable to prop type", () => {
@@ -129,7 +129,7 @@ Error: Component does not accept props of the given type.
 
 Overload 2 of 2, '(props: SecondProps): React.JSX.Element', gave the following error.
 Type 'SecondProps' is not assignable with type '{ one: boolean; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'undefined' is not assignable with type 'boolean'.
 
   45 |   test("property type is not assignable to prop type", () => {
@@ -288,7 +288,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ one: boolean; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string' is not assignable with type 'boolean'.
 
   70 |   test("property type is not assignable to prop type", () => {
@@ -321,7 +321,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 2 of 2, '(props: SecondProps): React.JSX.Element', gave the following error.
 Type 'SecondProps' is not assignable with type '{ one: boolean; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'undefined' is not assignable with type 'boolean'.
 
   70 |   test("property type is not assignable to prop type", () => {

--- a/tests/__snapshots__/api-toAcceptProps-overloaded-components-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-overloaded-components-stderr.snap.txt
@@ -48,7 +48,7 @@ Error: Component does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ enable: boolean; }'.
-Type 'FirstProps' requires property 'one' .
+Type 'FirstProps' requires property 'one'.
 
   40 |   test("property does not exist in props type", () => {
   41 |     expect(OverloadFunction).type.not.toAcceptProps({ enable: true });
@@ -64,7 +64,7 @@ Error: Component does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ enable: boolean; }'.
-Type 'FirstProps' requires property 'two' .
+Type 'FirstProps' requires property 'two'.
 
   40 |   test("property does not exist in props type", () => {
   41 |     expect(OverloadFunction).type.not.toAcceptProps({ enable: true });
@@ -113,7 +113,7 @@ Error: Component does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ one: boolean; }'.
-Type 'FirstProps' requires property 'two' .
+Type 'FirstProps' requires property 'two'.
 
   45 |   test("property type is not assignable to prop type", () => {
   46 |     expect(OverloadFunction).type.not.toAcceptProps({ one: true });
@@ -176,7 +176,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ three?: boolean | undefined; }'.
-Type 'FirstProps' requires property 'one' .
+Type 'FirstProps' requires property 'one'.
 
   60 |   test("property is required in props type", () => {
   61 |     expect<Overload>().type.not.toAcceptProps<{ three?: boolean }>();
@@ -192,7 +192,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ three?: boolean | undefined; }'.
-Type 'FirstProps' requires property 'two' .
+Type 'FirstProps' requires property 'two'.
 
   60 |   test("property is required in props type", () => {
   61 |     expect<Overload>().type.not.toAcceptProps<{ three?: boolean }>();
@@ -240,7 +240,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ enable: boolean; }'.
-Type 'FirstProps' requires property 'one' .
+Type 'FirstProps' requires property 'one'.
 
   65 |   test("property does not exist in props type", () => {
   66 |     expect<Overload>().type.not.toAcceptProps<{ enable: boolean }>();
@@ -256,7 +256,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ enable: boolean; }'.
-Type 'FirstProps' requires property 'two' .
+Type 'FirstProps' requires property 'two'.
 
   65 |   test("property does not exist in props type", () => {
   66 |     expect<Overload>().type.not.toAcceptProps<{ enable: boolean }>();
@@ -305,7 +305,7 @@ Error: Component type does not accept props of the given type.
 
 Overload 1 of 2, '(props: FirstProps): React.JSX.Element', gave the following error.
 Type 'FirstProps' is not assignable with type '{ one: boolean; }'.
-Type 'FirstProps' requires property 'two' .
+Type 'FirstProps' requires property 'two'.
 
   70 |   test("property type is not assignable to prop type", () => {
   71 |     expect<Overload>().type.not.toAcceptProps<{ one: boolean }>();

--- a/tests/__snapshots__/api-toAcceptProps-special-cases-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-special-cases-stderr.snap.txt
@@ -15,7 +15,7 @@ Type '{ one: string; }' is assignable with type '{ one: string; }'.
 Error: Component does not accept props of the given type.
 
 Type '{ one: string; }' is not assignable with type '{}'.
-Type '{ one: string; }' requires property 'one' .
+Type '{ one: string; }' requires property 'one'.
 
   11 | 
   12 |     expect(Default).type.not.toAcceptProps({});
@@ -45,7 +45,7 @@ Type '{ one: string; }' does not have property 'two'.
 Error: Component does not accept props of the given type.
 
 Type '{ one: string; }' is not assignable with type '{ two: boolean; }'.
-Type '{ one: string; }' requires property 'one' .
+Type '{ one: string; }' requires property 'one'.
 
   14 | 
   15 |     expect(Default).type.not.toAcceptProps({ two: false });
@@ -141,7 +141,7 @@ Error: Component does not accept props of the given type.
 
 Type 'One | Other' is not assignable with type '{}'.
 Type 'One' is not assignable with type '{}'.
-Type 'One' requires property 'one' .
+Type 'One' requires property 'one'.
 
   42 | 
   43 |     expect(OneOrTheOther).type.not.toAcceptProps({});
@@ -157,7 +157,7 @@ Error: Component does not accept props of the given type.
 
 Type 'One | Other' is not assignable with type '{}'.
 Type 'Other' is not assignable with type '{}'.
-Type 'Other' requires property 'two' .
+Type 'Other' requires property 'two'.
 
   42 | 
   43 |     expect(OneOrTheOther).type.not.toAcceptProps({});
@@ -189,7 +189,7 @@ Error: Component does not accept props of the given type.
 
 Type 'One | Other' is not assignable with type '{ three: boolean; }'.
 Type 'One' is not assignable with type '{ three: boolean; }'.
-Type 'One' requires property 'one' .
+Type 'One' requires property 'one'.
 
   45 | 
   46 |     expect(OneOrTheOther).type.not.toAcceptProps({ three: false });
@@ -221,7 +221,7 @@ Error: Component does not accept props of the given type.
 
 Type 'One | Other' is not assignable with type '{ three: boolean; }'.
 Type 'Other' is not assignable with type '{ three: boolean; }'.
-Type 'Other' requires property 'two' .
+Type 'Other' requires property 'two'.
 
   45 | 
   46 |     expect(OneOrTheOther).type.not.toAcceptProps({ three: false });

--- a/tests/__snapshots__/api-toAcceptProps-special-cases-stderr.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-special-cases-stderr.snap.txt
@@ -60,7 +60,7 @@ Type '{ one: string; }' requires property 'one'.
 Error: Component does not accept props of the given type.
 
 Type '{ one: string; }' is not assignable with type '{ one: boolean; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'string' is not assignable with type 'boolean'.
 
   17 | 
@@ -107,7 +107,7 @@ Error: Component does not accept props of the given type.
 
 Type 'One | Other' is not assignable with type '{ one: string; two: string; }'.
 Type 'One' is not assignable with type '{ one: string; two: string; }'.
-Types of property 'two' are incompatible.
+Types of property 'two' are not compatible.
 Type 'undefined' is not assignable with type 'string'.
 
   39 | 
@@ -124,7 +124,7 @@ Error: Component does not accept props of the given type.
 
 Type 'One | Other' is not assignable with type '{ one: string; two: string; }'.
 Type 'Other' is not assignable with type '{ one: string; two: string; }'.
-Types of property 'one' are incompatible.
+Types of property 'one' are not compatible.
 Type 'undefined' is not assignable with type 'string'.
 
   39 | 

--- a/tests/__snapshots__/api-toBeAny-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAny-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
    7 |   expect(returnsAny()).type.toBeAny();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'string'.
 
        at ./__typetests__/toBeAny.tst.ts:9:32 ❭ is any?
 
-Error: The source type is 'any'.
+Error: The type is 'any'.
 
   13 |   expect(returnsString()).type.not.toBeAny();
   14 | 

--- a/tests/__snapshots__/api-toBeAny-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeAny-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'string'.
+Error: Type is 'string'.
 
    7 |   expect(returnsAny()).type.toBeAny();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'string'.
 
        at ./__typetests__/toBeAny.tst.ts:9:32 ❭ is any?
 
-Error: The type is 'any'.
+Error: Type is 'any'.
 
   13 |   expect(returnsString()).type.not.toBeAny();
   14 | 

--- a/tests/__snapshots__/api-toBeBigInt-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeBigInt-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
    7 |   expect(returnsBigInt()).type.toBeBigInt();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'void'.
 
        at ./__typetests__/toBeBigInt.tst.ts:9:30 ❭ is bigint?
 
-Error: The source type is 'bigint'.
+Error: The type is 'bigint'.
 
   13 |   expect(returnsVoid()).type.not.toBeBigInt();
   14 | 

--- a/tests/__snapshots__/api-toBeBigInt-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeBigInt-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'void'.
+Error: Type is 'void'.
 
    7 |   expect(returnsBigInt()).type.toBeBigInt();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'void'.
 
        at ./__typetests__/toBeBigInt.tst.ts:9:30 ❭ is bigint?
 
-Error: The type is 'bigint'.
+Error: Type is 'bigint'.
 
   13 |   expect(returnsVoid()).type.not.toBeBigInt();
   14 | 

--- a/tests/__snapshots__/api-toBeBoolean-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeBoolean-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
    7 |   expect(returnsBoolean()).type.toBeBoolean();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'string'.
 
        at ./__typetests__/toBeBoolean.tst.ts:9:32 ❭ is boolean?
 
-Error: The source type is 'boolean'.
+Error: The type is 'boolean'.
 
   13 |   expect(returnsString()).type.not.toBeBoolean();
   14 | 

--- a/tests/__snapshots__/api-toBeBoolean-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeBoolean-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'string'.
+Error: Type is 'string'.
 
    7 |   expect(returnsBoolean()).type.toBeBoolean();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'string'.
 
        at ./__typetests__/toBeBoolean.tst.ts:9:32 ❭ is boolean?
 
-Error: The type is 'boolean'.
+Error: Type is 'boolean'.
 
   13 |   expect(returnsString()).type.not.toBeBoolean();
   14 | 

--- a/tests/__snapshots__/api-toBeNever-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNever-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'string'.
+Error: Type is 'string'.
 
    7 |   expect(returnsNever()).type.toBeNever();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'string'.
 
        at ./__typetests__/toBeNever.tst.ts:9:32 ❭ is never?
 
-Error: The type is 'never'.
+Error: Type is 'never'.
 
   13 |   expect(returnsString()).type.not.toBeNever();
   14 | 

--- a/tests/__snapshots__/api-toBeNever-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNever-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
    7 |   expect(returnsNever()).type.toBeNever();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'string'.
 
        at ./__typetests__/toBeNever.tst.ts:9:32 ❭ is never?
 
-Error: The source type is 'never'.
+Error: The type is 'never'.
 
   13 |   expect(returnsString()).type.not.toBeNever();
   14 | 

--- a/tests/__snapshots__/api-toBeNull-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNull-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'void'.
+Error: Type is 'void'.
 
    7 |   expect(returnsNull()).type.toBeNull();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'void'.
 
        at ./__typetests__/toBeNull.tst.ts:9:30 ❭ is null?
 
-Error: The type is 'null'.
+Error: Type is 'null'.
 
   13 |   expect(returnsVoid()).type.not.toBeNull();
   14 | 

--- a/tests/__snapshots__/api-toBeNull-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNull-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
    7 |   expect(returnsNull()).type.toBeNull();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'void'.
 
        at ./__typetests__/toBeNull.tst.ts:9:30 ❭ is null?
 
-Error: The source type is 'null'.
+Error: The type is 'null'.
 
   13 |   expect(returnsVoid()).type.not.toBeNull();
   14 | 

--- a/tests/__snapshots__/api-toBeNumber-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNumber-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'void'.
+Error: Type is 'void'.
 
    7 |   expect(returnsNumber()).type.toBeNumber();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'void'.
 
        at ./__typetests__/toBeNumber.tst.ts:9:30 ❭ is number?
 
-Error: The type is 'number'.
+Error: Type is 'number'.
 
   13 |   expect(returnsVoid()).type.not.toBeNumber();
   14 | 

--- a/tests/__snapshots__/api-toBeNumber-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeNumber-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
    7 |   expect(returnsNumber()).type.toBeNumber();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'void'.
 
        at ./__typetests__/toBeNumber.tst.ts:9:30 ❭ is number?
 
-Error: The source type is 'number'.
+Error: The type is 'number'.
 
   13 |   expect(returnsVoid()).type.not.toBeNumber();
   14 | 

--- a/tests/__snapshots__/api-toBeString-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeString-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'void'.
+Error: Type is 'void'.
 
    7 |   expect(returnsString()).type.toBeString();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'void'.
 
        at ./__typetests__/toBeString.tst.ts:9:30 ❭ is string?
 
-Error: The type is 'string'.
+Error: Type is 'string'.
 
   13 |   expect(returnsVoid()).type.not.toBeString();
   14 | 

--- a/tests/__snapshots__/api-toBeString-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeString-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
    7 |   expect(returnsString()).type.toBeString();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'void'.
 
        at ./__typetests__/toBeString.tst.ts:9:30 ❭ is string?
 
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
   13 |   expect(returnsVoid()).type.not.toBeString();
   14 | 

--- a/tests/__snapshots__/api-toBeSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeSymbol-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
    7 |   expect(returnsSymbol()).type.toBeSymbol();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'void'.
 
        at ./__typetests__/toBeSymbol.tst.ts:9:30 ❭ is symbol?
 
-Error: The source type is 'symbol'.
+Error: The type is 'symbol'.
 
   13 |   expect(returnsVoid()).type.not.toBeSymbol();
   14 | 

--- a/tests/__snapshots__/api-toBeSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeSymbol-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'void'.
+Error: Type is 'void'.
 
    7 |   expect(returnsSymbol()).type.toBeSymbol();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'void'.
 
        at ./__typetests__/toBeSymbol.tst.ts:9:30 ❭ is symbol?
 
-Error: The type is 'symbol'.
+Error: Type is 'symbol'.
 
   13 |   expect(returnsVoid()).type.not.toBeSymbol();
   14 | 

--- a/tests/__snapshots__/api-toBeUndefined-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUndefined-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'string'.
+Error: Type is 'string'.
 
    7 |   expect(returnsUndefined()).type.toBeUndefined();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'string'.
 
        at ./__typetests__/toBeUndefined.tst.ts:9:32 ❭ is undefined?
 
-Error: The type is 'undefined'.
+Error: Type is 'undefined'.
 
   13 |   expect(returnsString()).type.not.toBeUndefined();
   14 | 

--- a/tests/__snapshots__/api-toBeUndefined-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUndefined-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
    7 |   expect(returnsUndefined()).type.toBeUndefined();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'string'.
 
        at ./__typetests__/toBeUndefined.tst.ts:9:32 ❭ is undefined?
 
-Error: The source type is 'undefined'.
+Error: The type is 'undefined'.
 
   13 |   expect(returnsString()).type.not.toBeUndefined();
   14 | 

--- a/tests/__snapshots__/api-toBeUniqueSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUniqueSymbol-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'void'.
+Error: Type is 'void'.
 
    9 |   expect(returnsUniqueSymbol()).type.toBeUniqueSymbol();
   10 | 
@@ -10,7 +10,7 @@ Error: The type is 'void'.
 
        at ./__typetests__/toBeUniqueSymbol.tst.ts:11:30 ❭ is unique symbol?
 
-Error: The type is 'unique symbol'.
+Error: Type is 'unique symbol'.
 
   15 |   expect(returnsVoid()).type.not.toBeUniqueSymbol();
   16 | 

--- a/tests/__snapshots__/api-toBeUniqueSymbol-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUniqueSymbol-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
    9 |   expect(returnsUniqueSymbol()).type.toBeUniqueSymbol();
   10 | 
@@ -10,7 +10,7 @@ Error: The source type is 'void'.
 
        at ./__typetests__/toBeUniqueSymbol.tst.ts:11:30 ❭ is unique symbol?
 
-Error: The source type is 'unique symbol'.
+Error: The type is 'unique symbol'.
 
   15 |   expect(returnsVoid()).type.not.toBeUniqueSymbol();
   16 | 

--- a/tests/__snapshots__/api-toBeUnknown-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUnknown-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
    7 |   expect(returnsUnknown()).type.toBeUnknown();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'string'.
 
        at ./__typetests__/toBeUnknown.tst.ts:9:32 ❭ is unknown?
 
-Error: The source type is 'unknown'.
+Error: The type is 'unknown'.
 
   13 |   expect(returnsString()).type.not.toBeUnknown();
   14 | 

--- a/tests/__snapshots__/api-toBeUnknown-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeUnknown-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'string'.
+Error: Type is 'string'.
 
    7 |   expect(returnsUnknown()).type.toBeUnknown();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'string'.
 
        at ./__typetests__/toBeUnknown.tst.ts:9:32 ❭ is unknown?
 
-Error: The type is 'unknown'.
+Error: Type is 'unknown'.
 
   13 |   expect(returnsString()).type.not.toBeUnknown();
   14 | 

--- a/tests/__snapshots__/api-toBeVoid-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeVoid-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The type is 'string'.
+Error: Type is 'string'.
 
    7 |   expect(returnsVoid()).type.toBeVoid();
    8 | 
@@ -10,7 +10,7 @@ Error: The type is 'string'.
 
        at ./__typetests__/toBeVoid.tst.ts:9:32 ❭ is void?
 
-Error: The type is 'void'.
+Error: Type is 'void'.
 
   13 |   expect(returnsString()).type.not.toBeVoid();
   14 | 

--- a/tests/__snapshots__/api-toBeVoid-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeVoid-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: The type is 'string'.
 
    7 |   expect(returnsVoid()).type.toBeVoid();
    8 | 
@@ -10,7 +10,7 @@ Error: The source type is 'string'.
 
        at ./__typetests__/toBeVoid.tst.ts:9:32 ❭ is void?
 
-Error: The source type is 'void'.
+Error: The type is 'void'.
 
   13 |   expect(returnsString()).type.not.toBeVoid();
   14 | 

--- a/tests/__snapshots__/api-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/api-toRaiseError-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: Expression raised 1 type error.
+Error: Expression type raised 1 type error.
 
    6 | test("expression raises a type error", () => {
    7 |   expect(one("pass")).type.toRaiseError();
@@ -24,7 +24,7 @@ Error: Expression raised 1 type error.
 
            at ./__typetests__/toRaiseError.tst.ts:8:14
 
-Error: Expression did not raise a type error.
+Error: Expression type did not raise a type error.
 
   11 | test("expression does not raise a type error", () => {
   12 |   expect(one()).type.not.toRaiseError();
@@ -36,7 +36,7 @@ Error: Expression did not raise a type error.
 
        at ./__typetests__/toRaiseError.tst.ts:13:22 ❭ expression does not raise a type error
 
-Error: Type expression raised 1 type error.
+Error: Type raised 1 type error.
 
   16 | test("type expression raises a type error", () => {
   17 |   expect<One>().type.toRaiseError();
@@ -62,7 +62,7 @@ Error: Type expression raised 1 type error.
 
            at ./__typetests__/toRaiseError.tst.ts:18:10
 
-Error: Type expression did not raise a type error.
+Error: Type did not raise a type error.
 
   21 | test("type expression does not raise a type error", () => {
   22 |   expect<One<string>>().type.not.toRaiseError();
@@ -74,7 +74,7 @@ Error: Type expression did not raise a type error.
 
        at ./__typetests__/toRaiseError.tst.ts:23:30 ❭ type expression does not raise a type error
 
-Error: Expression raised 3 type errors.
+Error: Expression type raised 3 type errors.
 
   34 |     one("2");
   35 |     one("3");
@@ -124,7 +124,7 @@ Error: Expression raised 3 type errors.
 
            at ./__typetests__/toRaiseError.tst.ts:35:9
 
-Error: Expression raised a type error matching substring 'Expected 0 arguments'.
+Error: Expression type raised a type error matching substring 'Expected 0 arguments'.
 
   39 | test("expression raises a type error with matching message", () => {
   40 |   expect(one("pass")).type.toRaiseError("Expected 0 arguments");
@@ -150,7 +150,7 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
            at ./__typetests__/toRaiseError.tst.ts:41:14
 
-Error: Expression raised a type error matching substring 'Expected 0 arguments'.
+Error: Expression type raised a type error matching substring 'Expected 0 arguments'.
 
   44 | test("expression raises a type error with matching message passed as a template literal", () => {
   45 |   expect(one("pass")).type.toRaiseError(`Expected 0 arguments`);
@@ -176,7 +176,7 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
            at ./__typetests__/toRaiseError.tst.ts:46:14
 
-Error: Expression did not raise a type error matching substring 'Expected 2 arguments'.
+Error: Expression type did not raise a type error matching substring 'Expected 2 arguments'.
 
   49 | test("expression raises type error with not matching message", () => {
   50 |   expect(one("pass")).type.not.toRaiseError("Expected 2 arguments");
@@ -202,7 +202,7 @@ Error: Expression did not raise a type error matching substring 'Expected 2 argu
 
            at ./__typetests__/toRaiseError.tst.ts:51:14
 
-Error: Type expression raised a type error matching substring 'requires 1 type argument'.
+Error: Type raised a type error matching substring 'requires 1 type argument'.
 
   54 | test("type expression raises a type error with matching message", () => {
   55 |   expect<One>().type.toRaiseError("requires 1 type argument");
@@ -228,7 +228,7 @@ Error: Type expression raised a type error matching substring 'requires 1 type a
 
            at ./__typetests__/toRaiseError.tst.ts:56:10
 
-Error: Type expression raised a type error matching substring 'requires 1 type argument'.
+Error: Type raised a type error matching substring 'requires 1 type argument'.
 
   59 | test("type expression raises a type error with matching message passed as a template literal", () => {
   60 |   expect<One>().type.toRaiseError(`requires 1 type argument`);
@@ -254,7 +254,7 @@ Error: Type expression raised a type error matching substring 'requires 1 type a
 
            at ./__typetests__/toRaiseError.tst.ts:61:10
 
-Error: Type expression did not raise a type error matching substring 'requires type argument'.
+Error: Type did not raise a type error matching substring 'requires type argument'.
 
   64 | test("type expression raises a type error with not matching message", () => {
   65 |   expect<One>().type.not.toRaiseError("requires type argument");
@@ -280,7 +280,7 @@ Error: Type expression did not raise a type error matching substring 'requires t
 
            at ./__typetests__/toRaiseError.tst.ts:66:10
 
-Error: Expression raised a type error with code 2554.
+Error: Expression type raised a type error with code 2554.
 
   69 | test("expression raises a type error with expected code", () => {
   70 |   expect(one("pass")).type.toRaiseError(2554);
@@ -306,7 +306,7 @@ Error: Expression raised a type error with code 2554.
 
            at ./__typetests__/toRaiseError.tst.ts:71:14
 
-Error: Expression did not raise a type error with code 2544.
+Error: Expression type did not raise a type error with code 2544.
 
   74 | test("expression raises a type error with not expected code", () => {
   75 |   expect(one("pass")).type.not.toRaiseError(2544);
@@ -332,7 +332,7 @@ Error: Expression did not raise a type error with code 2544.
 
            at ./__typetests__/toRaiseError.tst.ts:76:14
 
-Error: Expression raised a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type raised a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
 
   92 |     two(1000);
   93 |     two<string>("fail");
@@ -358,7 +358,7 @@ Error: Expression raised a type error matching substring 'Argument of type 'numb
 
            at ./__typetests__/toRaiseError.tst.ts:92:9
 
-Error: Expression raised a type error matching substring 'Expected 0 arguments'.
+Error: Expression type raised a type error matching substring 'Expected 0 arguments'.
 
   92 |     two(1000);
   93 |     two<string>("fail");
@@ -384,7 +384,7 @@ Error: Expression raised a type error matching substring 'Expected 0 arguments'.
 
            at ./__typetests__/toRaiseError.tst.ts:93:17
 
-Error: Expression did not raise a type error matching substring 'Expected 0 arguments'.
+Error: Expression type did not raise a type error matching substring 'Expected 0 arguments'.
 
   110 |     two(1000);
   111 |     two<string>("fail");
@@ -410,7 +410,7 @@ Error: Expression did not raise a type error matching substring 'Expected 0 argu
 
             at ./__typetests__/toRaiseError.tst.ts:110:9
 
-Error: Expression did not raise a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type did not raise a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
 
   110 |     two(1000);
   111 |     two<string>("fail");
@@ -436,7 +436,7 @@ Error: Expression did not raise a type error matching substring 'Argument of typ
 
             at ./__typetests__/toRaiseError.tst.ts:111:17
 
-Error: Expression raised a type error with code 2345.
+Error: Expression type raised a type error with code 2345.
 
   125 |     two(1000);
   126 |     two<string>("fail");
@@ -462,7 +462,7 @@ Error: Expression raised a type error with code 2345.
 
             at ./__typetests__/toRaiseError.tst.ts:125:9
 
-Error: Expression raised a type error with code 2554.
+Error: Expression type raised a type error with code 2554.
 
   125 |     two(1000);
   126 |     two<string>("fail");
@@ -488,7 +488,7 @@ Error: Expression raised a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:126:17
 
-Error: Expression did not raise a type error with code 2554.
+Error: Expression type did not raise a type error with code 2554.
 
   132 |     two(1111);
   133 |     two<string>("pass");
@@ -514,7 +514,7 @@ Error: Expression did not raise a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:132:9
 
-Error: Expression did not raise a type error with code 2345.
+Error: Expression type did not raise a type error with code 2345.
 
   132 |     two(1111);
   133 |     two<string>("pass");
@@ -540,7 +540,7 @@ Error: Expression did not raise a type error with code 2345.
 
             at ./__typetests__/toRaiseError.tst.ts:133:17
 
-Error: Expression raised a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type raised a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
 
   149 |     two(1000);
   150 |     two<string>("fail");
@@ -566,7 +566,7 @@ Error: Expression raised a type error matching substring 'Argument of type 'numb
 
             at ./__typetests__/toRaiseError.tst.ts:149:9
 
-Error: Expression raised a type error with code 2554.
+Error: Expression type raised a type error with code 2554.
 
   149 |     two(1000);
   150 |     two<string>("fail");
@@ -592,7 +592,7 @@ Error: Expression raised a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:150:17
 
-Error: Expression did not raise a type error with code 2554.
+Error: Expression type did not raise a type error with code 2554.
 
   156 |     two(1111);
   157 |     two<string>("pass");
@@ -618,7 +618,7 @@ Error: Expression did not raise a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:156:9
 
-Error: Expression did not raise a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type did not raise a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
 
   156 |     two(1111);
   157 |     two<string>("pass");
@@ -644,7 +644,7 @@ Error: Expression did not raise a type error matching substring 'Argument of typ
 
             at ./__typetests__/toRaiseError.tst.ts:157:17
 
-Error: Expression raised 2 type errors.
+Error: Expression type raised 2 type errors.
 
   168 |     two(1111);
   169 |     two<string>("pass");
@@ -682,7 +682,7 @@ Error: Expression raised 2 type errors.
 
             at ./__typetests__/toRaiseError.tst.ts:169:17
 
-Error: Expression raised 2 type errors.
+Error: Expression type raised 2 type errors.
 
   175 |     two(1111);
   176 |     two<string>("pass");
@@ -720,7 +720,7 @@ Error: Expression raised 2 type errors.
 
             at ./__typetests__/toRaiseError.tst.ts:176:17
 
-Error: Expression raised only 1 type error.
+Error: Expression type raised only 1 type error.
 
   181 |   expect(() => {
   182 |     two(1111);
@@ -746,7 +746,7 @@ Error: Expression raised only 1 type error.
 
             at ./__typetests__/toRaiseError.tst.ts:182:9
 
-Error: Expression raised only 2 type errors.
+Error: Expression type raised only 2 type errors.
 
   192 |     two(1111);
   193 |     two<string>("pass");
@@ -784,7 +784,7 @@ Error: Expression raised only 2 type errors.
 
             at ./__typetests__/toRaiseError.tst.ts:193:17
 
-Error: Expression raised only 1 type error.
+Error: Expression type raised only 1 type error.
 
   202 |   expect(() => {
   203 |     two<string>("pass");
@@ -810,7 +810,7 @@ Error: Expression raised only 1 type error.
 
             at ./__typetests__/toRaiseError.tst.ts:203:17
 
-Error: Expression raised only 2 type errors.
+Error: Expression type raised only 2 type errors.
 
   209 |     two(1111);
   210 |     two<string>("pass");

--- a/tests/__snapshots__/api-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/api-toRaiseError-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: Expression type raised 1 type error.
+Error: Expression type raised a type error.
 
    6 | test("expression raises a type error", () => {
    7 |   expect(one("pass")).type.toRaiseError();
@@ -36,7 +36,7 @@ Error: Expression type did not raise a type error.
 
        at ./__typetests__/toRaiseError.tst.ts:13:22 ❭ expression does not raise a type error
 
-Error: Type raised 1 type error.
+Error: Type raised a type error.
 
   16 | test("type expression raises a type error", () => {
   17 |   expect<One>().type.toRaiseError();
@@ -124,7 +124,7 @@ Error: Expression type raised 3 type errors.
 
            at ./__typetests__/toRaiseError.tst.ts:35:9
 
-Error: Expression type raised a type error matching substring 'Expected 0 arguments'.
+Error: Expression type raised a matching type error.
 
   39 | test("expression raises a type error with matching message", () => {
   40 |   expect(one("pass")).type.toRaiseError("Expected 0 arguments");
@@ -150,7 +150,7 @@ Error: Expression type raised a type error matching substring 'Expected 0 argume
 
            at ./__typetests__/toRaiseError.tst.ts:41:14
 
-Error: Expression type raised a type error matching substring 'Expected 0 arguments'.
+Error: Expression type raised a matching type error.
 
   44 | test("expression raises a type error with matching message passed as a template literal", () => {
   45 |   expect(one("pass")).type.toRaiseError(`Expected 0 arguments`);
@@ -176,7 +176,7 @@ Error: Expression type raised a type error matching substring 'Expected 0 argume
 
            at ./__typetests__/toRaiseError.tst.ts:46:14
 
-Error: Expression type did not raise a type error matching substring 'Expected 2 arguments'.
+Error: Expression type did not raise a matching type error.
 
   49 | test("expression raises type error with not matching message", () => {
   50 |   expect(one("pass")).type.not.toRaiseError("Expected 2 arguments");
@@ -202,7 +202,7 @@ Error: Expression type did not raise a type error matching substring 'Expected 2
 
            at ./__typetests__/toRaiseError.tst.ts:51:14
 
-Error: Type raised a type error matching substring 'requires 1 type argument'.
+Error: Type raised a matching type error.
 
   54 | test("type expression raises a type error with matching message", () => {
   55 |   expect<One>().type.toRaiseError("requires 1 type argument");
@@ -228,7 +228,7 @@ Error: Type raised a type error matching substring 'requires 1 type argument'.
 
            at ./__typetests__/toRaiseError.tst.ts:56:10
 
-Error: Type raised a type error matching substring 'requires 1 type argument'.
+Error: Type raised a matching type error.
 
   59 | test("type expression raises a type error with matching message passed as a template literal", () => {
   60 |   expect<One>().type.toRaiseError(`requires 1 type argument`);
@@ -254,7 +254,7 @@ Error: Type raised a type error matching substring 'requires 1 type argument'.
 
            at ./__typetests__/toRaiseError.tst.ts:61:10
 
-Error: Type did not raise a type error matching substring 'requires type argument'.
+Error: Type did not raise a matching type error.
 
   64 | test("type expression raises a type error with not matching message", () => {
   65 |   expect<One>().type.not.toRaiseError("requires type argument");
@@ -280,7 +280,7 @@ Error: Type did not raise a type error matching substring 'requires type argumen
 
            at ./__typetests__/toRaiseError.tst.ts:66:10
 
-Error: Expression type raised a type error with code 2554.
+Error: Expression type raised a matching type error.
 
   69 | test("expression raises a type error with expected code", () => {
   70 |   expect(one("pass")).type.toRaiseError(2554);
@@ -306,7 +306,7 @@ Error: Expression type raised a type error with code 2554.
 
            at ./__typetests__/toRaiseError.tst.ts:71:14
 
-Error: Expression type did not raise a type error with code 2544.
+Error: Expression type did not raise a matching type error.
 
   74 | test("expression raises a type error with not expected code", () => {
   75 |   expect(one("pass")).type.not.toRaiseError(2544);
@@ -332,7 +332,7 @@ Error: Expression type did not raise a type error with code 2544.
 
            at ./__typetests__/toRaiseError.tst.ts:76:14
 
-Error: Expression type raised a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type raised a matching type error.
 
   92 |     two(1000);
   93 |     two<string>("fail");
@@ -358,7 +358,7 @@ Error: Expression type raised a type error matching substring 'Argument of type 
 
            at ./__typetests__/toRaiseError.tst.ts:92:9
 
-Error: Expression type raised a type error matching substring 'Expected 0 arguments'.
+Error: Expression type raised a matching type error.
 
   92 |     two(1000);
   93 |     two<string>("fail");
@@ -384,7 +384,7 @@ Error: Expression type raised a type error matching substring 'Expected 0 argume
 
            at ./__typetests__/toRaiseError.tst.ts:93:17
 
-Error: Expression type did not raise a type error matching substring 'Expected 0 arguments'.
+Error: Expression type did not raise a matching type error.
 
   110 |     two(1000);
   111 |     two<string>("fail");
@@ -410,7 +410,7 @@ Error: Expression type did not raise a type error matching substring 'Expected 0
 
             at ./__typetests__/toRaiseError.tst.ts:110:9
 
-Error: Expression type did not raise a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type did not raise a matching type error.
 
   110 |     two(1000);
   111 |     two<string>("fail");
@@ -436,7 +436,7 @@ Error: Expression type did not raise a type error matching substring 'Argument o
 
             at ./__typetests__/toRaiseError.tst.ts:111:17
 
-Error: Expression type raised a type error with code 2345.
+Error: Expression type raised a matching type error.
 
   125 |     two(1000);
   126 |     two<string>("fail");
@@ -462,7 +462,7 @@ Error: Expression type raised a type error with code 2345.
 
             at ./__typetests__/toRaiseError.tst.ts:125:9
 
-Error: Expression type raised a type error with code 2554.
+Error: Expression type raised a matching type error.
 
   125 |     two(1000);
   126 |     two<string>("fail");
@@ -488,7 +488,7 @@ Error: Expression type raised a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:126:17
 
-Error: Expression type did not raise a type error with code 2554.
+Error: Expression type did not raise a matching type error.
 
   132 |     two(1111);
   133 |     two<string>("pass");
@@ -514,7 +514,7 @@ Error: Expression type did not raise a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:132:9
 
-Error: Expression type did not raise a type error with code 2345.
+Error: Expression type did not raise a matching type error.
 
   132 |     two(1111);
   133 |     two<string>("pass");
@@ -540,7 +540,7 @@ Error: Expression type did not raise a type error with code 2345.
 
             at ./__typetests__/toRaiseError.tst.ts:133:17
 
-Error: Expression type raised a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type raised a matching type error.
 
   149 |     two(1000);
   150 |     two<string>("fail");
@@ -566,7 +566,7 @@ Error: Expression type raised a type error matching substring 'Argument of type 
 
             at ./__typetests__/toRaiseError.tst.ts:149:9
 
-Error: Expression type raised a type error with code 2554.
+Error: Expression type raised a matching type error.
 
   149 |     two(1000);
   150 |     two<string>("fail");
@@ -592,7 +592,7 @@ Error: Expression type raised a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:150:17
 
-Error: Expression type did not raise a type error with code 2554.
+Error: Expression type did not raise a matching type error.
 
   156 |     two(1111);
   157 |     two<string>("pass");
@@ -618,7 +618,7 @@ Error: Expression type did not raise a type error with code 2554.
 
             at ./__typetests__/toRaiseError.tst.ts:156:9
 
-Error: Expression type did not raise a type error matching substring 'Argument of type 'number' is not assignable to parameter of type 'string''.
+Error: Expression type did not raise a matching type error.
 
   156 |     two(1111);
   157 |     two<string>("pass");

--- a/tests/__snapshots__/config-failFast---failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-false-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
@@ -10,7 +10,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:3:29 ❭ is number?
 
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
@@ -21,7 +21,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:4:29 ❭ is number?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
@@ -33,7 +33,7 @@ Error: The source type is 'string'.
 
       at ./__typetests__/isString.tst.ts:3:29 ❭ is string?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   2 | test("is string?", () => {
   3 |   expect<string>().type.not.toBeString();

--- a/tests/__snapshots__/config-failFast---failFast-isNumber---failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-isNumber---failFast-false-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
@@ -10,7 +10,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:3:29 ❭ is number?
 
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();

--- a/tests/__snapshots__/config-failFast---failFast-isString-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-isString-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {

--- a/tests/__snapshots__/config-failFast---failFast-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {

--- a/tests/__snapshots__/config-failFast---failFast-true-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-true-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {

--- a/tests/__snapshots__/config-failFast-failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-failFast-false-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
@@ -10,7 +10,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:3:29 ❭ is number?
 
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
@@ -21,7 +21,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:4:29 ❭ is number?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
@@ -33,7 +33,7 @@ Error: The source type is 'string'.
 
       at ./__typetests__/isString.tst.ts:3:29 ❭ is string?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   2 | test("is string?", () => {
   3 |   expect<string>().type.not.toBeString();

--- a/tests/__snapshots__/config-failFast-failFast-true-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-failFast-true-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {

--- a/tests/__snapshots__/config-failFast-isNumber---failFast-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-isNumber---failFast-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {

--- a/tests/__snapshots__/config-failFast-overrides-failFast-false-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-overrides-failFast-false-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {

--- a/tests/__snapshots__/config-failFast-overrides-failFast-true-stderr.snap.txt
+++ b/tests/__snapshots__/config-failFast-overrides-failFast-true-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
@@ -10,7 +10,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:3:29 ❭ is number?
 
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   2 | test("is number?", () => {
   3 |   expect<number>().type.not.toBeNumber();
@@ -21,7 +21,7 @@ Error: The source type is 'number'.
 
       at ./__typetests__/isNumber.tst.ts:4:29 ❭ is number?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {
@@ -33,7 +33,7 @@ Error: The source type is 'string'.
 
       at ./__typetests__/isString.tst.ts:3:29 ❭ is string?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   2 | test("is string?", () => {
   3 |   expect<string>().type.not.toBeString();

--- a/tests/__snapshots__/feature-watch-failFast-option-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-failFast-option-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
@@ -9,7 +9,7 @@ Error: The source type is 'string'.
 
       at ./a-feature/__typetests__/isNumber.test.ts:3:25 ❭ is number?
 
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {

--- a/tests/__snapshots__/feature-watch-multiple-test-files-are-added-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-multiple-test-files-are-added-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {

--- a/tests/__snapshots__/feature-watch-multiple-test-files-are-changed-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-multiple-test-files-are-changed-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'string'.
+Error: Type is 'string'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is number?", () => {
@@ -9,7 +9,7 @@ Error: The source type is 'string'.
 
       at ./a-feature/__typetests__/isNumber.test.ts:3:25 ❭ is number?
 
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {

--- a/tests/__snapshots__/feature-watch-single-test-file-is-added-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-single-test-file-is-added-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {

--- a/tests/__snapshots__/feature-watch-single-test-file-is-changed-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-single-test-file-is-changed-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The source type is 'number'.
+Error: Type is 'number'.
 
   1 | import { expect, test } from "tstyche";
   2 | test("is string?", () => {

--- a/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
@@ -10,7 +10,9 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
       at ./__typetests__/toAcceptProps.tst.tsx:5:5
 
-Error: An argument for 'source' must be of a function or class type, received: '{ a: string; }'.
+Error: An argument for 'source' must be of a function or class type.
+
+Received type '{ a: string; }'.
 
    7 | 
    8 |   test("must be of a function or class type", () => {
@@ -22,7 +24,9 @@ Error: An argument for 'source' must be of a function or class type, received: '
 
        at ./__typetests__/toAcceptProps.tst.tsx:9:12
 
-Error: A type argument for 'Source' must be of a function or class type, received: '{ a: string; }'.
+Error: A type argument for 'Source' must be of a function or class type.
+
+Received type '{ a: string; }'.
 
   13 | describe("type argument for 'Source'", () => {
   14 |   test("must be of a function or class type", () => {
@@ -46,7 +50,9 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
        at ./__typetests__/toAcceptProps.tst.tsx:21:38
 
-Error: An argument for 'target' must be of an object type, received: '"nope"'.
+Error: An argument for 'target' must be of an object type.
+
+Received type '"nope"'.
 
   23 | 
   24 |   test("must be of object type", () => {
@@ -58,7 +64,9 @@ Error: An argument for 'target' must be of an object type, received: '"nope"'.
 
        at ./__typetests__/toAcceptProps.tst.tsx:25:52
 
-Error: A type argument for 'Target' must be of an object type, received: 'any'.
+Error: A type argument for 'Target' must be of an object type.
+
+Received type 'any'.
 
   29 | describe("type argument for 'Target'", () => {
   30 |   test("must be of object type", () => {
@@ -70,7 +78,9 @@ Error: A type argument for 'Target' must be of an object type, received: 'any'.
 
        at ./__typetests__/toAcceptProps.tst.tsx:31:52
 
-Error: A type argument for 'Target' must be of an object type, received: 'never'.
+Error: A type argument for 'Target' must be of an object type.
+
+Received type 'never'.
 
   30 |   test("must be of object type", () => {
   31 |     expect(() => <>{"test"}</>).type.toAcceptProps<any>();
@@ -82,7 +92,9 @@ Error: A type argument for 'Target' must be of an object type, received: 'never'
 
        at ./__typetests__/toAcceptProps.tst.tsx:32:52
 
-Error: A type argument for 'Target' must be of an object type, received: 'string'.
+Error: A type argument for 'Target' must be of an object type.
+
+Received type 'string'.
 
   32 |     expect(() => <>{"test"}</>).type.toAcceptProps<never>();
   33 | 
@@ -94,7 +106,9 @@ Error: A type argument for 'Target' must be of an object type, received: 'string
 
        at ./__typetests__/toAcceptProps.tst.tsx:34:52
 
-Error: A type argument for 'Target' must be of an object type, received: '{ test: string; } | { test: number; }'.
+Error: A type argument for 'Target' must be of an object type.
+
+Received type '{ test: string; } | { test: number; }'.
 
   34 |     expect(() => <>{"test"}</>).type.toAcceptProps<string>();
   35 | 

--- a/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
@@ -12,8 +12,6 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
 Error: An argument for 'source' must be of a function or class type.
 
-Received type '{ a: string; }'.
-
    7 | 
    8 |   test("must be of a function or class type", () => {
    9 |     expect({ a: "sample" }).type.toAcceptProps({ test: false });
@@ -25,8 +23,6 @@ Received type '{ a: string; }'.
        at ./__typetests__/toAcceptProps.tst.tsx:9:12
 
 Error: A type argument for 'Source' must be of a function or class type.
-
-Received type '{ a: string; }'.
 
   13 | describe("type argument for 'Source'", () => {
   14 |   test("must be of a function or class type", () => {
@@ -52,8 +48,6 @@ Error: An argument for 'target' or type argument for 'Target' must be provided.
 
 Error: An argument for 'target' must be of an object type.
 
-Received type '"nope"'.
-
   23 | 
   24 |   test("must be of object type", () => {
   25 |     expect(() => <>{"test"}</>).type.toAcceptProps("nope");
@@ -65,8 +59,6 @@ Received type '"nope"'.
        at ./__typetests__/toAcceptProps.tst.tsx:25:52
 
 Error: A type argument for 'Target' must be of an object type.
-
-Received type 'any'.
 
   29 | describe("type argument for 'Target'", () => {
   30 |   test("must be of object type", () => {
@@ -80,8 +72,6 @@ Received type 'any'.
 
 Error: A type argument for 'Target' must be of an object type.
 
-Received type 'never'.
-
   30 |   test("must be of object type", () => {
   31 |     expect(() => <>{"test"}</>).type.toAcceptProps<any>();
   32 |     expect(() => <>{"test"}</>).type.toAcceptProps<never>();
@@ -94,8 +84,6 @@ Received type 'never'.
 
 Error: A type argument for 'Target' must be of an object type.
 
-Received type 'string'.
-
   32 |     expect(() => <>{"test"}</>).type.toAcceptProps<never>();
   33 | 
   34 |     expect(() => <>{"test"}</>).type.toAcceptProps<string>();
@@ -107,8 +95,6 @@ Received type 'string'.
        at ./__typetests__/toAcceptProps.tst.tsx:34:52
 
 Error: A type argument for 'Target' must be of an object type.
-
-Received type '{ test: string; } | { test: number; }'.
 
   34 |     expect(() => <>{"test"}</>).type.toAcceptProps<string>();
   35 | 

--- a/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
@@ -10,7 +10,9 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
       at ./__typetests__/toHaveProperty.tst.ts:5:5
 
-Error: An argument for 'source' must be of an object type, received: '"sample"'.
+Error: An argument for 'source' must be of an object type.
+
+Received type '"sample"'.
 
    7 | 
    8 |   test("must be of an object type", () => {
@@ -22,7 +24,9 @@ Error: An argument for 'source' must be of an object type, received: '"sample"'.
 
        at ./__typetests__/toHaveProperty.tst.ts:9:12
 
-Error: A type argument for 'Source' must be of an object type, received: 'any'.
+Error: A type argument for 'Source' must be of an object type.
+
+Received type 'any'.
 
   15 |     expect<{}>().type.not.toHaveProperty("abc");
   16 | 
@@ -34,7 +38,9 @@ Error: A type argument for 'Source' must be of an object type, received: 'any'.
 
        at ./__typetests__/toHaveProperty.tst.ts:17:12
 
-Error: A type argument for 'Source' must be of an object type, received: 'never'.
+Error: A type argument for 'Source' must be of an object type.
+
+Received type 'never'.
 
   16 | 
   17 |     expect<any>().type.toHaveProperty("runTest");
@@ -46,7 +52,9 @@ Error: A type argument for 'Source' must be of an object type, received: 'never'
 
        at ./__typetests__/toHaveProperty.tst.ts:18:12
 
-Error: An argument for 'source' must be of an object type, received: 'null'.
+Error: An argument for 'source' must be of an object type.
+
+Received type 'null'.
 
   17 |     expect<any>().type.toHaveProperty("runTest");
   18 |     expect<never>().type.toHaveProperty("runTest");
@@ -58,7 +66,9 @@ Error: An argument for 'source' must be of an object type, received: 'null'.
 
        at ./__typetests__/toHaveProperty.tst.ts:19:12
 
-Error: A type argument for 'Source' must be of an object type, received: '"one" | "two"'.
+Error: A type argument for 'Source' must be of an object type.
+
+Received type '"one" | "two"'.
 
   18 |     expect<never>().type.toHaveProperty("runTest");
   19 |     expect(null).type.toHaveProperty("runTest");
@@ -82,7 +92,9 @@ Error: An argument for 'key' must be provided.
 
        at ./__typetests__/toHaveProperty.tst.ts:27:41
 
-Error: An argument for 'key' must be of type 'string | number | symbol', received: 'string[]'.
+Error: An argument for 'key' must be of type 'string | number | symbol'.
+
+Received type 'string[]'.
 
   30 |   test("must be of type 'string | number | symbol'", () => {
   31 |     // @ts-expect-error testing purpose

--- a/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
@@ -12,8 +12,6 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
 Error: An argument for 'source' must be of an object type.
 
-Received type '"sample"'.
-
    7 | 
    8 |   test("must be of an object type", () => {
    9 |     expect("sample").type.toHaveProperty("runTest");
@@ -25,8 +23,6 @@ Received type '"sample"'.
        at ./__typetests__/toHaveProperty.tst.ts:9:12
 
 Error: A type argument for 'Source' must be of an object type.
-
-Received type 'any'.
 
   15 |     expect<{}>().type.not.toHaveProperty("abc");
   16 | 
@@ -40,8 +36,6 @@ Received type 'any'.
 
 Error: A type argument for 'Source' must be of an object type.
 
-Received type 'never'.
-
   16 | 
   17 |     expect<any>().type.toHaveProperty("runTest");
   18 |     expect<never>().type.toHaveProperty("runTest");
@@ -54,8 +48,6 @@ Received type 'never'.
 
 Error: An argument for 'source' must be of an object type.
 
-Received type 'null'.
-
   17 |     expect<any>().type.toHaveProperty("runTest");
   18 |     expect<never>().type.toHaveProperty("runTest");
   19 |     expect(null).type.toHaveProperty("runTest");
@@ -67,8 +59,6 @@ Received type 'null'.
        at ./__typetests__/toHaveProperty.tst.ts:19:12
 
 Error: A type argument for 'Source' must be of an object type.
-
-Received type '"one" | "two"'.
 
   18 |     expect<never>().type.toHaveProperty("runTest");
   19 |     expect(null).type.toHaveProperty("runTest");
@@ -93,8 +83,6 @@ Error: An argument for 'key' must be provided.
        at ./__typetests__/toHaveProperty.tst.ts:27:41
 
 Error: An argument for 'key' must be of type 'string | number | symbol'.
-
-Received type 'string[]'.
 
   30 |   test("must be of type 'string | number | symbol'", () => {
   31 |     // @ts-expect-error testing purpose

--- a/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
@@ -12,8 +12,6 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
 Error: An argument for 'target' must be of type 'string | number'.
 
-Received type 'true'.
-
   14 |   test("must be of type 'string | number'", () => {
   15 |     // @ts-expect-error testing purpose
   16 |     expect(check(123)).type.toRaiseError(true, [2345]);
@@ -25,8 +23,6 @@ Received type 'true'.
        at ./__typetests__/toRaiseError.tst.ts:16:42
 
 Error: An argument for 'target' must be of type 'string | number'.
-
-Received type 'number[]'.
 
   14 |   test("must be of type 'string | number'", () => {
   15 |     // @ts-expect-error testing purpose

--- a/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
@@ -10,7 +10,9 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
       at ./__typetests__/toRaiseError.tst.ts:5:5
 
-Error: An argument for 'target' must be of type 'string | number', received: 'true'.
+Error: An argument for 'target' must be of type 'string | number'.
+
+Received type 'true'.
 
   14 |   test("must be of type 'string | number'", () => {
   15 |     // @ts-expect-error testing purpose
@@ -22,7 +24,9 @@ Error: An argument for 'target' must be of type 'string | number', received: 'tr
 
        at ./__typetests__/toRaiseError.tst.ts:16:42
 
-Error: An argument for 'target' must be of type 'string | number', received: 'number[]'.
+Error: An argument for 'target' must be of type 'string | number'.
+
+Received type 'number[]'.
 
   14 |   test("must be of type 'string | number'", () => {
   15 |     // @ts-expect-error testing purpose


### PR DESCRIPTION
Moving all messages to the `ExpectDiagnosticText` class.