### PR TITLE
refactor(events, handlers, output, store): rename the `store:adds` event

### DIFF
--- a/source/events/types.ts
+++ b/source/events/types.ts
@@ -6,7 +6,7 @@ export type Event =
   | ["select:error", { diagnostics: Array<Diagnostic> }]
   | ["run:start", { result: Result }]
   | ["run:end", { result: Result }]
-  | ["store:info", { packagePath: string; packageVersion: string }]
+  | ["store:adds", { packagePath: string; packageVersion: string }]
   | ["store:error", { diagnostics: Array<Diagnostic> }]
   | ["target:start", { result: TargetResult }]
   | ["target:end", { result: TargetResult }]

--- a/source/handlers/RunReporter.ts
+++ b/source/handlers/RunReporter.ts
@@ -1,7 +1,7 @@
 import type { ResolvedConfig } from "#config";
 import { Environment } from "#environment";
 import type { Event, EventHandler } from "#events";
-import { type OutputService, addsPackageStepText, diagnosticText, fileStatusText, usesCompilerStepText } from "#output";
+import { type OutputService, addsPackageText, diagnosticText, fileStatusText, usesCompilerStepText } from "#output";
 import { FileViewService } from "./FileViewService.js";
 import { Reporter } from "./Reporter.js";
 
@@ -32,8 +32,8 @@ export class RunReporter extends Reporter implements EventHandler {
         break;
       }
 
-      case "store:info": {
-        this.outputService.writeMessage(addsPackageStepText(payload.packageVersion, payload.packagePath));
+      case "store:adds": {
+        this.outputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
 
         this.#hasReportedAdds = true;
         break;

--- a/source/handlers/SetupReporter.ts
+++ b/source/handlers/SetupReporter.ts
@@ -1,12 +1,12 @@
 import { DiagnosticCategory } from "#diagnostic";
 import type { Event, EventHandler } from "#events";
-import { addsPackageStepText, diagnosticText } from "#output";
+import { addsPackageText, diagnosticText } from "#output";
 import { Reporter } from "./Reporter.js";
 
 export class SetupReporter extends Reporter implements EventHandler {
   handleEvent([eventName, payload]: Event): void {
-    if (eventName === "store:info") {
-      this.outputService.writeMessage(addsPackageStepText(payload.packageVersion, payload.packagePath));
+    if (eventName === "store:adds") {
+      this.outputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
       return;
     }
 

--- a/source/output/__tests__/addsPackageText.test.js
+++ b/source/output/__tests__/addsPackageText.test.js
@@ -1,0 +1,16 @@
+import { assert, describe, test } from "poku";
+import prettyAnsi from "pretty-ansi";
+import { Scribbler, addsPackageText } from "tstyche/tstyche";
+
+const scribbler = new Scribbler();
+
+describe("addsPackageText", () => {
+  test("formats adds package text", () => {
+    const text = scribbler.render(addsPackageText("5.4.3", "/sample/path/to/typescript@5.4.3"));
+
+    assert.strictEqual(
+      prettyAnsi(text),
+      ["<gray>adds</> TypeScript 5.4.3<gray> to /sample/path/to/typescript@5.4.3</>", ""].join("\n"),
+    );
+  });
+});

--- a/source/output/addsPackageText.tsx
+++ b/source/output/addsPackageText.tsx
@@ -1,6 +1,6 @@
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 
-export function addsPackageStepText(packageVersion: string, packagePath: string): ScribblerJsx.Element {
+export function addsPackageText(packageVersion: string, packagePath: string): ScribblerJsx.Element {
   return (
     <Line>
       <Text color={Color.Gray}>{"adds"}</Text>

--- a/source/output/index.ts
+++ b/source/output/index.ts
@@ -1,4 +1,4 @@
-export { addsPackageStepText } from "./addsPackageStepText.js";
+export { addsPackageText } from "./addsPackageText.js";
 export { describeNameText } from "./describeNameText.js";
 export { diagnosticText } from "./diagnosticText.js";
 export { fileStatusText } from "./fileStatusText.js";

--- a/source/store/PackageService.ts
+++ b/source/store/PackageService.ts
@@ -38,7 +38,7 @@ export class PackageService {
       return;
     }
 
-    EventEmitter.dispatch(["store:info", { packagePath, packageVersion }]);
+    EventEmitter.dispatch(["store:adds", { packagePath, packageVersion }]);
 
     const resource = manifest.packages[packageVersion];
 


### PR DESCRIPTION
Renaming the `store:adds` event to better reflect the intent.