### PR TITLE
refactor!: rename `on()` method of `EventHandler` interface

### DIFF
--- a/source/events/EventEmitter.ts
+++ b/source/events/EventEmitter.ts
@@ -1,7 +1,7 @@
 import type { Event } from "./types.js";
 
 export interface EventHandler {
-  handleEvent: (event: Event) => void;
+  on: (event: Event) => void;
 }
 
 export class EventEmitter {
@@ -15,7 +15,7 @@ export class EventEmitter {
 
   static dispatch(event: Event): void {
     for (const handler of EventEmitter.#handlers) {
-      handler.handleEvent(event);
+      handler.on(event);
     }
   }
 

--- a/source/handlers/CancellationHandler.ts
+++ b/source/handlers/CancellationHandler.ts
@@ -11,7 +11,7 @@ export class CancellationHandler implements EventHandler {
     this.#cancellationReason = cancellationReason;
   }
 
-  handleEvent([, payload]: Event): void {
+  on([, payload]: Event): void {
     if ("diagnostics" in payload) {
       if (payload.diagnostics.some((diagnostic) => diagnostic.category === DiagnosticCategory.Error)) {
         this.#cancellationToken.cancel(this.#cancellationReason);

--- a/source/handlers/ExitCodeHandler.ts
+++ b/source/handlers/ExitCodeHandler.ts
@@ -3,8 +3,8 @@ import { DiagnosticCategory } from "#diagnostic";
 import type { Event, EventHandler } from "#events";
 
 export class ExitCodeHandler implements EventHandler {
-  handleEvent([eventName, payload]: Event): void {
-    if (eventName === "run:start") {
+  on([event, payload]: Event): void {
+    if (event === "run:start") {
       // useful when tests are reran in watch mode
       this.resetCode();
       return;

--- a/source/handlers/Reporter.ts
+++ b/source/handlers/Reporter.ts
@@ -8,5 +8,5 @@ export abstract class Reporter implements EventHandler {
     this.outputService = outputService;
   }
 
-  abstract handleEvent([eventName, payload]: Event): void;
+  abstract on([event, payload]: Event): void;
 }

--- a/source/handlers/ResultHandler.ts
+++ b/source/handlers/ResultHandler.ts
@@ -20,8 +20,8 @@ export class ResultHandler implements EventHandler {
   #taskResult: TaskResult | undefined;
   #testResult: TestResult | undefined;
 
-  handleEvent([eventName, payload]: Event): void {
-    switch (eventName) {
+  on([event, payload]: Event): void {
+    switch (event) {
       case "run:start":
         this.#result = payload.result;
         this.#result.timing.start = Date.now();

--- a/source/handlers/RunReporter.ts
+++ b/source/handlers/RunReporter.ts
@@ -25,8 +25,8 @@ export class RunReporter extends Reporter implements EventHandler {
     return this.#fileCount === 0;
   }
 
-  handleEvent([eventName, payload]: Event): void {
-    switch (eventName) {
+  on([event, payload]: Event): void {
+    switch (event) {
       case "deprecation:info": {
         for (const diagnostic of payload.diagnostics) {
           if (!this.#seenDeprecations.has(diagnostic.text.toString())) {

--- a/source/handlers/SetupReporter.ts
+++ b/source/handlers/SetupReporter.ts
@@ -4,8 +4,8 @@ import { addsPackageText, diagnosticText } from "#output";
 import { Reporter } from "./Reporter.js";
 
 export class SetupReporter extends Reporter implements EventHandler {
-  handleEvent([eventName, payload]: Event): void {
-    if (eventName === "store:adds") {
+  on([event, payload]: Event): void {
+    if (event === "store:adds") {
       this.outputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
       return;
     }

--- a/source/handlers/SummaryReporter.ts
+++ b/source/handlers/SummaryReporter.ts
@@ -3,8 +3,8 @@ import { summaryText } from "#output";
 import { Reporter } from "./Reporter.js";
 
 export class SummaryReporter extends Reporter implements EventHandler {
-  handleEvent([eventName, payload]: Event): void {
-    if (eventName === "run:end") {
+  on([event, payload]: Event): void {
+    if (event === "run:end") {
       this.outputService.writeMessage(
         summaryText({
           duration: payload.result.timing.duration,

--- a/source/handlers/WatchReporter.ts
+++ b/source/handlers/WatchReporter.ts
@@ -3,8 +3,8 @@ import { diagnosticText, waitingForFileChangesText, watchUsageText } from "#outp
 import { Reporter } from "./Reporter.js";
 
 export class WatchReporter extends Reporter implements EventHandler {
-  handleEvent([eventName, payload]: Event): void {
-    switch (eventName) {
+  on([event, payload]: Event): void {
+    switch (event) {
       case "run:start":
         this.outputService.clearTerminal();
         break;

--- a/tests/integration-Runner.test.js
+++ b/tests/integration-Runner.test.js
@@ -26,11 +26,11 @@ class TestResultHandler {
   /**
    * @param {import("tstyche/tstyche").Event} event
    */
-  handleEvent([eventName, payload]) {
-    if (eventName === "run:start") {
+  on([event, payload]) {
+    if (event === "run:start") {
       result = undefined;
     }
-    if (eventName === "run:end") {
+    if (event === "run:end") {
       result = payload.result;
     }
   }


### PR DESCRIPTION
Renaming `on()` method of `EventHandler` interface. Less is less (;