### PR TITLE
refactor!: make the `OutputService` class not instantiable

### DIFF
--- a/source/api/TSTyche.ts
+++ b/source/api/TSTyche.ts
@@ -1,5 +1,4 @@
 import type { ResolvedConfig } from "#config";
-import type { OutputService } from "#output";
 import { Runner } from "#runner";
 import type { SelectService } from "#select";
 import type { StoreService } from "#store";
@@ -8,24 +7,17 @@ import { CancellationToken } from "#token";
 
 // biome-ignore lint/style/useNamingConvention: this is an exception
 export class TSTyche {
-  #outputService: OutputService;
   #resolvedConfig: ResolvedConfig;
   #runner: Runner;
   #selectService: SelectService;
   #storeService: StoreService;
   static version = "__version__";
 
-  constructor(
-    resolvedConfig: ResolvedConfig,
-    outputService: OutputService,
-    selectService: SelectService,
-    storeService: StoreService,
-  ) {
+  constructor(resolvedConfig: ResolvedConfig, selectService: SelectService, storeService: StoreService) {
     this.#resolvedConfig = resolvedConfig;
-    this.#outputService = outputService;
     this.#selectService = selectService;
     this.#storeService = storeService;
-    this.#runner = new Runner(this.#resolvedConfig, this.#outputService, this.#selectService, this.#storeService);
+    this.#runner = new Runner(this.#resolvedConfig, this.#selectService, this.#storeService);
   }
 
   // TODO perhaps it could be a static method that constructs runner instance? CLI should use the 'Runner' class directly.

--- a/source/output/OutputService.ts
+++ b/source/output/OutputService.ts
@@ -3,44 +3,44 @@ import type { WriteStream } from "node:tty";
 import { Scribbler, type ScribblerJsx } from "#scribbler";
 
 export class OutputService {
-  #isClear = false;
-  #scribbler = new Scribbler();
-  #stderr = process.stderr;
-  #stdout = process.stdout;
+  static #isClear = false;
+  static #scribbler = new Scribbler();
+  static #stderr = process.stderr;
+  static #stdout = process.stdout;
 
-  clearTerminal(): void {
-    if (!this.#isClear) {
+  static clearTerminal(): void {
+    if (!OutputService.#isClear) {
       // Erases all visible output, clears all lines saved in the scroll-back buffer
       // and moves the cursor to the upper left corner.
-      this.#stdout.write("\u001B[2J\u001B[3J\u001B[H");
-      this.#isClear = true;
+      OutputService.#stdout.write("\u001B[2J\u001B[3J\u001B[H");
+      OutputService.#isClear = true;
     }
   }
 
-  eraseLastLine(): void {
+  static eraseLastLine(): void {
     // Moves the cursor one line up and erases that line.
-    this.#stdout.write("\u001B[1A\u001B[0K");
+    OutputService.#stdout.write("\u001B[1A\u001B[0K");
   }
 
-  #writeTo(stream: WriteStream, element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
+  static #writeTo(stream: WriteStream, element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
     const elements = Array.isArray(element) ? element : [element];
 
     for (const element of elements) {
-      stream.write(this.#scribbler.render(element));
+      stream.write(OutputService.#scribbler.render(element));
     }
 
-    this.#isClear = false;
+    OutputService.#isClear = false;
   }
 
-  writeError(element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
-    this.#writeTo(this.#stderr, element);
+  static writeError(element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
+    OutputService.#writeTo(OutputService.#stderr, element);
   }
 
-  writeMessage(element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
-    this.#writeTo(this.#stdout, element);
+  static writeMessage(element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
+    OutputService.#writeTo(OutputService.#stdout, element);
   }
 
-  writeWarning(element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
-    this.#writeTo(this.#stderr, element);
+  static writeWarning(element: ScribblerJsx.Element | Array<ScribblerJsx.Element>): void {
+    OutputService.#writeTo(OutputService.#stderr, element);
   }
 }

--- a/source/reporters/BaseReporter.ts
+++ b/source/reporters/BaseReporter.ts
@@ -1,14 +1,11 @@
 import type { ResolvedConfig } from "#config";
-import type { OutputService } from "#output";
 import type { Reporter, ReporterEvent } from "./types.js";
 
 export abstract class BaseReporter implements Reporter {
-  protected outputService: OutputService;
   protected resolvedConfig: ResolvedConfig;
 
-  constructor(resolvedConfig: ResolvedConfig, outputService: OutputService) {
+  constructor(resolvedConfig: ResolvedConfig) {
     this.resolvedConfig = resolvedConfig;
-    this.outputService = outputService;
   }
 
   abstract on([event, payload]: ReporterEvent): void;

--- a/source/reporters/ListReporter.ts
+++ b/source/reporters/ListReporter.ts
@@ -1,4 +1,4 @@
-import { addsPackageText, diagnosticText, taskStatusText, usesCompilerText } from "#output";
+import { OutputService, addsPackageText, diagnosticText, taskStatusText, usesCompilerText } from "#output";
 import { BaseReporter } from "./BaseReporter.js";
 import { FileViewService } from "./FileViewService.js";
 import type { ReporterEvent } from "./types.js";
@@ -34,14 +34,14 @@ export class ListReporter extends BaseReporter {
         break;
 
       case "store:adds":
-        this.outputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
+        OutputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
 
         this.#hasReportedAdds = true;
         break;
 
       case "store:error":
         for (const diagnostic of payload.diagnostics) {
-          this.outputService.writeError(diagnosticText(diagnostic));
+          OutputService.writeError(diagnosticText(diagnostic));
         }
         break;
 
@@ -59,7 +59,7 @@ export class ListReporter extends BaseReporter {
           this.#currentCompilerVersion !== payload.compilerVersion ||
           this.#currentProjectConfigFilePath !== payload.projectConfigFilePath
         ) {
-          this.outputService.writeMessage(
+          OutputService.writeMessage(
             usesCompilerText(payload.compilerVersion, payload.projectConfigFilePath, {
               prependEmptyLine:
                 this.#currentCompilerVersion != null && !this.#hasReportedAdds && !this.#hasReportedError,
@@ -75,13 +75,13 @@ export class ListReporter extends BaseReporter {
 
       case "project:error":
         for (const diagnostic of payload.diagnostics) {
-          this.outputService.writeError(diagnosticText(diagnostic));
+          OutputService.writeError(diagnosticText(diagnostic));
         }
         break;
 
       case "task:start":
         if (!this.resolvedConfig.noInteractive) {
-          this.outputService.writeMessage(taskStatusText(payload.result.status, payload.result.task));
+          OutputService.writeMessage(taskStatusText(payload.result.status, payload.result.task));
         }
 
         this.#fileCount--;
@@ -96,15 +96,15 @@ export class ListReporter extends BaseReporter {
 
       case "task:end":
         if (!this.resolvedConfig.noInteractive) {
-          this.outputService.eraseLastLine();
+          OutputService.eraseLastLine();
         }
 
-        this.outputService.writeMessage(taskStatusText(payload.result.status, payload.result.task));
+        OutputService.writeMessage(taskStatusText(payload.result.status, payload.result.task));
 
-        this.outputService.writeMessage(this.#fileView.getViewText({ appendEmptyLine: this.#isLastFile }));
+        OutputService.writeMessage(this.#fileView.getViewText({ appendEmptyLine: this.#isLastFile }));
 
         if (this.#fileView.hasErrors) {
-          this.outputService.writeError(this.#fileView.getMessages());
+          OutputService.writeError(this.#fileView.getMessages());
           this.#hasReportedError = true;
         }
 

--- a/source/reporters/SetupReporter.ts
+++ b/source/reporters/SetupReporter.ts
@@ -1,17 +1,11 @@
 import { DiagnosticCategory } from "#diagnostic";
-import { type OutputService, addsPackageText, diagnosticText } from "#output";
+import { OutputService, addsPackageText, diagnosticText } from "#output";
 import type { ReporterEvent } from "./types.js";
 
 export class SetupReporter {
-  protected outputService: OutputService;
-
-  constructor(outputService: OutputService) {
-    this.outputService = outputService;
-  }
-
   on([event, payload]: ReporterEvent): void {
     if (event === "store:adds") {
-      this.outputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
+      OutputService.writeMessage(addsPackageText(payload.packageVersion, payload.packagePath));
       return;
     }
 
@@ -19,11 +13,11 @@ export class SetupReporter {
       for (const diagnostic of payload.diagnostics) {
         switch (diagnostic.category) {
           case DiagnosticCategory.Error:
-            this.outputService.writeError(diagnosticText(diagnostic));
+            OutputService.writeError(diagnosticText(diagnostic));
             break;
 
           case DiagnosticCategory.Warning:
-            this.outputService.writeWarning(diagnosticText(diagnostic));
+            OutputService.writeWarning(diagnosticText(diagnostic));
             break;
         }
       }

--- a/source/reporters/SummaryReporter.ts
+++ b/source/reporters/SummaryReporter.ts
@@ -1,4 +1,4 @@
-import { summaryText } from "#output";
+import { OutputService, summaryText } from "#output";
 import { BaseReporter } from "./BaseReporter.js";
 import type { ReporterEvent } from "./types.js";
 
@@ -9,7 +9,7 @@ export class SummaryReporter extends BaseReporter {
     }
 
     if (event === "run:end") {
-      this.outputService.writeMessage(
+      OutputService.writeMessage(
         summaryText({
           duration: payload.result.timing.duration,
           expectCount: payload.result.expectCount,

--- a/source/reporters/WatchReporter.ts
+++ b/source/reporters/WatchReporter.ts
@@ -1,4 +1,4 @@
-import { diagnosticText, waitingForFileChangesText, watchUsageText } from "#output";
+import { OutputService, diagnosticText, waitingForFileChangesText, watchUsageText } from "#output";
 import { BaseReporter } from "./BaseReporter.js";
 import type { ReporterEvent } from "./types.js";
 
@@ -6,21 +6,21 @@ export class WatchReporter extends BaseReporter {
   on([event, payload]: ReporterEvent): void {
     switch (event) {
       case "run:start":
-        this.outputService.clearTerminal();
+        OutputService.clearTerminal();
         break;
 
       case "run:end":
-        this.outputService.writeMessage(watchUsageText());
+        OutputService.writeMessage(watchUsageText());
         break;
 
       case "watch:error":
-        this.outputService.clearTerminal();
+        OutputService.clearTerminal();
 
         for (const diagnostic of payload.diagnostics) {
-          this.outputService.writeError(diagnosticText(diagnostic));
+          OutputService.writeError(diagnosticText(diagnostic));
         }
 
-        this.outputService.writeMessage(waitingForFileChangesText());
+        OutputService.writeMessage(waitingForFileChangesText());
         break;
     }
   }

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -1,7 +1,6 @@
 import type { ResolvedConfig } from "#config";
 import { EventEmitter } from "#events";
 import { CancellationHandler, ResultHandler } from "#handlers";
-import type { OutputService } from "#output";
 import { ListReporter, type Reporter, SummaryReporter, WatchReporter } from "#reporters";
 import { Result, TargetResult } from "#result";
 import type { SelectService } from "#select";
@@ -11,22 +10,15 @@ import { CancellationReason, CancellationToken } from "#token";
 import { WatchService } from "#watch";
 import { TaskRunner } from "./TaskRunner.js";
 
-type ReporterConstructor = new (resolvedConfig: ResolvedConfig, outputService: OutputService) => Reporter;
+type ReporterConstructor = new (resolvedConfig: ResolvedConfig) => Reporter;
 
 export class Runner {
   #eventEmitter = new EventEmitter();
-  #outputService: OutputService;
   #resolvedConfig: ResolvedConfig;
   #selectService: SelectService;
   #storeService: StoreService;
 
-  constructor(
-    resolvedConfig: ResolvedConfig,
-    outputService: OutputService,
-    selectService: SelectService,
-    storeService: StoreService,
-  ) {
-    this.#outputService = outputService;
+  constructor(resolvedConfig: ResolvedConfig, selectService: SelectService, storeService: StoreService) {
     this.#resolvedConfig = resolvedConfig;
     this.#selectService = selectService;
     this.#storeService = storeService;
@@ -36,27 +28,27 @@ export class Runner {
     for (const reporter of this.#resolvedConfig.reporters) {
       switch (reporter) {
         case "list": {
-          const listReporter = new ListReporter(this.#resolvedConfig, this.#outputService);
+          const listReporter = new ListReporter(this.#resolvedConfig);
           this.#eventEmitter.addReporter(listReporter);
           break;
         }
 
         case "summary": {
-          const summaryReporter = new SummaryReporter(this.#resolvedConfig, this.#outputService);
+          const summaryReporter = new SummaryReporter(this.#resolvedConfig);
           this.#eventEmitter.addReporter(summaryReporter);
           break;
         }
 
         default: {
           const CustomReporter: ReporterConstructor = (await import(reporter)).default;
-          const customReporter = new CustomReporter(this.#resolvedConfig, this.#outputService);
+          const customReporter = new CustomReporter(this.#resolvedConfig);
           this.#eventEmitter.addReporter(customReporter);
         }
       }
     }
 
     if (this.#resolvedConfig.watch === true) {
-      const watchReporter = new WatchReporter(this.#resolvedConfig, this.#outputService);
+      const watchReporter = new WatchReporter(this.#resolvedConfig);
       this.#eventEmitter.addReporter(watchReporter);
     }
   }

--- a/tests/integration-Runner.test.js
+++ b/tests/integration-Runner.test.js
@@ -12,7 +12,6 @@ const fixtureUrl = getFixtureFileUrl(testFileName);
 const configService = new tstyche.ConfigService();
 const resolvedConfig = { ...configService.resolveConfig(), reporters: [] };
 
-const outputService = new tstyche.OutputService();
 const selectService = new tstyche.SelectService(resolvedConfig);
 const storeService = new tstyche.StoreService();
 
@@ -39,7 +38,7 @@ class TestResultReporter {
 
 await test("tstyche.Runner", async (t) => {
   await t.test("tasks", async (t) => {
-    const runner = new tstyche.Runner(resolvedConfig, outputService, selectService, storeService);
+    const runner = new tstyche.Runner(resolvedConfig, selectService, storeService);
 
     eventEmitter.addReporter(new TestResultReporter());
 
@@ -140,7 +139,7 @@ await test("tstyche.Runner", async (t) => {
     });
 
     await t.test("when 'failFast: true' is specified", async () => {
-      runner = new tstyche.Runner({ ...resolvedConfig, failFast: true }, outputService, selectService, storeService);
+      runner = new tstyche.Runner({ ...resolvedConfig, failFast: true }, selectService, storeService);
       const task = new tstyche.Task(new URL("./__typetests__/toBeNumber.tst.ts", fixtureUrl));
 
       await runner.run([task]);


### PR DESCRIPTION
Making the `OutputService` class not instantiable. This simplifies programmatic usage. 