### PR TITLE
refactor!: make the `Config` class not instantiable

### DIFF
--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -49,9 +49,7 @@ export class Cli {
       return;
     }
 
-    const configService = new ConfigService();
-
-    await configService.parseCommandLine(commandLine);
+    const { commandLineOptions, pathMatch } = await ConfigService.parseCommandLine(commandLine);
 
     if (cancellationToken.isCancellationRequested) {
       return;
@@ -68,9 +66,14 @@ export class Cli {
         this.#eventEmitter.addReporter(setupReporter);
       }
 
-      await configService.readConfigFile();
+      const { configFileOptions, configFilePath } = await ConfigService.parseConfigFile(commandLineOptions.config);
 
-      let resolvedConfig = configService.resolveConfig();
+      let resolvedConfig = ConfigService.resolveConfig({
+        configFileOptions,
+        configFilePath,
+        commandLineOptions,
+        pathMatch,
+      });
 
       if (cancellationToken.isCancellationRequested) {
         if (commandLine.includes("--watch")) {

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -1,4 +1,4 @@
-import { ConfigService, OptionDefinitionsMap, OptionGroup, type ResolvedConfig } from "#config";
+import { Config, OptionDefinitionsMap, OptionGroup, type ResolvedConfig } from "#config";
 import { EventEmitter } from "#events";
 import { CancellationHandler, ExitCodeHandler } from "#handlers";
 import { type Hooks, HooksService } from "#hooks";
@@ -49,7 +49,7 @@ export class Cli {
       return;
     }
 
-    const { commandLineOptions, pathMatch } = await ConfigService.parseCommandLine(commandLine);
+    const { commandLineOptions, pathMatch } = await Config.parseCommandLine(commandLine);
 
     if (cancellationToken.isCancellationRequested) {
       return;
@@ -66,9 +66,9 @@ export class Cli {
         this.#eventEmitter.addReporter(setupReporter);
       }
 
-      const { configFileOptions, configFilePath } = await ConfigService.parseConfigFile(commandLineOptions.config);
+      const { configFileOptions, configFilePath } = await Config.parseConfigFile(commandLineOptions.config);
 
-      let resolvedConfig = ConfigService.resolveConfig({
+      let resolvedConfig = Config.resolve({
         configFileOptions,
         configFilePath,
         commandLineOptions,

--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -68,8 +68,6 @@ export class Config {
       );
 
       await configFileParser.parse();
-      await configFileParser.parse();
-      await configFileParser.parse();
     }
 
     return { configFileOptions, configFilePath };

--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -23,7 +23,7 @@ export interface ResolvedConfig
   pathMatch: Array<string>;
 }
 
-export class ConfigService {
+export class Config {
   static #onDiagnostics(this: void, diagnostics: Diagnostic) {
     EventEmitter.dispatch(["config:error", { diagnostics: [diagnostics] }]);
   }
@@ -37,7 +37,7 @@ export class ConfigService {
     const commandLineParser = new CommandLineParser(
       commandLineOptions as Record<string, OptionValue>,
       pathMatch,
-      ConfigService.#onDiagnostics,
+      Config.#onDiagnostics,
     );
 
     await commandLineParser.parse(commandLine);
@@ -48,7 +48,7 @@ export class ConfigService {
   static async parseConfigFile(
     filePath?: string,
   ): Promise<{ configFileOptions: ConfigFileOptions; configFilePath: string }> {
-    const configFilePath = ConfigService.resolveConfigFilePath(filePath);
+    const configFilePath = Config.resolveConfigFilePath(filePath);
 
     const configFileOptions: ConfigFileOptions = {
       rootPath: Path.dirname(configFilePath),
@@ -64,7 +64,7 @@ export class ConfigService {
       const configFileParser = new ConfigFileParser(
         configFileOptions as Record<string, OptionValue>,
         sourceFile,
-        ConfigService.#onDiagnostics,
+        Config.#onDiagnostics,
       );
 
       await configFileParser.parse();
@@ -75,7 +75,7 @@ export class ConfigService {
     return { configFileOptions, configFilePath };
   }
 
-  static resolveConfig(options?: {
+  static resolve(options?: {
     configFileOptions?: ConfigFileOptions;
     configFilePath?: string;
     commandLineOptions?: CommandLineOptions;
@@ -85,7 +85,7 @@ export class ConfigService {
     delete options?.commandLineOptions?.config;
 
     return {
-      configFilePath: options?.configFilePath ?? ConfigService.resolveConfigFilePath(),
+      configFilePath: options?.configFilePath ?? Config.resolveConfigFilePath(),
       pathMatch: options?.pathMatch ?? [],
       ...defaultOptions,
       ...environmentOptions,

--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -11,7 +11,7 @@ import type { CommandLineOptions, ConfigFileOptions, OptionValue } from "./types
 
 export interface ResolvedConfig
   extends EnvironmentOptions,
-    Omit<CommandLineOptions, keyof ConfigFileOptions | "config">,
+    Omit<CommandLineOptions, "config" | keyof ConfigFileOptions>,
     Required<ConfigFileOptions> {
   /**
    * The path to a TSTyche configuration file.
@@ -76,13 +76,10 @@ export class Config {
   static resolve(options?: {
     configFileOptions?: ConfigFileOptions;
     configFilePath?: string;
-    commandLineOptions?: CommandLineOptions;
+    commandLineOptions?: Omit<CommandLineOptions, "config">;
     pathMatch?: Array<string>;
   }): ResolvedConfig {
-    // biome-ignore lint/performance/noDelete: that's fine
-    delete options?.commandLineOptions?.config;
-
-    return {
+    const resolvedConfig = {
       configFilePath: Config.resolveConfigFilePath(options?.configFilePath),
       pathMatch: options?.pathMatch ?? [],
       ...defaultOptions,
@@ -90,6 +87,13 @@ export class Config {
       ...options?.configFileOptions,
       ...options?.commandLineOptions,
     };
+
+    if ("config" in resolvedConfig) {
+      // biome-ignore lint/performance/noDelete: must clean up
+      delete resolvedConfig.config;
+    }
+
+    return resolvedConfig;
   }
 
   static resolveConfigFilePath(filePath?: string) {

--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -83,7 +83,7 @@ export class Config {
     delete options?.commandLineOptions?.config;
 
     return {
-      configFilePath: options?.configFilePath ?? Config.resolveConfigFilePath(),
+      configFilePath: Config.resolveConfigFilePath(options?.configFilePath),
       pathMatch: options?.pathMatch ?? [],
       ...defaultOptions,
       ...environmentOptions,

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -1,5 +1,5 @@
 export { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
-export { ConfigService, type ResolvedConfig } from "./ConfigService.js";
+export { Config, type ResolvedConfig } from "./Config.js";
 export { OptionBrand } from "./OptionBrand.enum.js";
 export { type ItemDefinition, type OptionDefinition, OptionDefinitionsMap } from "./OptionDefinitionsMap.js";
 export { OptionGroup } from "./OptionGroup.enum.js";

--- a/tests/integration-Runner.test.js
+++ b/tests/integration-Runner.test.js
@@ -57,7 +57,7 @@ await test("Runner", async (t) => {
 
   for (const { testCase, testFiles } of testCases) {
     await t.test(testCase, async () => {
-      const resolvedConfig = tstyche.ConfigService.resolveConfig({ configFileOptions: { reporters: [] } });
+      const resolvedConfig = tstyche.Config.resolve({ configFileOptions: { reporters: [] } });
       const runner = new tstyche.Runner(resolvedConfig);
 
       eventEmitter.addReporter(new TestResultReporter());
@@ -73,7 +73,7 @@ await test("Runner", async (t) => {
   }
 
   await t.test("when test file is a 'Task' object", async (t) => {
-    const resolvedConfig = tstyche.ConfigService.resolveConfig({ configFileOptions: { reporters: [] } });
+    const resolvedConfig = tstyche.Config.resolve({ configFileOptions: { reporters: [] } });
     const runner = new tstyche.Runner(resolvedConfig);
 
     eventEmitter.addReporter(new TestResultReporter());
@@ -170,7 +170,7 @@ await test("Runner", async (t) => {
     });
 
     await t.test("when 'failFast: true' is specified", async () => {
-      const resolvedConfig = tstyche.ConfigService.resolveConfig({
+      const resolvedConfig = tstyche.Config.resolve({
         configFileOptions: { reporters: [], failFast: true },
       });
       const runner = new tstyche.Runner(resolvedConfig);

--- a/tests/integration-Runner.test.js
+++ b/tests/integration-Runner.test.js
@@ -9,8 +9,7 @@ const isWindows = process.platform === "win32";
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
-const configService = new tstyche.ConfigService();
-const resolvedConfig = { ...configService.resolveConfig(), reporters: [] };
+const resolvedConfig = tstyche.ConfigService.resolveConfig({ configFileOptions: { reporters: [] } });
 
 const eventEmitter = new tstyche.EventEmitter();
 

--- a/tests/integration-Runner.test.js
+++ b/tests/integration-Runner.test.js
@@ -9,8 +9,6 @@ const isWindows = process.platform === "win32";
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
-const resolvedConfig = tstyche.ConfigService.resolveConfig({ configFileOptions: { reporters: [] } });
-
 const eventEmitter = new tstyche.EventEmitter();
 
 /**
@@ -59,6 +57,7 @@ await test("Runner", async (t) => {
 
   for (const { testCase, testFiles } of testCases) {
     await t.test(testCase, async () => {
+      const resolvedConfig = tstyche.ConfigService.resolveConfig({ configFileOptions: { reporters: [] } });
       const runner = new tstyche.Runner(resolvedConfig);
 
       eventEmitter.addReporter(new TestResultReporter());
@@ -74,6 +73,7 @@ await test("Runner", async (t) => {
   }
 
   await t.test("when test file is a 'Task' object", async (t) => {
+    const resolvedConfig = tstyche.ConfigService.resolveConfig({ configFileOptions: { reporters: [] } });
     const runner = new tstyche.Runner(resolvedConfig);
 
     eventEmitter.addReporter(new TestResultReporter());
@@ -161,11 +161,6 @@ await test("Runner", async (t) => {
   });
 
   await t.test("configuration options", async (t) => {
-    /**
-     * @type {import("tstyche/tstyche").Runner | undefined}
-     */
-    let runner;
-
     t.beforeEach(() => {
       eventEmitter.addReporter(new TestResultReporter());
     });
@@ -175,7 +170,10 @@ await test("Runner", async (t) => {
     });
 
     await t.test("when 'failFast: true' is specified", async () => {
-      runner = new tstyche.Runner({ ...resolvedConfig, failFast: true });
+      const resolvedConfig = tstyche.ConfigService.resolveConfig({
+        configFileOptions: { reporters: [], failFast: true },
+      });
+      const runner = new tstyche.Runner(resolvedConfig);
 
       const testFiles = [
         new URL("./__typetests__/toBeNumber.tst.ts", fixtureUrl),


### PR DESCRIPTION
This PR reshapes all public methods of the `Config` class and makes it not instantiable. One more change to simplify programmatic usage.