### PR TITLE
refactor(input): remove `InputService` constructor options

### DIFF
--- a/source/input/InputService.ts
+++ b/source/input/InputService.ts
@@ -2,25 +2,12 @@ import process from "node:process";
 
 export type InputHandler = (chunk: string) => void;
 
-export interface ReadStream {
-  addListener: (event: "data", handler: InputHandler) => this;
-  removeListener: (event: "data", handler: InputHandler) => this;
-  setEncoding: (encoding: "utf8") => this;
-  setRawMode?: (mode: boolean) => this;
-  unref: () => this;
-}
-
-export interface InputServiceOptions {
-  stdin?: ReadStream;
-}
-
 export class InputService {
   #onInput: InputHandler;
-  #stdin: ReadStream;
+  #stdin = process.stdin;
 
-  constructor(onInput: InputHandler, options?: InputServiceOptions) {
+  constructor(onInput: InputHandler) {
     this.#onInput = onInput;
-    this.#stdin = options?.stdin ?? process.stdin;
 
     this.#stdin.setRawMode?.(true);
     this.#stdin.setEncoding("utf8");

--- a/source/input/index.ts
+++ b/source/input/index.ts
@@ -1,1 +1,1 @@
-export { InputService, type InputHandler, type InputServiceOptions, type ReadStream } from "./InputService.js";
+export { InputService, type InputHandler } from "./InputService.js";


### PR DESCRIPTION
Remove `InputService` constructor options, because they were not anyhow useful.