### PR TITLE
fix(config): reduce verbosity of the `target` option validation

### DIFF
--- a/source/config/OptionValidator.ts
+++ b/source/config/OptionValidator.ts
@@ -37,7 +37,7 @@ export class OptionValidator {
       }
 
       case "target": {
-        if ((await this.#storeService.validateTag(optionValue)) !== true) {
+        if ((await this.#storeService.validateTag(optionValue)) === false) {
           this.#onDiagnostics(
             Diagnostic.error(
               [

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -32,9 +32,11 @@ await describe("store", async () => {
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://tstyche.org'.",
       "",
       "The request failed with status code 404.",
+      "",
+      "",
     ].join("\n");
 
-    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(stderr, expected);
     assert.equal(exitCode, 1);
   });
 
@@ -53,9 +55,11 @@ await describe("store", async () => {
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://registry.npmjs.org'.",
       "",
       "The request timeout of 0.001s was exceeded.",
+      "",
+      "",
     ].join("\n");
 
-    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(stderr, expected);
     assert.equal(exitCode, 1);
   });
 
@@ -74,9 +78,11 @@ await describe("store", async () => {
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://nothing.tstyche.org'.",
       "",
       "Might be there is an issue with the registry or the network connection.",
+      "",
+      "",
     ].join("\n");
 
-    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(stderr, expected);
     assert.equal(exitCode, 1);
   });
 

--- a/tests/validation-update.test.js
+++ b/tests/validation-update.test.js
@@ -40,10 +40,12 @@ await describe("'--update' command line option", async () => {
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://tstyche.org'.",
       "",
       "The request failed with status code 404.",
+      "",
+      "",
     ].join("\n");
 
     assert.equal(stdout, "");
-    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(stderr, expected);
     assert.equal(exitCode, 1);
   });
 
@@ -70,10 +72,12 @@ await describe("'--update' command line option", async () => {
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://registry.npmjs.org'.",
       "",
       "The request timeout of 0.001s was exceeded.",
+      "",
+      "",
     ].join("\n");
 
     assert.equal(stdout, "");
-    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(stderr, expected);
     assert.equal(exitCode, 1);
   });
 
@@ -104,10 +108,12 @@ await describe("'--update' command line option", async () => {
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://nothing.tstyche.org'.",
       "",
       "Might be there is an issue with the registry or the network connection.",
+      "",
+      "",
     ].join("\n");
 
     assert.equal(stdout, "");
-    assert.match(stderr, new RegExp(`^${expected}`));
+    assert.equal(stderr, expected);
     assert.equal(exitCode, 1);
   });
 });


### PR DESCRIPTION
The `target` option validation should be less verbose (and somewhat less misleading), when manifest is not available.