### PR TITLE
refactor!: rename the `Options` class

### DIFF
--- a/scripts/generate-schema.js
+++ b/scripts/generate-schema.js
@@ -75,9 +75,9 @@ function createJsonSchemaDefinition(optionDefinition, defaultValue) {
   return jsonSchemaDefinition;
 }
 
-const configFileOptionDefinitions = tstyche.OptionDefinitionsMap.for(tstyche.OptionGroup.ConfigFile);
+const configFileOptions = tstyche.Options.for(tstyche.OptionGroup.ConfigFile);
 
-for (const [key, optionDefinition] of configFileOptionDefinitions) {
+for (const [key, optionDefinition] of configFileOptions) {
   if (key.startsWith("$")) {
     continue;
   }

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -3,13 +3,13 @@ import process from "node:process";
 import * as tstyche from "tstyche/tstyche";
 import ts from "typescript";
 
-const commandLineOptionDefinitions = tstyche.OptionDefinitionsMap.for(tstyche.OptionGroup.CommandLine);
-const configFileOptionDefinitions = tstyche.OptionDefinitionsMap.for(tstyche.OptionGroup.ConfigFile);
+const commandLineOptions = tstyche.Options.for(tstyche.OptionGroup.CommandLine);
+const configFileOptions = tstyche.Options.for(tstyche.OptionGroup.ConfigFile);
 
 /** @type {Array<[string, string, Map<string, tstyche.OptionDefinition>]>} */
 const filesToGenerate = [
-  ["ConfigFileOptions", "Options loaded from the configuration file.", configFileOptionDefinitions],
-  ["CommandLineOptions", "Options passed through the command line.", commandLineOptionDefinitions],
+  ["ConfigFileOptions", "Options loaded from the configuration file.", configFileOptions],
+  ["CommandLineOptions", "Options passed through the command line.", commandLineOptions],
 ];
 
 /**

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -1,4 +1,4 @@
-import { Config, OptionDefinitionsMap, OptionGroup, type ResolvedConfig } from "#config";
+import { Config, OptionGroup, Options, type ResolvedConfig } from "#config";
 import { EventEmitter } from "#events";
 import { CancellationHandler, ExitCodeHandler } from "#handlers";
 import { type Hooks, HooksService } from "#hooks";
@@ -24,9 +24,9 @@ export class Cli {
     this.#eventEmitter.addReporter(setupReporter);
 
     if (commandLine.includes("--help")) {
-      const commandLineOptionDefinitions = OptionDefinitionsMap.for(OptionGroup.CommandLine);
+      const options = Options.for(OptionGroup.CommandLine);
 
-      OutputService.writeMessage(helpText(commandLineOptionDefinitions, Runner.version));
+      OutputService.writeMessage(helpText(options, Runner.version));
 
       return;
     }

--- a/source/config/CommandLineParser.ts
+++ b/source/config/CommandLineParser.ts
@@ -3,16 +3,16 @@ import { Diagnostic, type DiagnosticsHandler } from "#diagnostic";
 import { Path } from "#path";
 import { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
 import { OptionBrand } from "./OptionBrand.enum.js";
-import { type OptionDefinition, OptionDefinitionsMap } from "./OptionDefinitionsMap.js";
 import { OptionGroup } from "./OptionGroup.enum.js";
 import { OptionUsageText } from "./OptionUsageText.js";
 import { OptionValidator } from "./OptionValidator.js";
+import { type OptionDefinition, Options } from "./Options.js";
 import type { OptionValue } from "./types.js";
 
 export class CommandLineParser {
-  #commandLineOptionDefinitions: Map<string, OptionDefinition>;
   #commandLineOptions: Record<string, OptionValue>;
   #onDiagnostics: DiagnosticsHandler;
+  #options: Map<string, OptionDefinition>;
   #optionGroup = OptionGroup.CommandLine;
   #optionUsageText: OptionUsageText;
   #optionValidator: OptionValidator;
@@ -23,10 +23,9 @@ export class CommandLineParser {
     this.#pathMatch = pathMatch;
     this.#onDiagnostics = onDiagnostics;
 
-    this.#commandLineOptionDefinitions = OptionDefinitionsMap.for(this.#optionGroup);
+    this.#options = Options.for(this.#optionGroup);
 
     this.#optionUsageText = new OptionUsageText(this.#optionGroup);
-
     this.#optionValidator = new OptionValidator(this.#optionGroup, this.#onDiagnostics);
   }
 
@@ -48,7 +47,7 @@ export class CommandLineParser {
 
       if (arg.startsWith("--")) {
         const optionName = arg.slice(2);
-        const optionDefinition = this.#commandLineOptionDefinitions.get(optionName);
+        const optionDefinition = this.#options.get(optionName);
 
         if (optionDefinition) {
           index = await this.#parseOptionValue(commandLineArgs, index, optionDefinition);

--- a/source/config/ConfigFileParser.ts
+++ b/source/config/ConfigFileParser.ts
@@ -5,16 +5,16 @@ import { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
 import type { JsonNode } from "./JsonNode.js";
 import { JsonScanner } from "./JsonScanner.js";
 import { OptionBrand } from "./OptionBrand.enum.js";
-import { type ItemDefinition, type OptionDefinition, OptionDefinitionsMap } from "./OptionDefinitionsMap.js";
 import { OptionGroup } from "./OptionGroup.enum.js";
 import { OptionValidator } from "./OptionValidator.js";
+import { type ItemDefinition, type OptionDefinition, Options } from "./Options.js";
 import type { OptionValue } from "./types.js";
 
 export class ConfigFileParser {
-  #configFileOptionDefinitions: Map<string, OptionDefinition>;
   #configFileOptions: Record<string, OptionValue>;
   #jsonScanner: JsonScanner;
   #onDiagnostics: DiagnosticsHandler;
+  #options: Map<string, OptionDefinition>;
   #optionGroup = OptionGroup.ConfigFile;
   #optionValidator: OptionValidator;
   #sourceFile: SourceFile;
@@ -28,7 +28,7 @@ export class ConfigFileParser {
     this.#sourceFile = sourceFile;
     this.#onDiagnostics = onDiagnostics;
 
-    this.#configFileOptionDefinitions = OptionDefinitionsMap.for(this.#optionGroup);
+    this.#options = Options.for(this.#optionGroup);
 
     this.#jsonScanner = new JsonScanner(this.#sourceFile);
     this.#optionValidator = new OptionValidator(this.#optionGroup, this.#onDiagnostics);
@@ -167,7 +167,7 @@ export class ConfigFileParser {
         return;
       }
 
-      const optionDefinition = this.#configFileOptionDefinitions.get(optionName);
+      const optionDefinition = this.#options.get(optionName);
 
       if (!optionDefinition) {
         const text = ConfigDiagnosticText.unknownOption(optionName);

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -25,7 +25,7 @@ interface ListTypeOptionDefinition extends BaseOptionDefinition {
   items: ItemDefinition;
 }
 
-export class OptionDefinitionsMap {
+export class Options {
   static #definitions: Array<OptionDefinition> = [
     {
       brand: OptionBrand.String,
@@ -174,7 +174,7 @@ export class OptionDefinitionsMap {
   static for(optionGroup: OptionGroup): Map<string, OptionDefinition> {
     const definitionMap = new Map<string, OptionDefinition>();
 
-    for (const definition of OptionDefinitionsMap.#definitions) {
+    for (const definition of Options.#definitions) {
       if (definition.group & optionGroup) {
         definitionMap.set(definition.name, definition);
       }

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -1,7 +1,7 @@
 export { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
 export { Config, type ResolvedConfig } from "./Config.js";
 export { OptionBrand } from "./OptionBrand.enum.js";
-export { type ItemDefinition, type OptionDefinition, OptionDefinitionsMap } from "./OptionDefinitionsMap.js";
+export { type ItemDefinition, type OptionDefinition, Options } from "./Options.js";
 export { OptionGroup } from "./OptionGroup.enum.js";
 export { defaultOptions } from "./defaultOptions.js";
 export type { CommandLineOptions, ConfigFileOptions } from "./types.js";

--- a/source/output/helpText.tsx
+++ b/source/output/helpText.tsx
@@ -120,17 +120,14 @@ function HelpFooterText() {
   return <Line>{"To learn more, visit https://tstyche.org"}</Line>;
 }
 
-export function helpText(
-  optionDefinitions: Map<string, OptionDefinition>,
-  tstycheVersion: string,
-): ScribblerJsx.Element {
+export function helpText(options: Map<string, OptionDefinition>, version: string): ScribblerJsx.Element {
   return (
     <Text>
-      <HelpHeaderText tstycheVersion={tstycheVersion} />
+      <HelpHeaderText tstycheVersion={version} />
       <Line />
       <CommandLineUsageText />
       <Line />
-      <CommandLineOptionsText optionDefinitions={optionDefinitions} />
+      <CommandLineOptionsText optionDefinitions={options} />
       <Line />
       <HelpFooterText />
       <Line />


### PR DESCRIPTION
Renaming the `Options` class. Its previous name was rather verbose.