### PR TITLE
feat(diagnostic, expect): add `.extendWith()` method to `Diagnostic`

### DIFF
--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -39,12 +39,8 @@ export class Diagnostic {
     return new Diagnostic(text, DiagnosticCategory.Error, origin);
   }
 
-  extendWith(options: { origin?: DiagnosticOrigin; text?: string | Array<string> }): Diagnostic {
-    const origin = options?.origin != null ? options.origin : this.origin;
-
-    const text = options?.text != null ? [this.text, options.text] : [this.text];
-
-    return new Diagnostic(text.flat(), this.category, origin);
+  extendWith(text: string | Array<string>, origin?: DiagnosticOrigin): Diagnostic {
+    return new Diagnostic([this.text, text].flat(), this.category, origin ?? this.origin);
   }
 
   static fromDiagnostics(diagnostics: ReadonlyArray<ts.Diagnostic>, compiler: typeof ts): Array<Diagnostic> {

--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -39,6 +39,14 @@ export class Diagnostic {
     return new Diagnostic(text, DiagnosticCategory.Error, origin);
   }
 
+  extendWith(options: { origin?: DiagnosticOrigin; text?: string | Array<string> }): Diagnostic {
+    const origin = options?.origin != null ? options.origin : this.origin;
+
+    const text = options?.text != null ? [this.text, options.text] : [this.text];
+
+    return new Diagnostic(text.flat(), this.category, origin);
+  }
+
   static fromDiagnostics(diagnostics: ReadonlyArray<ts.Diagnostic>, compiler: typeof ts): Array<Diagnostic> {
     return diagnostics.map((diagnostic) => {
       const code = `ts(${String(diagnostic.code)})`;

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -131,25 +131,27 @@ export class ToAcceptProps {
         const sourceProperty = sourceType?.getProperty(targetPropertyName);
 
         if (!sourceProperty) {
-          const origin = this.#resolveOrigin(targetProperty, target.node);
           const text = [
             ExpectDiagnosticText.typeIsNotCompatibleWith(sourceTypeText, targetTypeText),
             ExpectDiagnosticText.typeDoesNotHaveProperty(sourceTypeText, targetPropertyName),
           ];
 
-          diagnostics.push(diagnostic.extendWith({ origin, text }));
+          const origin = this.#resolveOrigin(targetProperty, target.node);
+
+          diagnostics.push(diagnostic.extendWith(text, origin));
 
           continue;
         }
 
         if (this.#isOptionalProperty(targetProperty) && !this.#isOptionalProperty(sourceProperty)) {
-          const origin = this.#resolveOrigin(targetProperty, target.node);
           const text = [
             ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
             ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, targetPropertyName),
           ];
 
-          diagnostics.push(diagnostic.extendWith({ origin, text }));
+          const origin = this.#resolveOrigin(targetProperty, target.node);
+
+          diagnostics.push(diagnostic.extendWith(text, origin));
 
           continue;
         }
@@ -161,14 +163,15 @@ export class ToAcceptProps {
           const targetPropertyTypeText = this.#typeChecker.typeToString(targetPropertyType);
           const sourcePropertyTypeText = this.#typeChecker.typeToString(sourcePropertyType);
 
-          const origin = this.#resolveOrigin(targetProperty, target.node);
           const text = [
             ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
             ExpectDiagnosticText.typesOfPropertyAreNotCompatible(targetPropertyName),
             ExpectDiagnosticText.typeIsNotAssignableWith(sourcePropertyTypeText, targetPropertyTypeText),
           ];
 
-          diagnostics.push(diagnostic.extendWith({ origin, text }));
+          const origin = this.#resolveOrigin(targetProperty, target.node);
+
+          diagnostics.push(diagnostic.extendWith(text, origin));
         }
       }
 
@@ -184,7 +187,7 @@ export class ToAcceptProps {
               ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, sourcePropertyName),
             ];
 
-            diagnostics.push(diagnostic.extendWith({ text }));
+            diagnostics.push(diagnostic.extendWith(text));
           }
         }
       }
@@ -192,7 +195,7 @@ export class ToAcceptProps {
       if (diagnostics.length === 0) {
         const text = ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText);
 
-        diagnostics.push(diagnostic.extendWith({ text }));
+        diagnostics.push(diagnostic.extendWith(text));
 
         return { diagnostics, isMatch: true };
       }
@@ -208,7 +211,7 @@ export class ToAcceptProps {
           ? ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)
           : ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText);
 
-        const { diagnostics, isMatch } = explain(sourceType, target.type, diagnostic.extendWith({ text }));
+        const { diagnostics, isMatch } = explain(sourceType, target.type, diagnostic.extendWith(text));
 
         if (isMatch === true) {
           accumulator = { diagnostics, isMatch };

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -204,25 +204,25 @@ export class ToAcceptProps {
     };
 
     if (sourceParameterType != null && this.#isUnionType(sourceParameterType)) {
-      let accumulator: { diagnostics: Array<Diagnostic>; isMatch: boolean } = { diagnostics: [], isMatch: true };
+      let accumulator: Array<Diagnostic> = [];
 
-      for (const sourceType of sourceParameterType.types) {
+      const isMatch = sourceParameterType.types.some((sourceType) => {
         const text = isNot
           ? ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)
           : ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText);
 
         const { diagnostics, isMatch } = explain(sourceType, target.type, diagnostic.extendWith(text));
 
-        if (isMatch === true) {
-          accumulator = { diagnostics, isMatch };
-          break;
+        if (isMatch) {
+          accumulator = diagnostics;
+        } else {
+          accumulator.push(...diagnostics);
         }
 
-        accumulator.diagnostics.push(...diagnostics);
-        accumulator.isMatch = isMatch;
-      }
+        return isMatch;
+      });
 
-      return accumulator;
+      return { diagnostics: accumulator, isMatch };
     }
 
     return explain(sourceParameterType, target.type, diagnostic);

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -3,19 +3,6 @@ import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchResult, TypeChecker } from "./types.js";
 
-interface Explanation {
-  origin?: DiagnosticOrigin | undefined;
-  text: Array<string>;
-}
-
-// TODO push 'Diagnostic' around, not 'node'
-// that should eliminate 'Explanation' as well
-
-// 'Diagnostic' could get new '.extendWith()' method which:
-//   - pushes in additional message text into existing array
-//   - optionally origin could be set as well
-//   - and return new 'Diagnostic', i.e. does not alter the existing one
-
 interface ToAcceptPropsSource {
   node: ts.Expression | ts.TypeNode;
   signatures: Array<ts.Signature>;
@@ -36,40 +23,36 @@ export class ToAcceptProps {
   }
 
   #explain(source: ToAcceptPropsSource, target: ToAcceptPropsTarget, isNot: boolean) {
-    const diagnostics: Array<Diagnostic> = [];
-    let signatureIndex = 0;
+    return source.signatures.reduce<Array<Diagnostic>>((accumulator, signature, index) => {
+      let diagnostic: Diagnostic | undefined;
 
-    for (const signature of source.signatures) {
       const introText = isNot
         ? ExpectDiagnosticText.componentAcceptsProps(this.#compiler.isTypeNode(source.node))
         : ExpectDiagnosticText.componentDoesNotAcceptProps(this.#compiler.isTypeNode(source.node));
 
-      const { explanations, isMatch } = this.#explainProperties(signature, target, isNot);
+      const origin = DiagnosticOrigin.fromNode(target.node);
 
-      if (isNot ? !isMatch : isMatch) {
-        signatureIndex++;
-        continue;
+      if (source.signatures.length > 1) {
+        const signatureText = this.#typeChecker.signatureToString(signature, source.node);
+        const overloadText = ExpectDiagnosticText.overloadGaveTheFollowingError(
+          String(index + 1),
+          String(source.signatures.length),
+          signatureText,
+        );
+
+        diagnostic = Diagnostic.error([introText, overloadText], origin);
+      } else {
+        diagnostic = Diagnostic.error([introText], origin);
       }
 
-      for (const { origin, text } of explanations) {
-        if (source.signatures.length > 1) {
-          const signatureText = this.#typeChecker.signatureToString(signature, source.node);
-          const overloadText = ExpectDiagnosticText.overloadGaveTheFollowingError(
-            String(signatureIndex + 1),
-            String(source.signatures.length),
-            signatureText,
-          );
+      const { diagnostics, isMatch } = this.#explainProperties(signature, target, isNot, diagnostic);
 
-          diagnostics.push(Diagnostic.error([introText, overloadText, ...text], origin));
-        } else {
-          diagnostics.push(Diagnostic.error([introText, ...text], origin));
-        }
+      if (isNot ? isMatch : !isMatch) {
+        accumulator.push(...diagnostics);
       }
 
-      signatureIndex++;
-    }
-
-    return diagnostics;
+      return accumulator;
+    }, []);
   }
 
   #isOptionalProperty(symbol: ts.Symbol) {
@@ -130,17 +113,17 @@ export class ToAcceptProps {
     return check(sourceParameterType, target.type);
   }
 
-  #explainProperties(signature: ts.Signature, target: ToAcceptPropsTarget, isNot: boolean) {
+  #explainProperties(signature: ts.Signature, target: ToAcceptPropsTarget, isNot: boolean, diagnostic: Diagnostic) {
     const sourceParameter = signature.getDeclaration().parameters[0];
     const sourceParameterType = sourceParameter && this.#typeChecker.getTypeAtLocation(sourceParameter);
 
     const targetTypeText = this.#typeChecker.typeToString(target.type);
     const sourceTypeText = sourceParameterType != null ? this.#typeChecker.typeToString(sourceParameterType) : "{}";
 
-    const explain = (sourceType: ts.Type | undefined, targetType: ts.Type, text: Array<string> = []) => {
+    const explain = (sourceType: ts.Type | undefined, targetType: ts.Type, diagnostic: Diagnostic) => {
       const sourceTypeText = sourceType != null ? this.#typeChecker.typeToString(sourceType) : "{}";
 
-      const explanations: Array<Explanation> = [];
+      const diagnostics: Array<Diagnostic> = [];
 
       for (const targetProperty of targetType.getProperties()) {
         const targetPropertyName = targetProperty.getName();
@@ -149,29 +132,24 @@ export class ToAcceptProps {
 
         if (!sourceProperty) {
           const origin = this.#resolveOrigin(targetProperty, target.node);
+          const text = [
+            ExpectDiagnosticText.typeIsNotCompatibleWith(sourceTypeText, targetTypeText),
+            ExpectDiagnosticText.typeDoesNotHaveProperty(sourceTypeText, targetPropertyName),
+          ];
 
-          explanations.push({
-            origin,
-            text: [
-              ...text,
-              ExpectDiagnosticText.typeIsNotCompatibleWith(sourceTypeText, targetTypeText),
-              ExpectDiagnosticText.typeDoesNotHaveProperty(sourceTypeText, targetPropertyName),
-            ],
-          });
+          diagnostics.push(diagnostic.extendWith({ origin, text }));
+
           continue;
         }
 
         if (this.#isOptionalProperty(targetProperty) && !this.#isOptionalProperty(sourceProperty)) {
           const origin = this.#resolveOrigin(targetProperty, target.node);
+          const text = [
+            ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
+            ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, targetPropertyName),
+          ];
 
-          explanations.push({
-            origin,
-            text: [
-              ...text,
-              ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
-              ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, targetPropertyName),
-            ],
-          });
+          diagnostics.push(diagnostic.extendWith({ origin, text }));
 
           continue;
         }
@@ -184,16 +162,13 @@ export class ToAcceptProps {
           const sourcePropertyTypeText = this.#typeChecker.typeToString(sourcePropertyType);
 
           const origin = this.#resolveOrigin(targetProperty, target.node);
+          const text = [
+            ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
+            ExpectDiagnosticText.typesOfPropertyAreNotCompatible(targetPropertyName),
+            ExpectDiagnosticText.typeIsNotAssignableWith(sourcePropertyTypeText, targetPropertyTypeText),
+          ];
 
-          explanations.push({
-            origin,
-            text: [
-              ...text,
-              ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
-              ExpectDiagnosticText.typesOfPropertyAreNotCompatible(targetPropertyName),
-              ExpectDiagnosticText.typeIsNotAssignableWith(sourcePropertyTypeText, targetPropertyTypeText),
-            ],
-          });
+          diagnostics.push(diagnostic.extendWith({ origin, text }));
         }
       }
 
@@ -204,57 +179,50 @@ export class ToAcceptProps {
           const targetProperty = targetType.getProperty(sourcePropertyName);
 
           if (!targetProperty && !this.#isOptionalProperty(sourceProperty)) {
-            const origin = DiagnosticOrigin.fromNode(target.node);
+            const text = [
+              ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
+              ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, sourcePropertyName),
+            ];
 
-            explanations.push({
-              origin,
-              text: [
-                ...text,
-                ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
-                ExpectDiagnosticText.typeRequiresProperty(sourceTypeText, sourcePropertyName),
-              ],
-            });
+            diagnostics.push(diagnostic.extendWith({ text }));
           }
         }
       }
 
-      if (explanations.length === 0) {
-        const origin = DiagnosticOrigin.fromNode(target.node);
+      if (diagnostics.length === 0) {
+        const text = ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText);
 
-        explanations.push({
-          origin,
-          text: [...text, ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)],
-        });
+        diagnostics.push(diagnostic.extendWith({ text }));
 
-        return { explanations, isMatch: true };
+        return { diagnostics, isMatch: true };
       }
 
-      return { explanations, isMatch: false };
+      return { diagnostics, isMatch: false };
     };
 
     if (sourceParameterType != null && this.#isUnionType(sourceParameterType)) {
-      let accumulator: { explanations: Array<Explanation>; isMatch: boolean } = { explanations: [], isMatch: true };
+      let accumulator: { diagnostics: Array<Diagnostic>; isMatch: boolean } = { diagnostics: [], isMatch: true };
 
       for (const sourceType of sourceParameterType.types) {
-        const { explanations, isMatch } = explain(sourceType, target.type, [
-          isNot
-            ? ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)
-            : ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText),
-        ]);
+        const text = isNot
+          ? ExpectDiagnosticText.typeIsAssignableWith(sourceTypeText, targetTypeText)
+          : ExpectDiagnosticText.typeIsNotAssignableWith(sourceTypeText, targetTypeText);
+
+        const { diagnostics, isMatch } = explain(sourceType, target.type, diagnostic.extendWith({ text }));
 
         if (isMatch === true) {
-          accumulator = { explanations, isMatch };
+          accumulator = { diagnostics, isMatch };
           break;
         }
 
-        accumulator.explanations.push(...explanations);
+        accumulator.diagnostics.push(...diagnostics);
         accumulator.isMatch = isMatch;
       }
 
       return accumulator;
     }
 
-    return explain(sourceParameterType, target.type);
+    return explain(sourceParameterType, target.type, diagnostic);
   }
 
   match(source: ToAcceptPropsSource, target: ToAcceptPropsTarget): MatchResult {


### PR DESCRIPTION
Adding `.extendWith()` method to `Diagnostic`. It updates the `origin`, adds more `text` and returns new `Diagnostic`.