### PR TITLE
fix(output): mark warning locations in yellow

### DIFF
--- a/source/output/diagnosticText.tsx
+++ b/source/output/diagnosticText.tsx
@@ -26,7 +26,7 @@ function DiagnosticText({ diagnostic }: DiagnosticTextProps) {
   const codeSpan = diagnostic.origin ? (
     <Text>
       <Line />
-      <CodeSpanText diagnosticOrigin={diagnostic.origin} />
+      <CodeSpanText diagnosticCategory={diagnostic.category} diagnosticOrigin={diagnostic.origin} />
     </Text>
   ) : undefined;
 


### PR DESCRIPTION
Warnings should look less alarming. Better to mark locations in yellow.

<img width="645" alt="Screenshot 2024-07-24 at 10 21 20" src="https://github.com/user-attachments/assets/15af430a-53c0-45f6-9394-faa7d2a75f42">
