### PR TITLE
chore: use configuration from `.editorconfig`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,8 +17,7 @@
 
   "formatter": {
     "enabled": true,
-    "indentStyle": "space",
-    "lineWidth": 120
+    "useEditorconfig": true
   },
 
   "linter": {


### PR DESCRIPTION
Use configuration from `.editorconfig` to reduce duplication.