### PR TITLE
fix(path): fix relative path normalization logic

### DIFF
--- a/source/path/Path.ts
+++ b/source/path/Path.ts
@@ -20,13 +20,13 @@ export class Path {
   }
 
   static relative(from: string, to: string): string {
-    let relativePath = path.relative(from, to);
+    const relativePath = Path.normalizeSlashes(path.relative(from, to));
 
-    if (!relativePath.startsWith("./")) {
-      relativePath = `./${relativePath}`;
+    if (/^\.\.?\//.test(relativePath)) {
+      return relativePath;
     }
 
-    return Path.normalizeSlashes(relativePath);
+    return `./${relativePath}`;
   }
 
   static resolve(...filePaths: Array<string>): string {

--- a/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
@@ -20,5 +20,5 @@ Error: Expected 2 arguments, but got 1. ts(2554)
       40 |      * Marks a test as focused.
       41 |      *
 
-           at ./../../../build/index.d.ts:38:20
+           at ../../../build/index.d.ts:38:20
 


### PR DESCRIPTION
Relative paths like `../../../build/index.d.ts` shouldn't be altered.