### PR TITLE
fix(store): if requested, always suppress errors when fetching manifest

### DIFF
--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -13,13 +13,13 @@ export class Fetcher {
     request: Request,
     timeout: number,
     diagnostic: Diagnostic,
-    options?: { quiet?: boolean | undefined },
+    options?: { suppressErrors?: boolean | undefined },
   ): Promise<Response | undefined> {
     try {
       const response = await fetch(request, { signal: AbortSignal.timeout(timeout) });
 
       if (!response.ok) {
-        !options?.quiet &&
+        !options?.suppressErrors &&
           this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.requestFailedWithStatusCode(response.status)));
 
         return;
@@ -28,10 +28,10 @@ export class Fetcher {
       return response;
     } catch (error) {
       if (error instanceof Error && error.name === "TimeoutError") {
-        !options?.quiet &&
+        !options?.suppressErrors &&
           this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(timeout)));
       } else {
-        !options?.quiet &&
+        !options?.suppressErrors &&
           this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.maybeNetworkConnectionIssue()));
       }
     }

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -13,27 +13,26 @@ export class Fetcher {
     request: Request,
     timeout: number,
     diagnostic: Diagnostic,
-    options?: { quite?: boolean | undefined },
+    options?: { quiet?: boolean | undefined },
   ): Promise<Response | undefined> {
     try {
       const response = await fetch(request, { signal: AbortSignal.timeout(timeout) });
 
       if (!response.ok) {
-        this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.requestFailedWithStatusCode(response.status)));
+        !options?.quiet &&
+          this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.requestFailedWithStatusCode(response.status)));
 
         return;
       }
 
       return response;
     } catch (error) {
-      if (options?.quite === true) {
-        return;
-      }
-
       if (error instanceof Error && error.name === "TimeoutError") {
-        this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(timeout)));
+        !options?.quiet &&
+          this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(timeout)));
       } else {
-        this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.maybeNetworkConnectionIssue()));
+        !options?.quiet &&
+          this.#onDiagnostics(diagnostic.extendWith(StoreDiagnosticText.maybeNetworkConnectionIssue()));
       }
     }
 

--- a/source/store/ManifestWorker.ts
+++ b/source/store/ManifestWorker.ts
@@ -54,7 +54,7 @@ export class ManifestWorker {
     return false;
   }
 
-  async #load(options?: { quite?: boolean }) {
+  async #load(options?: { quiet?: boolean }) {
     const diagnostic = Diagnostic.error(StoreDiagnosticText.failedToFetchMetadata(this.#npmRegistry));
 
     const request = new Request(new URL("typescript", this.#npmRegistry), {
@@ -64,7 +64,7 @@ export class ManifestWorker {
       },
     });
 
-    const response = await this.#fetcher.get(request, this.#timeout, diagnostic, { quite: options?.quite });
+    const response = await this.#fetcher.get(request, this.#timeout, diagnostic, { quiet: options?.quiet });
 
     if (!response) {
       return;
@@ -127,9 +127,9 @@ export class ManifestWorker {
     }
 
     if (this.isOutdated(manifest) || options?.refresh === true) {
-      const quite = options?.refresh !== true;
+      const quiet = options?.refresh !== true;
 
-      const freshManifest = await this.#load({ quite });
+      const freshManifest = await this.#load({ quiet });
 
       if (freshManifest != null) {
         await this.persist(freshManifest);

--- a/source/store/ManifestWorker.ts
+++ b/source/store/ManifestWorker.ts
@@ -54,7 +54,7 @@ export class ManifestWorker {
     return false;
   }
 
-  async #load(options?: { quiet?: boolean }) {
+  async #load(options?: { suppressErrors?: boolean }) {
     const diagnostic = Diagnostic.error(StoreDiagnosticText.failedToFetchMetadata(this.#npmRegistry));
 
     const request = new Request(new URL("typescript", this.#npmRegistry), {
@@ -64,7 +64,9 @@ export class ManifestWorker {
       },
     });
 
-    const response = await this.#fetcher.get(request, this.#timeout, diagnostic, { quiet: options?.quiet });
+    const response = await this.#fetcher.get(request, this.#timeout, diagnostic, {
+      suppressErrors: options?.suppressErrors,
+    });
 
     if (!response) {
       return;
@@ -127,8 +129,8 @@ export class ManifestWorker {
     }
 
     if (this.isOutdated(manifest) || options?.refresh === true) {
-      // errors are logged only when manifest refresh was requested explicitly (e.g. via the '--update' option)
-      const freshManifest = await this.#load({ quiet: !options?.refresh });
+      // error events are dispatched only when manifest refresh is requested explicitly (e.g. via the '--update' option)
+      const freshManifest = await this.#load({ suppressErrors: !options?.refresh });
 
       if (freshManifest != null) {
         await this.persist(freshManifest);

--- a/source/store/ManifestWorker.ts
+++ b/source/store/ManifestWorker.ts
@@ -127,9 +127,8 @@ export class ManifestWorker {
     }
 
     if (this.isOutdated(manifest) || options?.refresh === true) {
-      const quiet = options?.refresh !== true;
-
-      const freshManifest = await this.#load({ quiet });
+      // errors are logged only when manifest refresh was requested explicitly (e.g. via the '--update' option)
+      const freshManifest = await this.#load({ quiet: !options?.refresh });
 
       if (freshManifest != null) {
         await this.persist(freshManifest);

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -231,4 +231,111 @@ await describe("store", async () => {
       });
     }
   });
+
+  await describe("does not error if resolution of a tag may be outdated", async () => {
+    await test("when fetch request of metadata fails with 404", async () => {
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+      });
+
+      await spawnTyche(fixtureUrl, ["--target", "5.2"]);
+
+      const storeManifest = {
+        $version: "1",
+        lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+        resolutions: {
+          ["5.2"]: "5.2.2",
+          ["5.3"]: "5.3.3",
+          beta: "5.3.0-beta",
+          latest: "5.3.3",
+          next: "5.4.0-dev.20240112",
+          rc: "5.3.1-rc",
+        },
+        versions: ["5.2.2", "5.3.2", "5.3.3"],
+      };
+
+      await writeFixture(fixtureUrl, {
+        [".store/store-manifest.json"]: JSON.stringify(storeManifest),
+      });
+
+      const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.2"], {
+        env: {
+          ["TSTYCHE_NPM_REGISTRY"]: "https://tstyche.org",
+        },
+      });
+
+      assert.equal(stderr, "");
+      assert.equal(exitCode, 0);
+    });
+
+    await test("when fetch request of metadata times out", async () => {
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+      });
+
+      await spawnTyche(fixtureUrl, ["--target", "5.2"]);
+
+      const storeManifest = {
+        $version: "1",
+        lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+        resolutions: {
+          ["5.2"]: "5.2.2",
+          ["5.3"]: "5.3.3",
+          beta: "5.3.0-beta",
+          latest: "5.3.3",
+          next: "5.4.0-dev.20240112",
+          rc: "5.3.1-rc",
+        },
+        versions: ["5.2.2", "5.3.2", "5.3.3"],
+      };
+
+      await writeFixture(fixtureUrl, {
+        [".store/store-manifest.json"]: JSON.stringify(storeManifest),
+      });
+
+      const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.2"], {
+        env: {
+          ["TSTYCHE_TIMEOUT"]: "0.001",
+        },
+      });
+
+      assert.equal(stderr, "");
+      assert.equal(exitCode, 0);
+    });
+
+    await test("when fetch request of metadata fails", async () => {
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/dummy.test.ts"]: isStringTestText,
+      });
+
+      await spawnTyche(fixtureUrl, ["--target", "5.2"]);
+
+      const storeManifest = {
+        $version: "1",
+        lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+        resolutions: {
+          ["5.2"]: "5.2.2",
+          ["5.3"]: "5.3.3",
+          beta: "5.3.0-beta",
+          latest: "5.3.3",
+          next: "5.4.0-dev.20240112",
+          rc: "5.3.1-rc",
+        },
+        versions: ["5.2.2", "5.3.2", "5.3.3"],
+      };
+
+      await writeFixture(fixtureUrl, {
+        [".store/store-manifest.json"]: JSON.stringify(storeManifest),
+      });
+
+      const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.2"], {
+        env: {
+          ["TSTYCHE_NPM_REGISTRY"]: "https://nothing.tstyche.org",
+        },
+      });
+
+      assert.equal(stderr, "");
+      assert.equal(exitCode, 0);
+    });
+  })
 });

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -232,7 +232,7 @@ await describe("store", async () => {
     }
   });
 
-  await describe("does not error if resolution of a tag may be outdated", async () => {
+  await describe("suppresses fetch errors if resolution of a tag may be outdated", async () => {
     await test("when fetch request of metadata fails with 404", async () => {
       await writeFixture(fixtureUrl, {
         ["__typetests__/dummy.test.ts"]: isStringTestText,
@@ -337,5 +337,5 @@ await describe("store", async () => {
       assert.equal(stderr, "");
       assert.equal(exitCode, 0);
     });
-  })
+  });
 });

--- a/tests/validation-update.test.js
+++ b/tests/validation-update.test.js
@@ -51,7 +51,6 @@ await describe("'--update' command line option", async () => {
     assert.equal(exitCode, 1);
   });
 
-
   await test("when fetch request of metadata times out", async () => {
     const storeManifest = {
       $version: "1",

--- a/tests/validation-update.test.js
+++ b/tests/validation-update.test.js
@@ -22,7 +22,7 @@ await describe("'--update' command line option", async () => {
     await clearFixture(fixtureUrl);
   });
 
-  await test("failed to fetch metadata of the 'typescript' package", async () => {
+  await test("when fetch request of metadata fails with 404", async () => {
     const storeManifest = {
       $version: "1",
       lastUpdated: Date.now(), // this is considered fresh during regular test run
@@ -35,11 +35,71 @@ await describe("'--update' command line option", async () => {
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--update"], {
-      env: { ["TSTYCHE_TIMEOUT"]: "0.001" },
+      env: {
+        ["TSTYCHE_NPM_REGISTRY"]: "https://tstyche.org",
+      },
     });
 
+    const expected = [
+      "Error: Failed to fetch metadata of the 'typescript' package from 'https://tstyche.org'.",
+      "",
+      "The request failed with status code 404.",
+    ].join("\n");
+
     assert.equal(stdout, "");
-    assert.match(stderr, /^Error: Failed to fetch metadata of the 'typescript' package/);
+    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(exitCode, 1);
+  });
+
+
+  await test("when fetch request of metadata times out", async () => {
+    const storeManifest = {
+      $version: "1",
+      lastUpdated: Date.now(), // this is considered fresh during regular test run
+      versions: ["5.0.2", "5.0.3", "5.0.4"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      [".store/store-manifest.json"]: JSON.stringify(storeManifest),
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--update"], {
+      env: {
+        ["TSTYCHE_TIMEOUT"]: "0.001",
+      },
+    });
+
+    const expected = [
+      "Error: Failed to fetch metadata of the 'typescript' package from 'https://registry.npmjs.org'.",
+      "",
+      "The request timeout of 0.001s was exceeded.",
+    ].join("\n");
+
+    assert.equal(stdout, "");
+    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(exitCode, 1);
+  });
+
+  await test("when fetch request of metadata fails", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--update"], {
+      env: {
+        ["TSTYCHE_NPM_REGISTRY"]: "https://nothing.tstyche.org",
+      },
+    });
+
+    const expected = [
+      "Error: Failed to fetch metadata of the 'typescript' package from 'https://nothing.tstyche.org'.",
+      "",
+      "Might be there is an issue with the registry or the network connection.",
+    ].join("\n");
+
+    assert.equal(stdout, "");
+    assert.match(stderr, new RegExp(`^${expected}`));
     assert.equal(exitCode, 1);
   });
 });


### PR DESCRIPTION
When requested, fetch must always suppress errors.