### PR TITLE
refactor: add environment options to `ResolvedConfig`

### DIFF
--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -1,6 +1,5 @@
 import { TSTyche } from "#api";
 import { ConfigService, OptionDefinitionsMap, OptionGroup, type ResolvedConfig } from "#config";
-import { Environment } from "#environment";
 import { EventEmitter } from "#events";
 import { CancellationHandler, ExitCodeHandler, SetupReporter } from "#handlers";
 import { OutputService, formattedText, helpText, waitingForFileChangesText } from "#output";
@@ -82,17 +81,7 @@ export class Cli {
       }
 
       if (commandLineArguments.includes("--showConfig")) {
-        this.#outputService.writeMessage(
-          formattedText({
-            noColor: Environment.noColor,
-            noInteractive: Environment.noInteractive,
-            npmRegistry: Environment.npmRegistry,
-            storePath: Environment.storePath,
-            timeout: Environment.timeout,
-            typescriptPath: Environment.typescriptPath,
-            ...resolvedConfig,
-          }),
-        );
+        this.#outputService.writeMessage(formattedText({ ...resolvedConfig }));
         continue;
       }
 

--- a/source/config/CommandLineOptionsWorker.ts
+++ b/source/config/CommandLineOptionsWorker.ts
@@ -8,8 +8,6 @@ import { OptionValidator } from "./OptionValidator.js";
 import { OptionBrand, OptionGroup } from "./enums.js";
 import type { DiagnosticsHandler } from "./types.js";
 
-export type { CommandLineOptions } from "../../models/CommandLineOptions.js";
-
 export class CommandLineOptionsWorker {
   #commandLineOptionDefinitions: Map<string, OptionDefinition>;
   #commandLineOptions: Record<string, OptionValue>;

--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -13,8 +13,6 @@ import { OptionValidator } from "./OptionValidator.js";
 import { OptionBrand, OptionGroup } from "./enums.js";
 import type { DiagnosticsHandler } from "./types.js";
 
-export type { ConfigFileOptions } from "../../models/ConfigFileOptions.js";
-
 export class ConfigFileOptionsWorker {
   #compiler: typeof ts;
   #configFileOptionDefinitions: Map<string, OptionDefinition>;

--- a/source/config/EnvironmentService.ts
+++ b/source/config/EnvironmentService.ts
@@ -2,63 +2,19 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import process from "node:process";
 import { Path } from "#path";
+import type { EnvironmentOptions } from "./types.js";
 
-export class Environment {
-  static #isCi = Environment.#resolveIsCi();
-  static #noColor = Environment.#resolveNoColor();
-  static #noInteractive = Environment.#resolveNoInteractive();
-  static #npmRegistry = Environment.#resolveNpmRegistry();
-  static #storePath = Environment.#resolveStorePath();
-  static #timeout = Environment.#resolveTimeout();
-  static #typescriptPath = Environment.#resolveTypeScriptPath();
-
-  /**
-   * Is `true` if the process is running in a continuous integration environment.
-   */
-  static get isCi(): boolean {
-    return Environment.#isCi;
-  }
-
-  /**
-   * Specifies whether color should be disabled in the output.
-   */
-  static get noColor(): boolean {
-    return Environment.#noColor;
-  }
-
-  /**
-   * Specifies whether interactive elements should be disabled in the output.
-   */
-  static get noInteractive(): boolean {
-    return Environment.#noInteractive;
-  }
-
-  /**
-   * The base URL of the 'npm' registry to use.
-   */
-  static get npmRegistry(): string {
-    return Environment.#npmRegistry;
-  }
-
-  /**
-   * The directory where to store the 'typescript' packages.
-   */
-  static get storePath(): string {
-    return Environment.#storePath;
-  }
-
-  /**
-   * The number of seconds to wait before giving up stale operations.
-   */
-  static get timeout(): number {
-    return Environment.#timeout;
-  }
-
-  /**
-   * The path to the currently installed TypeScript module.
-   */
-  static get typescriptPath(): string | undefined {
-    return Environment.#typescriptPath;
+export class EnvironmentService {
+  static resolve(): EnvironmentOptions {
+    return {
+      isCi: EnvironmentService.#resolveIsCi(),
+      noColor: EnvironmentService.#resolveNoColor(),
+      noInteractive: EnvironmentService.#resolveNoInteractive(),
+      npmRegistry: EnvironmentService.#resolveNpmRegistry(),
+      storePath: EnvironmentService.#resolveStorePath(),
+      timeout: EnvironmentService.#resolveTimeout(),
+      typescriptPath: EnvironmentService.#resolveTypeScriptPath(),
+    };
   }
 
   static #resolveIsCi() {

--- a/source/config/OptionValidator.ts
+++ b/source/config/OptionValidator.ts
@@ -1,10 +1,10 @@
 import { existsSync } from "node:fs";
 import { Diagnostic, type DiagnosticOrigin } from "#diagnostic";
-import { Environment } from "#environment";
 import type { StoreService } from "#store";
 import { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
 import { OptionUsageText } from "./OptionUsageText.js";
 import type { OptionBrand, OptionGroup } from "./enums.js";
+import { environmentOptions } from "./environmentOptions.js";
 import type { DiagnosticsHandler } from "./types.js";
 
 export class OptionValidator {
@@ -61,7 +61,7 @@ export class OptionValidator {
       }
 
       case "watch": {
-        if (Environment.isCi) {
+        if (environmentOptions.isCi) {
           this.#onDiagnostics(Diagnostic.error(ConfigDiagnosticText.watchCannotBeEnabled(), origin));
         }
         break;

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -1,0 +1,10 @@
+import { Path } from "#path";
+import { environmentOptions } from "./environmentOptions.js";
+import type { ConfigFileOptions } from "./types.js";
+
+export const defaultOptions: Required<ConfigFileOptions> = {
+  failFast: false,
+  rootPath: Path.resolve("./"),
+  target: environmentOptions.typescriptPath != null ? ["current"] : ["latest"],
+  testFileMatch: ["**/*.tst.*", "**/__typetests__/*.test.*", "**/typetests/*.test.*"],
+};

--- a/source/config/environmentOptions.ts
+++ b/source/config/environmentOptions.ts
@@ -1,0 +1,3 @@
+import { EnvironmentService } from "./EnvironmentService.js";
+
+export const environmentOptions = EnvironmentService.resolve();

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -1,6 +1,7 @@
-export type { CommandLineOptions } from "./CommandLineOptionsWorker.js";
+export type { CommandLineOptions, ConfigFileOptions } from "./types.js";
 export { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
-export type { ConfigFileOptions } from "./ConfigFileOptionsWorker.js";
-export { ConfigService, type ResolvedConfig, defaultOptions } from "./ConfigService.js";
+export { ConfigService, type ResolvedConfig } from "./ConfigService.js";
 export { OptionBrand, OptionGroup } from "./enums.js";
 export { type ItemDefinition, type OptionDefinition, OptionDefinitionsMap } from "./OptionDefinitionsMap.js";
+export { defaultOptions } from "./defaultOptions.js";
+export { environmentOptions } from "./environmentOptions.js";

--- a/source/config/types.ts
+++ b/source/config/types.ts
@@ -1,3 +1,38 @@
 import type { Diagnostic } from "#diagnostic";
 
+export type { ConfigFileOptions } from "../../models/ConfigFileOptions.js";
+
+export type { CommandLineOptions } from "../../models/CommandLineOptions.js";
+
 export type DiagnosticsHandler = (diagnostics: Diagnostic | Array<Diagnostic>) => void;
+
+export interface EnvironmentOptions {
+  /**
+   * Is `true` if the process is running in a continuous integration environment.
+   */
+  isCi: boolean;
+  /**
+   * Specifies whether color should be disabled in the output.
+   */
+  noColor: boolean;
+  /**
+   * Specifies whether interactive elements should be disabled in the output.
+   */
+  noInteractive: boolean;
+  /**
+   * The base URL of the 'npm' registry to use.
+   */
+  npmRegistry: string;
+  /**
+   * The directory where to store the 'typescript' packages.
+   */
+  storePath: string;
+  /**
+   * The number of seconds to wait before giving up stale operations.
+   */
+  timeout: number;
+  /**
+   * The path to the currently installed TypeScript module.
+   */
+  typescriptPath: string | undefined;
+}

--- a/source/environment/index.ts
+++ b/source/environment/index.ts
@@ -1,1 +1,0 @@
-export { Environment } from "./Environment.js";

--- a/source/handlers/RunReporter.ts
+++ b/source/handlers/RunReporter.ts
@@ -1,5 +1,4 @@
 import type { ResolvedConfig } from "#config";
-import { Environment } from "#environment";
 import type { Event, EventHandler } from "#events";
 import { type OutputService, addsPackageText, diagnosticText, taskStatusText, usesCompilerText } from "#output";
 import { FileViewService } from "./FileViewService.js";
@@ -85,7 +84,7 @@ export class RunReporter extends Reporter implements EventHandler {
       }
 
       case "task:start": {
-        if (!Environment.noInteractive) {
+        if (!this.#resolvedConfig.noInteractive) {
           this.outputService.writeMessage(taskStatusText(payload.result.status, payload.result.task));
         }
 
@@ -102,7 +101,7 @@ export class RunReporter extends Reporter implements EventHandler {
       }
 
       case "task:end": {
-        if (!Environment.noInteractive) {
+        if (!this.#resolvedConfig.noInteractive) {
           this.outputService.eraseLastLine();
         }
 

--- a/source/output/OutputService.ts
+++ b/source/output/OutputService.ts
@@ -1,11 +1,11 @@
 import process from "node:process";
 import type { WriteStream } from "node:tty";
-import { Environment } from "#environment";
+import { environmentOptions } from "#config";
 import { Scribbler, type ScribblerJsx } from "#scribbler";
 
 export class OutputService {
   #isClear = false;
-  #noColor = Environment.noColor;
+  #noColor = environmentOptions.noColor;
   #scribbler: Scribbler;
   #stderr = process.stderr;
   #stdout = process.stdout;

--- a/source/store/StoreService.ts
+++ b/source/store/StoreService.ts
@@ -2,8 +2,8 @@ import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import vm from "node:vm";
 import type ts from "typescript";
+import { environmentOptions } from "#config";
 import { Diagnostic } from "#diagnostic";
-import { Environment } from "#environment";
 import { EventEmitter } from "#events";
 import { Path } from "#path";
 import { Version } from "#version";
@@ -21,10 +21,10 @@ export class StoreService {
   #manifest: Manifest | undefined;
   #manifestService: ManifestService;
   #packageService: PackageService;
-  #npmRegistry = Environment.npmRegistry;
-  #storePath = Environment.storePath;
+  #npmRegistry = environmentOptions.npmRegistry;
+  #storePath = environmentOptions.storePath;
   #supportedTags: Array<string> | undefined;
-  #timeout = Environment.timeout * 1000;
+  #timeout = environmentOptions.timeout * 1000;
 
   constructor() {
     this.#fetcher = new Fetcher(this.#onDiagnostics, this.#timeout);
@@ -67,8 +67,8 @@ export class StoreService {
 
     let modulePath: string | undefined;
 
-    if (tag === "current" && Environment.typescriptPath != null) {
-      modulePath = Environment.typescriptPath;
+    if (tag === "current" && environmentOptions.typescriptPath != null) {
+      modulePath = environmentOptions.typescriptPath;
     } else {
       await this.open();
 
@@ -167,7 +167,7 @@ export class StoreService {
 
   async validateTag(tag: string): Promise<boolean | undefined> {
     if (tag === "current") {
-      return Environment.typescriptPath != null;
+      return environmentOptions.typescriptPath != null;
     }
 
     await this.open();

--- a/source/tstyche.ts
+++ b/source/tstyche.ts
@@ -3,7 +3,6 @@ export * from "#cli";
 export * from "#collect";
 export * from "#config";
 export * from "#diagnostic";
-export * from "#environment";
 export * from "#events";
 export * from "#expect";
 export * from "#handlers";


### PR DESCRIPTION
Adding environment options to `ResolvedConfig`.

Note that `Environment` class is replaced with `environmentOptions`. But that will be rarely needed since the `ResolvedConfig` is passed around.