### PR TITLE
refactor: remove environment options to `ResolvedConfig`

### DIFF
--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -1,4 +1,5 @@
 import { Config, OptionGroup, Options, type ResolvedConfig } from "#config";
+import { environmentOptions } from "#environment";
 import { EventEmitter } from "#events";
 import { CancellationHandler, ExitCodeHandler } from "#handlers";
 import { type Hooks, HooksService } from "#hooks";
@@ -90,7 +91,7 @@ export class Cli {
       resolvedConfig = await HooksService.call("config", resolvedConfig);
 
       if (commandLine.includes("--showConfig")) {
-        OutputService.writeMessage(formattedText({ ...resolvedConfig }));
+        OutputService.writeMessage(formattedText({ ...resolvedConfig, ...environmentOptions }));
         continue;
       }
 

--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { type Diagnostic, SourceFile } from "#diagnostic";
-import { type EnvironmentOptions, environmentOptions } from "#environment";
 import { EventEmitter } from "#events";
 import { Path } from "#path";
 import { CommandLineParser } from "./CommandLineParser.js";
@@ -10,8 +9,7 @@ import { defaultOptions } from "./defaultOptions.js";
 import type { CommandLineOptions, ConfigFileOptions, OptionValue } from "./types.js";
 
 export interface ResolvedConfig
-  extends EnvironmentOptions,
-    Omit<CommandLineOptions, "config" | keyof ConfigFileOptions>,
+  extends Omit<CommandLineOptions, "config" | keyof ConfigFileOptions>,
     Required<ConfigFileOptions> {
   /**
    * The path to a TSTyche configuration file.
@@ -83,7 +81,6 @@ export class Config {
       configFilePath: Config.resolveConfigFilePath(options?.configFilePath),
       pathMatch: options?.pathMatch ?? [],
       ...defaultOptions,
-      ...environmentOptions,
       ...options?.configFileOptions,
       ...options?.commandLineOptions,
     };

--- a/source/reporters/ListReporter.ts
+++ b/source/reporters/ListReporter.ts
@@ -1,3 +1,4 @@
+import { environmentOptions } from "#environment";
 import { OutputService, addsPackageText, diagnosticText, taskStatusText, usesCompilerText } from "#output";
 import { BaseReporter } from "./BaseReporter.js";
 import { FileView } from "./FileView.js";
@@ -80,7 +81,7 @@ export class ListReporter extends BaseReporter {
         break;
 
       case "task:start":
-        if (!this.resolvedConfig.noInteractive) {
+        if (!environmentOptions.noInteractive) {
           OutputService.writeMessage(taskStatusText(payload.result.status, payload.result.task));
         }
 
@@ -95,7 +96,7 @@ export class ListReporter extends BaseReporter {
         break;
 
       case "task:end":
-        if (!this.resolvedConfig.noInteractive) {
+        if (!environmentOptions.noInteractive) {
           OutputService.eraseLastLine();
         }
 


### PR DESCRIPTION
Reverts #299.

Since the `ResolvedConfig` can be modified using plugins, it should not include any environment options. Because modifying those will have no effect. The environment variables should be the source of truth. 