### PR TITLE
refactor(output): remove `OutputService` constructor options

### DIFF
--- a/source/output/OutputService.ts
+++ b/source/output/OutputService.ts
@@ -1,29 +1,16 @@
 import process from "node:process";
+import type { WriteStream } from "node:tty";
 import { Environment } from "#environment";
 import { Scribbler, type ScribblerJsx } from "#scribbler";
 
-export interface WriteStream {
-  write: (chunk: string) => void;
-}
-
-export interface OutputServiceOptions {
-  noColor?: boolean;
-  stderr?: WriteStream;
-  stdout?: WriteStream;
-}
-
 export class OutputService {
   #isClear = false;
-  #noColor: boolean;
+  #noColor = Environment.noColor;
   #scribbler: Scribbler;
-  #stderr: WriteStream;
-  #stdout: WriteStream;
+  #stderr = process.stderr;
+  #stdout = process.stdout;
 
-  constructor(options?: OutputServiceOptions) {
-    this.#noColor = options?.noColor ?? Environment.noColor;
-    this.#stderr = options?.stderr ?? process.stderr;
-    this.#stdout = options?.stdout ?? process.stdout;
-
+  constructor() {
     this.#scribbler = new Scribbler({ noColor: this.#noColor });
   }
 

--- a/source/output/index.ts
+++ b/source/output/index.ts
@@ -5,7 +5,7 @@ export { fileStatusText } from "./fileStatusText.js";
 export { fileViewText } from "./fileViewText.js";
 export { formattedText } from "./formattedText.js";
 export { helpText } from "./helpText.js";
-export { OutputService, type OutputServiceOptions, type WriteStream } from "./OutputService.js";
+export { OutputService } from "./OutputService.js";
 export { summaryText } from "./summaryText.js";
 export { testNameText } from "./testNameText.js";
 export { usesCompilerText } from "./usesCompilerText.js";


### PR DESCRIPTION
Remove `OutputService` constructor options, because they didn’t proof to be useful.