### PR TITLE
chore: use `poku` to run unit tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -100,7 +100,7 @@
     },
 
     {
-      "include": ["**/*.test.js"],
+      "include": ["tests/*.test.js"],
       "linter": {
         "rules": {
           "complexity": {

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -22,6 +22,7 @@
     "jsxs",
     "monocart",
     "packagephobia",
+    "poku",
     "tsserverlibrary",
     "tstyche",
     "typecheck",

--- a/models/__tests__/config-schema.test.js
+++ b/models/__tests__/config-schema.test.js
@@ -1,8 +1,7 @@
-import { strict as assert } from "node:assert";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { Ajv } from "ajv";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -27,8 +26,8 @@ function readJsonFixtureFile(fixtureFileName) {
 
 const configSchema = readJsonFile("../config-schema.json");
 
-describe("config-schema.json", function () {
-  describe("valid", function () {
+describe("config-schema.json", () => {
+  describe("valid", () => {
     const testCases = [
       {
         fixtureFileName: "valid-all-options.json",
@@ -52,17 +51,17 @@ describe("config-schema.json", function () {
       },
     ];
 
-    testCases.forEach(({ fixtureFileName, testCase }) => {
-      test(testCase, function () {
+    for (const { fixtureFileName, testCase } of testCases) {
+      test(testCase, () => {
         const validate = ajv.compile(configSchema);
         const fixture = readJsonFixtureFile(fixtureFileName);
 
-        assert.equal(validate(fixture), true);
+        assert.strictEqual(validate(fixture), true);
       });
-    });
+    }
   });
 
-  describe("invalid", function () {
+  describe("invalid", () => {
     const testCases = [
       {
         fixtureFileName: "invalid-failFast.json",
@@ -102,13 +101,13 @@ describe("config-schema.json", function () {
       },
     ];
 
-    testCases.forEach(({ fixtureFileName, testCase }) => {
-      test(testCase, function () {
+    for (const { fixtureFileName, testCase } of testCases) {
+      test(testCase, () => {
         const validate = ajv.compile(configSchema);
         const fixture = readJsonFixtureFile(fixtureFileName);
 
-        assert.equal(validate(fixture), false);
+        assert.strictEqual(validate(fixture), false);
       });
-    });
+    }
   });
 });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:examples": "tstyche examples",
     "test:run": "mocha --config mocha.config.json",
     "test:types": "tstyche typetests",
-    "test:unit": "yarn test:run **/__tests__/*.test.* --parallel --reporter dot"
+    "test:unit": "yarn poku **/__tests__/*.test.* --parallel"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
@@ -71,6 +71,7 @@
     "magic-string": "0.30.10",
     "mocha": "10.7.0",
     "monocart-coverage-reports": "2.9.3",
+    "poku": "2.1.0",
     "pretty-ansi": "2.0.0",
     "rollup": "4.19.0",
     "rollup-plugin-dts": "6.1.1",

--- a/source/output/__tests__/describeNameText.test.js
+++ b/source/output/__tests__/describeNameText.test.js
@@ -1,19 +1,18 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import { Scribbler, describeNameText } from "tstyche/tstyche";
 
 const scribbler = new Scribbler();
 
-describe("describeNameText", function () {
-  test("describe name text", function () {
+describe("describeNameText", () => {
+  test("describe name text", () => {
     const text = scribbler.render(describeNameText("sample describe name"));
 
-    assert.equal(text, ["  sample describe name", ""].join("\n"));
+    assert.strictEqual(text, ["  sample describe name", ""].join("\n"));
   });
 
-  test("describe name text with indent", function () {
+  test("describe name text with indent", () => {
     const text = scribbler.render(describeNameText("sample describe name", 2));
 
-    assert.equal(text, ["      sample describe name", ""].join("\n"));
+    assert.strictEqual(text, ["      sample describe name", ""].join("\n"));
   });
 });

--- a/source/output/__tests__/diagnosticText.test.js
+++ b/source/output/__tests__/diagnosticText.test.js
@@ -1,21 +1,20 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import prettyAnsi from "pretty-ansi";
 import { Diagnostic, Scribbler, diagnosticText } from "tstyche/tstyche";
 
 const scribbler = new Scribbler();
 
-describe("diagnosticText", function () {
-  test("formats diagnostic text", function () {
+describe("diagnosticText", () => {
+  test("formats diagnostic text", () => {
     const text = scribbler.render(diagnosticText(Diagnostic.error("sample text")));
 
-    assert.equal(prettyAnsi(text), ["<red>Error: </>sample text", "", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["<red>Error: </>sample text", "", ""].join("\n"));
   });
 
-  test("formats diagnostic text with more than two lines", function () {
+  test("formats diagnostic text with more than two lines", () => {
     const text = scribbler.render(diagnosticText(Diagnostic.error(["sample text", "with more than", "two lines"])));
 
-    assert.equal(
+    assert.strictEqual(
       prettyAnsi(text),
       ["<red>Error: </>sample text", "", "with more than", "two lines", "", ""].join("\n"),
     );

--- a/source/output/__tests__/fileStatusText.test.js
+++ b/source/output/__tests__/fileStatusText.test.js
@@ -1,5 +1,4 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import prettyAnsi from "pretty-ansi";
 import { ResultStatus, Scribbler, TestFile, fileStatusText } from "tstyche/tstyche";
 
@@ -8,22 +7,22 @@ const sampleTestFile = new TestFile(sampleTestFileUrl);
 
 const scribbler = new Scribbler();
 
-describe("fileStatusText", function () {
-  test("formats failing file status text", function () {
+describe("fileStatusText", () => {
+  test("formats failing file status text", () => {
     const text = scribbler.render(fileStatusText(ResultStatus.Failed, sampleTestFile));
 
-    assert.equal(prettyAnsi(text), ["<red>fail</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["<red>fail</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
   });
 
-  test("formats passing file status text", function () {
+  test("formats passing file status text", () => {
     const text = scribbler.render(fileStatusText(ResultStatus.Passed, sampleTestFile));
 
-    assert.equal(prettyAnsi(text), ["<green>pass</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["<green>pass</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
   });
 
-  test("formats running file status text", function () {
+  test("formats running file status text", () => {
     const text = scribbler.render(fileStatusText(ResultStatus.Runs, sampleTestFile));
 
-    assert.equal(prettyAnsi(text), ["<yellow>runs</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["<yellow>runs</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
   });
 });

--- a/source/output/__tests__/formattedText.test.js
+++ b/source/output/__tests__/formattedText.test.js
@@ -1,25 +1,24 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import { Scribbler, formattedText } from "tstyche/tstyche";
 
 const scribbler = new Scribbler();
 
-describe("formattedText", function () {
-  test("formats string", function () {
+describe("formattedText", () => {
+  test("formats string", () => {
     const string = scribbler.render(formattedText("1.2.3"));
 
-    assert.equal(string, ["1.2.3", ""].join("\n"));
+    assert.strictEqual(string, ["1.2.3", ""].join("\n"));
   });
 
-  test("formats list", function () {
+  test("formats list", () => {
     const list = scribbler.render(formattedText(["path/to/first.test.ts", "path/to/second.test.ts"]));
 
-    assert.equal(list, ["[", '  "path/to/first.test.ts",', '  "path/to/second.test.ts"', "]", ""].join("\n"));
+    assert.strictEqual(list, ["[", '  "path/to/first.test.ts",', '  "path/to/second.test.ts"', "]", ""].join("\n"));
   });
 
-  test("formats object", function () {
+  test("formats object", () => {
     const record = scribbler.render(formattedText({ k: "keys", a: "all", s: "sorted" }));
 
-    assert.equal(record, ["{", '  "a": "all",', '  "k": "keys",', '  "s": "sorted"', "}", ""].join("\n"));
+    assert.strictEqual(record, ["{", '  "a": "all",', '  "k": "keys",', '  "s": "sorted"', "}", ""].join("\n"));
   });
 });

--- a/source/output/__tests__/helpText.test.js
+++ b/source/output/__tests__/helpText.test.js
@@ -1,5 +1,4 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import prettyAnsi from "pretty-ansi";
 import { OptionBrand, Scribbler, helpText } from "tstyche/tstyche";
 
@@ -66,11 +65,11 @@ const sampleVersion = "1.2.3";
 
 const scribbler = new Scribbler();
 
-describe("helpText", function () {
-  test("formats help text", function () {
+describe("helpText", () => {
+  test("formats help text", () => {
     const text = scribbler.render(helpText(sampleCommandLineOptionDefinitions, sampleVersion));
 
-    assert.equal(
+    assert.strictEqual(
       prettyAnsi(text),
       [
         "The TSTyche Type Test Runner  <gray>1.2.3</>",

--- a/source/output/__tests__/testNameText.test.js
+++ b/source/output/__tests__/testNameText.test.js
@@ -1,56 +1,55 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import prettyAnsi from "pretty-ansi";
 import { Scribbler, testNameText } from "tstyche/tstyche";
 
 const scribbler = new Scribbler();
 
-describe("testNameText", function () {
-  test("formats failing test name text", function () {
+describe("testNameText", () => {
+  test("formats failing test name text", () => {
     const text = scribbler.render(testNameText("fail", "sample test name"));
 
-    assert.equal(prettyAnsi(text), ["  <red>×</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["  <red>×</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats failing test name text with indent", function () {
+  test("formats failing test name text with indent", () => {
     const text = scribbler.render(testNameText("fail", "sample test name", 2));
 
-    assert.equal(prettyAnsi(text), ["      <red>×</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["      <red>×</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats passing test name text", function () {
+  test("formats passing test name text", () => {
     const text = scribbler.render(testNameText("pass", "sample test name"));
 
-    assert.equal(prettyAnsi(text), ["  <green>+</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["  <green>+</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats passing test name text with indent", function () {
+  test("formats passing test name text with indent", () => {
     const text = scribbler.render(testNameText("pass", "sample test name", 2));
 
-    assert.equal(prettyAnsi(text), ["      <green>+</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["      <green>+</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats skipped test name text", function () {
+  test("formats skipped test name text", () => {
     const text = scribbler.render(testNameText("skip", "sample test name"));
 
-    assert.equal(prettyAnsi(text), ["  <yellow>- skip</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["  <yellow>- skip</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats skipped test name text with indent", function () {
+  test("formats skipped test name text with indent", () => {
     const text = scribbler.render(testNameText("skip", "sample test name", 2));
 
-    assert.equal(prettyAnsi(text), ["      <yellow>- skip</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["      <yellow>- skip</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats todo test name text", function () {
+  test("formats todo test name text", () => {
     const text = scribbler.render(testNameText("todo", "sample test name"));
 
-    assert.equal(prettyAnsi(text), ["  <magenta>- todo</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["  <magenta>- todo</> <gray>sample test name</>", ""].join("\n"));
   });
 
-  test("formats todo test name text with indent", function () {
+  test("formats todo test name text with indent", () => {
     const text = scribbler.render(testNameText("todo", "sample test name", 2));
 
-    assert.equal(prettyAnsi(text), ["      <magenta>- todo</> <gray>sample test name</>", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["      <magenta>- todo</> <gray>sample test name</>", ""].join("\n"));
   });
 });

--- a/source/output/__tests__/usesCompilerStepText.test.js
+++ b/source/output/__tests__/usesCompilerStepText.test.js
@@ -1,6 +1,5 @@
-import { strict as assert } from "node:assert";
 import path from "node:path";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import prettyAnsi from "pretty-ansi";
 import { Scribbler, usesCompilerStepText } from "tstyche/tstyche";
 
@@ -8,28 +7,28 @@ const sampleTsconfigFilePath = path.resolve("path", "to", "tsconfig.json");
 
 const scribbler = new Scribbler();
 
-describe("usesCompilerStepText", function () {
-  test("formats uses compiler step text", function () {
+describe("usesCompilerStepText", () => {
+  test("formats uses compiler step text", () => {
     const text = scribbler.render(usesCompilerStepText("1.2.3", sampleTsconfigFilePath));
 
-    assert.equal(
+    assert.strictEqual(
       prettyAnsi(text),
       ["<blue>uses</> TypeScript 1.2.3<gray> with ./path/to/tsconfig.json</>", "", ""].join("\n"),
     );
   });
 
-  test("formats uses compiler step text with empty line prepended", function () {
+  test("formats uses compiler step text with empty line prepended", () => {
     const text = scribbler.render(usesCompilerStepText("1.2.3", sampleTsconfigFilePath, { prependEmptyLine: true }));
 
-    assert.equal(
+    assert.strictEqual(
       prettyAnsi(text),
       ["", "<blue>uses</> TypeScript 1.2.3<gray> with ./path/to/tsconfig.json</>", "", ""].join("\n"),
     );
   });
 
-  test("formats uses compiler step text without TSConfig path", function () {
+  test("formats uses compiler step text without TSConfig path", () => {
     const text = scribbler.render(usesCompilerStepText("1.2.3", undefined));
 
-    assert.equal(prettyAnsi(text), ["<blue>uses</> TypeScript 1.2.3", "", ""].join("\n"));
+    assert.strictEqual(prettyAnsi(text), ["<blue>uses</> TypeScript 1.2.3", "", ""].join("\n"));
   });
 });

--- a/source/version/__tests__/Version.test.js
+++ b/source/version/__tests__/Version.test.js
@@ -1,10 +1,9 @@
-import { strict as assert } from "node:assert";
-import { describe, test } from "mocha";
+import { assert, describe, test } from "poku";
 import { Version } from "tstyche/tstyche";
 
-describe("Version", function () {
-  describe("'isVersionTag' method", function () {
-    const cases = [
+describe("Version", () => {
+  describe("'isVersionTag' method", () => {
+    const testCases = [
       {
         expected: true,
         target: "6",
@@ -53,17 +52,17 @@ describe("Version", function () {
       },
     ];
 
-    cases.forEach(({ expected, target, testCase }) => {
-      test(testCase, function () {
+    for (const { expected, target, testCase } of testCases) {
+      test(testCase, () => {
         const result = Version.isVersionTag(target);
 
-        assert.equal(result, expected);
+        assert.strictEqual(result, expected);
       });
-    });
+    }
   });
 
-  describe("'isGreaterThan' method", function () {
-    const cases = [
+  describe("'isGreaterThan' method", () => {
+    const testCases = [
       {
         expected: true,
         source: "5.3",
@@ -164,17 +163,17 @@ describe("Version", function () {
       },
     ];
 
-    cases.forEach(({ expected, source, target, testCase }) => {
-      test(testCase, function () {
+    for (const { expected, source, target, testCase } of testCases) {
+      test(testCase, () => {
         const result = Version.isGreaterThan(source, target);
 
-        assert.equal(result, expected);
+        assert.strictEqual(result, expected);
       });
-    });
+    }
   });
 
-  describe("'isSatisfiedWith' method", function () {
-    const cases = [
+  describe("'isSatisfiedWith' method", () => {
+    const testCases = [
       {
         expected: true,
         source: "5.3.2",
@@ -275,12 +274,12 @@ describe("Version", function () {
       },
     ];
 
-    cases.forEach(({ expected, source, target, testCase }) => {
-      test(testCase, function () {
+    for (const { expected, source, target, testCase } of testCases) {
+      test(testCase, () => {
         const result = Version.isSatisfiedWith(source, target);
 
-        assert.equal(result, expected);
+        assert.strictEqual(result, expected);
       });
-    });
+    }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2562,6 +2562,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"poku@npm:2.1.0":
+  version: 2.1.0
+  resolution: "poku@npm:2.1.0"
+  bin:
+    poku: lib/bin/index.js
+  checksum: f21287c2e19a23c04eed4d474cddccc12ff647cec9b1c1b0565dc7d614e647663b7deb32d7c778f54acde6ec032edc74a83cd8f529c8c9409f942ffb477d87d6
+  languageName: node
+  linkType: hard
+
 "pretty-ansi@npm:2.0.0":
   version: 2.0.0
   resolution: "pretty-ansi@npm:2.0.0"
@@ -2998,6 +3007,7 @@ __metadata:
     magic-string: 0.30.10
     mocha: 10.7.0
     monocart-coverage-reports: 2.9.3
+    poku: 2.1.0
     pretty-ansi: 2.0.0
     rollup: 4.19.0
     rollup-plugin-dts: 6.1.1


### PR DESCRIPTION
Let’s use `poku` to run unit tests.