### PR TITLE
refactor(collect, output): move the `breadcrumbs` logic to a component

### DIFF
--- a/source/collect/Assertion.ts
+++ b/source/collect/Assertion.ts
@@ -46,20 +46,6 @@ export class Assertion extends TestMember {
     }
   }
 
-  override get ancestorNames(): Array<string> {
-    const ancestorNames: Array<string> = [];
-
-    if ("ancestorNames" in this.parent) {
-      ancestorNames.push(...this.parent.ancestorNames);
-    }
-
-    if ("name" in this.parent) {
-      ancestorNames.push(this.parent.name);
-    }
-
-    return ancestorNames;
-  }
-
   get matcherName(): ts.MemberName {
     return this.matcherNode.expression.name;
   }

--- a/source/collect/TestMember.ts
+++ b/source/collect/TestMember.ts
@@ -48,19 +48,6 @@ export class TestMember {
     }
   }
 
-  get ancestorNames(): Array<string> {
-    const ancestorNames: Array<string> = [];
-
-    let ancestor: TestTree | TestMember = this.parent;
-
-    while ("name" in ancestor) {
-      ancestorNames.unshift(ancestor.name);
-      ancestor = ancestor.parent;
-    }
-
-    return ancestorNames;
-  }
-
   // TODO consider moving validation logic to the collector and passing 'onDiagnostics()' around
   validate(): Array<Diagnostic> {
     const diagnostics: Array<Diagnostic> = [];

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -1,6 +1,22 @@
+import type { TestMember, TestTree } from "#collect";
 import type { DiagnosticOrigin } from "#diagnostic";
 import { Path } from "#path";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
+
+interface BreadcrumbsTextProps {
+  ancestor: TestMember | TestTree;
+}
+
+function BreadcrumbsText({ ancestor }: BreadcrumbsTextProps) {
+  const breadcrumbsText: Array<string> = [];
+
+  while ("name" in ancestor) {
+    breadcrumbsText.unshift(` ❭ ${ancestor.name}`);
+    ancestor = ancestor.parent;
+  }
+
+  return <Text color={Color.Gray}>{breadcrumbsText.join("")}</Text>;
+}
 
 interface CodeLineTextProps {
   lineText: string;
@@ -99,11 +115,6 @@ export function CodeSpanText({ diagnosticOrigin }: CodeSpanTextProps) {
     }
   }
 
-  const breadcrumbs = diagnosticOrigin.assertion?.ancestorNames.map((ancestor) => [
-    <Text color={Color.Gray}>{" ❭ "}</Text>,
-    <Text>{ancestor}</Text>,
-  ]);
-
   const location = (
     <Line>
       {" ".repeat(gutterWidth + 2)}
@@ -112,7 +123,7 @@ export function CodeSpanText({ diagnosticOrigin }: CodeSpanTextProps) {
       <Text color={Color.Gray}>
         :{String(firstMarkedLine + 1)}:{String(firstMarkedLineCharacter + 1)}
       </Text>
-      {breadcrumbs}
+      {diagnosticOrigin.assertion && <BreadcrumbsText ancestor={diagnosticOrigin.assertion.parent} />}
     </Line>
   );
 

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -8,14 +8,14 @@ interface BreadcrumbsTextProps {
 }
 
 function BreadcrumbsText({ ancestor }: BreadcrumbsTextProps) {
-  const breadcrumbsText: Array<string> = [];
+  const text: Array<string> = [];
 
   while ("name" in ancestor) {
-    breadcrumbsText.unshift(" ❭ ", ancestor.name);
+    text.unshift(" ❭ ", ancestor.name);
     ancestor = ancestor.parent;
   }
 
-  return <Text color={Color.Gray}>{breadcrumbsText.join("")}</Text>;
+  return <Text color={Color.Gray}>{text.join("")}</Text>;
 }
 
 interface CodeLineTextProps {

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -11,7 +11,7 @@ function BreadcrumbsText({ ancestor }: BreadcrumbsTextProps) {
   const breadcrumbsText: Array<string> = [];
 
   while ("name" in ancestor) {
-    breadcrumbsText.unshift(` ❭ ${ancestor.name}`);
+    breadcrumbsText.unshift(" ❭ ", ancestor.name);
     ancestor = ancestor.parent;
   }
 


### PR DESCRIPTION
Moving the `breadcrumbs` to an output component, because `ancestorNames` are only useful in the output. 