### PR TITLE
fix(store): make sure the same `npmRegistry` is used to fetch metadata and packages

### DIFF
--- a/source/store/StoreService.ts
+++ b/source/store/StoreService.ts
@@ -9,9 +9,10 @@ import { Path } from "#path";
 import type { CancellationToken } from "#token";
 import { Version } from "#version";
 import { Fetcher } from "./Fetcher.js";
-import { type Manifest, ManifestWorker } from "./ManifestWorker.js";
+import { ManifestWorker } from "./ManifestWorker.js";
 import { PackageInstaller } from "./PackageInstaller.js";
 import { StoreDiagnosticText } from "./StoreDiagnosticText.js";
+import type { Manifest } from "./types.js";
 
 export class StoreService {
   #compilerInstanceCache = new Map<string, typeof ts>();

--- a/source/store/types.ts
+++ b/source/store/types.ts
@@ -1,3 +1,12 @@
 import type { Diagnostic } from "#diagnostic";
 
 export type DiagnosticsHandler = (diagnostic: Diagnostic) => void;
+
+export interface Manifest {
+  $version: string;
+  lastUpdated: number;
+  npmRegistry: string;
+  packages: Record<string, { integrity: string; tarball: string }>;
+  resolutions: Record<string, string>;
+  versions: Array<string>;
+}

--- a/tests/config-prune.test.js
+++ b/tests/config-prune.test.js
@@ -43,7 +43,7 @@ await describe("'--prune' command line option", async () => {
 
   for (const { args, testCase } of testCases) {
     await test(testCase, async () => {
-      const storeManifest = { $version: "0" };
+      const storeManifest = { $version: "2" };
       const storeUrl = new URL("./.store", fixtureUrl);
 
       await writeFixture(fixtureUrl, {

--- a/tests/config-update.test.js
+++ b/tests/config-update.test.js
@@ -56,9 +56,9 @@ await describe("'--update' command line option", async () => {
 
   await test("updates existing store manifest", async () => {
     const oldStoreManifest = JSON.stringify({
-      $version: "1",
+      $version: "2",
       lastUpdated: Date.now(), // this is considered fresh during regular test run
-      versions: ["5.0.2", "5.0.3", "5.0.4"],
+      npmRegistry: "https://registry.npmjs.org",
     });
 
     await writeFixture(fixtureUrl, {

--- a/tests/feature-store.test.js
+++ b/tests/feature-store.test.js
@@ -113,7 +113,7 @@ await describe("store", async () => {
   });
 
   await test("when text is unparsable, store manifest is regenerated", async () => {
-    const storeManifest = '{"$version":"1","last';
+    const storeManifest = '{"$version":"2","last';
 
     await writeFixture(fixtureUrl, {
       [".store/store-manifest.json"]: storeManifest,
@@ -133,7 +133,7 @@ await describe("store", async () => {
   });
 
   await test("when '$version' is different, store manifest is regenerated", async () => {
-    const storeManifest = { $version: "0" };
+    const storeManifest = { $version: "1" };
 
     await writeFixture(fixtureUrl, {
       [".store/store-manifest.json"]: JSON.stringify(storeManifest),
@@ -146,7 +146,33 @@ await describe("store", async () => {
       encoding: "utf8",
     });
 
-    assert.matchObject(result, { $version: "1" });
+    assert.matchObject(result, { $version: "2" });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
+  await test("when 'npmRegistry' is different, store manifest is regenerated", async () => {
+    const storeManifest = {
+      $version: "2", npmRegistry: "https://registry.npmjs.org",
+    };
+
+    await writeFixture(fixtureUrl, {
+      [".store/store-manifest.json"]: JSON.stringify(storeManifest),
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.2"], {
+      env: {
+        ["TSTYCHE_NPM_REGISTRY"]: "https://registry.yarnpkg.com",
+      },
+    });
+
+    const result = await fs.readFile(new URL("./.store/store-manifest.json", fixtureUrl), {
+      encoding: "utf8",
+    });
+
+    assert.matchObject(result, { npmRegistry: "https://registry.yarnpkg.com" });
 
     assert.equal(stderr, "");
     assert.equal(exitCode, 0);
@@ -154,8 +180,9 @@ await describe("store", async () => {
 
   await test("when is up to date, store manifest is not regenerated", async () => {
     const storeManifest = JSON.stringify({
-      $version: "1",
+      $version: "2",
       lastUpdated: Date.now() - 60 * 60 * 1000, // 2 hours
+      npmRegistry: "https://registry.npmjs.org",
       resolutions: {},
       versions: ["5.0.2", "5.0.3", "5.0.4"],
     });
@@ -179,8 +206,9 @@ await describe("store", async () => {
 
   await test("when is outdated, store manifest is regenerated", async () => {
     const storeManifest = JSON.stringify({
-      $version: "1",
+      $version: "2",
       lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+      npmRegistry: "https://registry.npmjs.org",
       resolutions: {},
       versions: ["5.0.2", "5.0.3", "5.0.4"],
     });

--- a/tests/feature-store.test.js
+++ b/tests/feature-store.test.js
@@ -154,7 +154,8 @@ await describe("store", async () => {
 
   await test("when 'npmRegistry' is different, store manifest is regenerated", async () => {
     const storeManifest = {
-      $version: "2", npmRegistry: "https://registry.npmjs.org",
+      $version: "2",
+      npmRegistry: "https://registry.npmjs.org",
     };
 
     await writeFixture(fixtureUrl, {

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -148,8 +148,9 @@ await describe("store", async () => {
     for (const { target, testCase } of testCases) {
       await test(testCase, async () => {
         const storeManifest = {
-          $version: "1",
+          $version: "2",
           lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+          npmRegistry: "https://registry.npmjs.org",
           resolutions: {
             ["5.2"]: "5.2.2",
             ["5.3"]: "5.3.3",
@@ -202,15 +203,12 @@ await describe("store", async () => {
     for (const { target, testCase } of testCases) {
       await test(testCase, async () => {
         const storeManifest = {
-          $version: "1",
+          $version: "2",
+          npmRegistry: "https://registry.npmjs.org",
           lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
           resolutions: {
             ["5.2"]: "5.2.2",
             ["5.3"]: "5.3.3",
-            beta: "5.3.0-beta",
-            latest: "5.3.3",
-            next: "5.4.0-dev.20240112",
-            rc: "5.3.1-rc",
           },
           versions: ["5.2.2", "5.3.2", "5.3.3"],
         };
@@ -241,15 +239,12 @@ await describe("store", async () => {
       await spawnTyche(fixtureUrl, ["--target", "5.2"]);
 
       const storeManifest = {
-        $version: "1",
+        $version: "2",
         lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+        npmRegistry: "https://tstyche.org",
         resolutions: {
           ["5.2"]: "5.2.2",
           ["5.3"]: "5.3.3",
-          beta: "5.3.0-beta",
-          latest: "5.3.3",
-          next: "5.4.0-dev.20240112",
-          rc: "5.3.1-rc",
         },
         versions: ["5.2.2", "5.3.2", "5.3.3"],
       };
@@ -276,15 +271,12 @@ await describe("store", async () => {
       await spawnTyche(fixtureUrl, ["--target", "5.2"]);
 
       const storeManifest = {
-        $version: "1",
+        $version: "2",
         lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+        npmRegistry: "https://registry.npmjs.org",
         resolutions: {
           ["5.2"]: "5.2.2",
           ["5.3"]: "5.3.3",
-          beta: "5.3.0-beta",
-          latest: "5.3.3",
-          next: "5.4.0-dev.20240112",
-          rc: "5.3.1-rc",
         },
         versions: ["5.2.2", "5.3.2", "5.3.3"],
       };
@@ -311,15 +303,12 @@ await describe("store", async () => {
       await spawnTyche(fixtureUrl, ["--target", "5.2"]);
 
       const storeManifest = {
-        $version: "1",
+        $version: "2",
         lastUpdated: Date.now() - 2.25 * 60 * 60 * 1000, // 2 hours and 15 minutes
+        npmRegistry: "https://nothing.tstyche.org",
         resolutions: {
           ["5.2"]: "5.2.2",
           ["5.3"]: "5.3.3",
-          beta: "5.3.0-beta",
-          latest: "5.3.3",
-          next: "5.4.0-dev.20240112",
-          rc: "5.3.1-rc",
         },
         versions: ["5.2.2", "5.3.2", "5.3.3"],
       };

--- a/tests/validation-update.test.js
+++ b/tests/validation-update.test.js
@@ -24,8 +24,9 @@ await describe("'--update' command line option", async () => {
 
   await test("when fetch request of metadata fails with 404", async () => {
     const storeManifest = {
-      $version: "1",
+      $version: "2",
       lastUpdated: Date.now(), // this is considered fresh during regular test run
+      npmRegistry: "https://tstyche.org",
       versions: ["5.0.2", "5.0.3", "5.0.4"],
     };
 
@@ -53,8 +54,9 @@ await describe("'--update' command line option", async () => {
 
   await test("when fetch request of metadata times out", async () => {
     const storeManifest = {
-      $version: "1",
+      $version: "2",
       lastUpdated: Date.now(), // this is considered fresh during regular test run
+      npmRegistry: "https://nothing.tstyche.org",
       versions: ["5.0.2", "5.0.3", "5.0.4"],
     };
 
@@ -81,6 +83,18 @@ await describe("'--update' command line option", async () => {
   });
 
   await test("when fetch request of metadata fails", async () => {
+    const storeManifest = {
+      $version: "2",
+      lastUpdated: Date.now(), // this is considered fresh during regular test run
+      npmRegistry: "https://nothing.tstyche.org",
+      versions: ["5.0.2", "5.0.3", "5.0.4"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      [".store/store-manifest.json"]: JSON.stringify(storeManifest),
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
     await writeFixture(fixtureUrl, {
       ["__typetests__/dummy.test.ts"]: isStringTestText,
     });


### PR DESCRIPTION
Since `npmRegistry` can be specified (#266), it is important to make sure that store manifest was created using the specified registry. Because packages must be fetched from the same registry.

This change is especially important for is split from #269.