### PR TITLE
feat: add support for TSTyche plugins

### DIFF
--- a/models/CommandLineOptions.ts
+++ b/models/CommandLineOptions.ts
@@ -29,6 +29,10 @@ export interface CommandLineOptions {
      */
     only?: string;
     /**
+     * The list of TSTyche plugins.
+     */
+    plugins?: Array<string>;
+    /**
      * Remove all installed versions of the 'typescript' package and exit.
      */
     prune?: boolean;

--- a/models/ConfigFileOptions.ts
+++ b/models/ConfigFileOptions.ts
@@ -9,6 +9,10 @@ export interface ConfigFileOptions {
      */
     failFast?: boolean;
     /**
+     * The list of TSTyche plugins.
+     */
+    plugins?: Array<string>;
+    /**
      * The path to a directory containing files of a test project.
      */
     rootPath?: string;

--- a/models/__tests__/__fixtures__/invalid-plugins-1.json
+++ b/models/__tests__/__fixtures__/invalid-plugins-1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "plugins": [true]
+}

--- a/models/__tests__/__fixtures__/invalid-plugins-2.json
+++ b/models/__tests__/__fixtures__/invalid-plugins-2.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "plugins": ["./tstyche-plugin.js", "./tstyche-plugin.js"]
+}

--- a/models/__tests__/__fixtures__/invalid-plugins-3.json
+++ b/models/__tests__/__fixtures__/invalid-plugins-3.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "plugins": "./tstyche-plugin.js"
+}

--- a/models/__tests__/__fixtures__/valid-all-options.json
+++ b/models/__tests__/__fixtures__/valid-all-options.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../config-schema.json",
   "failFast": true,
+  "plugins": ["./tstyche-plugin.js"],
   "rootPath": "../",
   "target": ["4.9", "5.0.4", "beta", "latest", "next", "rc"],
   "testFileMatch": ["examples/*.test.ts", "**/__typetests__/*.test.ts"]

--- a/models/__tests__/__fixtures__/valid-plugins.json
+++ b/models/__tests__/__fixtures__/valid-plugins.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "plugins": ["./tstyche-plugin.js"]
+}

--- a/models/__tests__/config-schema.test.js
+++ b/models/__tests__/config-schema.test.js
@@ -39,6 +39,10 @@ test("config-schema.json", async (t) => {
         testCase: "'failFast' option",
       },
       {
+        fixtureFileName: "valid-plugins.json",
+        testCase: "'plugins' option",
+      },
+      {
         fixtureFileName: "valid-rootPath.json",
         testCase: "'rootPath' option",
       },
@@ -67,6 +71,18 @@ test("config-schema.json", async (t) => {
       {
         fixtureFileName: "invalid-failFast.json",
         testCase: "value of 'failFast' option must be of type boolean",
+      },
+      {
+        fixtureFileName: "invalid-plugins-1.json",
+        testCase: "item of 'plugins' option must be of type string",
+      },
+      {
+        fixtureFileName: "invalid-plugins-2.json",
+        testCase: "items of 'plugins' option must NOT be identical",
+      },
+      {
+        fixtureFileName: "invalid-plugins-3.json",
+        testCase: "value of 'plugins' option must be of type Array",
       },
       {
         fixtureFileName: "invalid-rootPath.json",

--- a/models/__typetests__/CommandLineOptions.tst.ts
+++ b/models/__typetests__/CommandLineOptions.tst.ts
@@ -12,6 +12,7 @@ describe("CommandLineOptions", () => {
       install: true,
       listFiles: true,
       only: "external",
+      plugins: ["./tstyche-plugin.js"],
       prune: true,
       showConfig: true,
       skip: "internal",
@@ -61,6 +62,12 @@ describe("CommandLineOptions", () => {
   test("'prune' option", () => {
     expect<Pick<tstyche.CommandLineOptions, "prune">>().type.toBe<{
       prune?: boolean;
+    }>();
+  });
+
+  test("'plugins' option", () => {
+    expect<Pick<tstyche.CommandLineOptions, "plugins">>().type.toBe<{
+      plugins?: Array<string>;
     }>();
   });
 

--- a/models/__typetests__/ConfigFileOptions.tst.ts
+++ b/models/__typetests__/ConfigFileOptions.tst.ts
@@ -7,6 +7,7 @@ describe("ConfigFileOptions", () => {
   test("all options", () => {
     expect(options).type.toBeAssignableWith({
       failFast: true,
+      plugins: ["./tstyche-plugin.js"],
       rootPath: "../",
       target: ["4.9.5" as const, "5.0" as const, "latest" as const],
       testFileMatch: ["**/tests/types/**/*"],
@@ -16,6 +17,12 @@ describe("ConfigFileOptions", () => {
   test("'failFast' option", () => {
     expect<Pick<tstyche.ConfigFileOptions, "failFast">>().type.toBe<{
       failFast?: boolean;
+    }>();
+  });
+
+  test("'plugins' option", () => {
+    expect<Pick<tstyche.ConfigFileOptions, "plugins">>().type.toBe<{
+      plugins?: Array<string>;
     }>();
   });
 

--- a/models/config-schema.json
+++ b/models/config-schema.json
@@ -6,6 +6,15 @@
       "description": "Stop running tests after the first failed assertion.",
       "type": "boolean"
     },
+    "plugins": {
+      "default": [],
+      "description": "The list of TSTyche plugins.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
     "rootPath": {
       "default": "./",
       "description": "The path to a directory containing files of a test project.",

--- a/source/config/CommandLineOptionsWorker.ts
+++ b/source/config/CommandLineOptionsWorker.ts
@@ -94,10 +94,14 @@ export class CommandLineOptionsWorker {
 
       case OptionBrand.List:
         if (optionValue !== "") {
-          const optionValues = optionValue
+          let optionValues = optionValue
             .split(",")
             .map((value) => value.trim())
             .filter((value) => value !== ""); // in case if a comma was at the end of a list, e.g. "--target 5.0,current,"
+
+          if (optionDefinition.name === "plugins") {
+            optionValues = optionValues.map((optionValue) => Path.resolve(optionValue));
+          }
 
           for (const optionValue of optionValues) {
             await this.#optionValidator.check(optionDefinition.name, optionValue, optionDefinition.brand);

--- a/source/config/ConfigFileOptionsWorker.ts
+++ b/source/config/ConfigFileOptionsWorker.ts
@@ -71,7 +71,7 @@ export class ConfigFileOptionsWorker {
           break;
         }
 
-        if (optionDefinition.name === "rootPath") {
+        if (optionDefinition.name === "plugins" || optionDefinition.name === "rootPath") {
           optionValue = Path.resolve(Path.dirname(this.#sourceFile.fileName), optionValue);
         }
 

--- a/source/config/OptionDefinitionsMap.ts
+++ b/source/config/OptionDefinitionsMap.ts
@@ -77,6 +77,17 @@ export class OptionDefinitionsMap {
     },
 
     {
+      brand: OptionBrand.List,
+      description: "The list of TSTyche plugins.",
+      group: OptionGroup.CommandLine | OptionGroup.ConfigFile,
+      items: {
+        brand: OptionBrand.String,
+        name: "plugins",
+      },
+      name: "plugins",
+    },
+
+    {
       brand: OptionBrand.BareTrue,
       description: "Remove all installed versions of the 'typescript' package and exit.",
       group: OptionGroup.CommandLine,

--- a/source/config/OptionValidator.ts
+++ b/source/config/OptionValidator.ts
@@ -30,6 +30,7 @@ export class OptionValidator {
   ): Promise<void> {
     switch (optionName) {
       case "config":
+      case "plugins":
       case "rootPath":
         if (!existsSync(optionValue)) {
           this.#onDiagnostics(Diagnostic.error(ConfigDiagnosticText.fileDoesNotExist(optionValue), origin));

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -4,6 +4,7 @@ import type { ConfigFileOptions } from "./types.js";
 
 export const defaultOptions: Required<ConfigFileOptions> = {
   failFast: false,
+  plugins: [],
   rootPath: Path.resolve("./"),
   target: environmentOptions.typescriptPath != null ? ["current"] : ["latest"],
   testFileMatch: ["**/*.tst.*", "**/__typetests__/*.test.*", "**/typetests/*.test.*"],

--- a/source/plugins/PluginService.ts
+++ b/source/plugins/PluginService.ts
@@ -1,0 +1,23 @@
+import type { Hooks, Plugin } from "./types.js";
+
+export class PluginService {
+  static #plugins = new Map<string, Plugin>();
+
+  static async callHook<T extends keyof Hooks>(hook: T, options: Hooks[T]): Promise<Hooks[T]> {
+    for (const plugin of PluginService.#plugins.values()) {
+      const result = await plugin[hook]?.(options);
+
+      Object.assign(options, result);
+    }
+
+    return options;
+  }
+
+  static async register(plugins: Array<string>) {
+    for (const plugin of plugins) {
+      if (!PluginService.#plugins.has(plugin)) {
+        PluginService.#plugins.set(plugin, (await import(plugin)).default);
+      }
+    }
+  }
+}

--- a/source/plugins/index.ts
+++ b/source/plugins/index.ts
@@ -1,0 +1,2 @@
+export { PluginService } from "./PluginService.js";
+export { Plugin } from "./types.js";

--- a/source/plugins/types.ts
+++ b/source/plugins/types.ts
@@ -1,0 +1,13 @@
+import type { ResolvedConfig } from "#config";
+
+export type Hooks = {
+  config: ResolvedConfig;
+  select: Array<string | URL>;
+  // TODO also add 'runner', 'target', 'project', etc
+};
+
+export type Plugin = {
+  [K in keyof Hooks]?: (
+    options: Hooks[K],
+  ) => Hooks[K] extends Array<unknown> ? Hooks[K] | Promise<Hooks[K]> : Partial<Hooks[K]> | Promise<Partial<Hooks[K]>>;
+};

--- a/source/tstyche.ts
+++ b/source/tstyche.ts
@@ -9,6 +9,7 @@ export * from "#handlers";
 export * from "#input";
 export * from "#output";
 export * from "#path";
+export * from "#plugins";
 export * from "#project";
 export * from "#result";
 export * from "#runner";

--- a/tests/__snapshots__/config-listFiles-testFileMatch-[]-stdout.snap.txt
+++ b/tests/__snapshots__/config-listFiles-testFileMatch-[]-stdout.snap.txt
@@ -1,5 +1,0 @@
-Targets:    1 passed, 1 total
-Test files: 0 total
-Duration:   <<timestamp>>
-
-Ran all test files.

--- a/tests/__snapshots__/validation-plugins-path-does-not-exist-stderr.snap.txt
+++ b/tests/__snapshots__/validation-plugins-path-does-not-exist-stderr.snap.txt
@@ -1,0 +1,12 @@
+Error: The specified path '/Users/mrazauskas/Projects/tstyche/tests/__fixtures__/.generated/validation-plugins/not-plugin.js' does not exist.
+
+  2 |   "plugins": [
+  3 |     "./tstyche-plugin.js",
+  4 |     "./not-plugin.js"
+    |     ~~~~~~~~~~~~~~~~~
+  5 |   ],
+  6 |   "testFileMatch": [
+  7 |     "examples/*.tst.*"
+
+      at ./tstyche.config.json:4:5
+

--- a/tests/__snapshots__/validation-plugins-wrong-list-item-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-plugins-wrong-list-item-type-stderr.snap.txt
@@ -1,0 +1,12 @@
+Error: Item of the 'plugins' list must be of type string.
+
+  2 |   "plugins": [
+  3 |     "./tstyche-plugin.js",
+  4 |     true
+    |     ~~~~
+  5 |   ],
+  6 |   "testFileMatch": [
+  7 |     "examples/*.test.*"
+
+      at ./tstyche.config.json:4:5
+

--- a/tests/__snapshots__/validation-plugins-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-plugins-wrong-option-value-type-stderr.snap.txt
@@ -1,0 +1,12 @@
+Error: Option 'plugins' requires a value of type list.
+
+  1 | {
+  2 |   "plugins": "./tstyche-plugin.js",
+    |              ~~~~~~~~~~~~~~~~~~~~~
+  3 |   "testFileMatch": [
+  4 |     "examples/*.test.*"
+  5 |   ]
+  6 | }
+
+      at ./tstyche.config.json:2:14
+

--- a/tests/config-listFiles.test.js
+++ b/tests/config-listFiles.test.js
@@ -77,26 +77,4 @@ await test("'--listFiles' command line option", async (t) => {
     assert.equal(stderr, "");
     assert.equal(exitCode, 0);
   });
-
-  await t.test("when 'testFileMatch' is specified as an empty list", async () => {
-    const config = {
-      testFileMatch: [],
-    };
-
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
-      ["__typetests__/isString.tst.ts"]: isStringTestText,
-      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
-    });
-
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--listFiles"]);
-
-    await assert.matchSnapshot(normalizeOutput(stdout), {
-      fileName: `${testFileName}-testFileMatch-[]-stdout`,
-      testFileUrl: import.meta.url,
-    });
-
-    assert.equal(stderr, "");
-    assert.equal(exitCode, 0);
-  });
 });

--- a/tests/validation-plugins.test.js
+++ b/tests/validation-plugins.test.js
@@ -1,0 +1,159 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'--plugins' command line option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when option value is missing", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--plugins"]);
+
+    assert.equal(stdout, "");
+
+    const expected = [
+      "Error: Option '--plugins' expects a value.",
+      "",
+      "Option '--plugins' requires a value of type list.",
+      "",
+      "",
+    ].join("\n");
+
+    assert.equal(stderr, expected);
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when specified path does not exist", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--plugins", "./tstyche-plugin.js"]);
+
+    assert.equal(stdout, "");
+
+    const expected = [
+      "Error: The specified path '<<cwd>>/tests/__fixtures__/.generated/validation-plugins/tstyche-plugin.js' does not exist.",
+      "",
+      "",
+    ].join("\n");
+
+    assert.equal(normalizeOutput(stderr), expected);
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when one of specified paths does not exist", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche-plugin.js"]: "",
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [
+      "--plugins",
+      "./tstyche-plugin.js,./not-plugin.js",
+    ]);
+
+    assert.equal(stdout, "");
+
+    const expected = [
+      "Error: The specified path '<<cwd>>/tests/__fixtures__/.generated/validation-plugins/not-plugin.js' does not exist.",
+      "",
+      "",
+    ].join("\n");
+
+    assert.equal(normalizeOutput(stderr), expected);
+    assert.equal(exitCode, 1);
+  });
+});
+
+await test("'plugins' configuration file option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when option value is not a list", async () => {
+    const config = {
+      plugins: "./tstyche-plugin.js",
+      testFileMatch: ["examples/*.test.*"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    assert.equal(stdout, "");
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-wrong-option-value-type-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when item of the list is not a string", async () => {
+    const config = {
+      plugins: ["./tstyche-plugin.js", true],
+      testFileMatch: ["examples/*.test.*"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+      ["tstyche-plugin.js"]: "",
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    assert.equal(stdout, "");
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-wrong-list-item-type-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when specified path does not exist", async () => {
+    const config = {
+      plugins: ["./tstyche-plugin.js", "./not-plugin.js"],
+      testFileMatch: ["examples/*.tst.*"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+      ["tstyche-plugin.js"]: "",
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    assert.equal(stdout, "");
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-path-does-not-exist-stderr`,
+      testFileUrl: import.meta.url,
+    });
+    assert.equal(exitCode, 1);
+  });
+});


### PR DESCRIPTION
The plugins allow to customize behaviour of TSTyche. This PR implements `config` and `select` hooks.

## `config`

Is called after configuration is resolved and allows altering it:

```js
export default {
  config: () => {
    return { testFileMatch: [] };
  },
  // ...
};
```

## `select `

Is called after files are selected and allows altering the list of selected files:

```js
 export default {
  // ...
  select: () => {
    return ["./examples/firstItem.tst.ts"];
  },
};
```

The allows overriding test file lookup and providing own test file list instead.