### PR TITLE
fix(hooks): require to return full object

### DIFF
--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -115,7 +115,7 @@ export class Cli {
         }
       }
 
-      testFiles = await HooksService.call("select", testFiles);
+      testFiles = await HooksService.call("select", testFiles as Array<string>);
 
       if (commandLine.includes("--listFiles")) {
         OutputService.writeMessage(formattedText(testFiles.map((testFile) => testFile.toString())));

--- a/source/hooks/types.ts
+++ b/source/hooks/types.ts
@@ -4,9 +4,9 @@ export interface Hooks {
   /**
    * Is called after configuration is resolved and allows to modify it.
    */
-  config?: (resolvedConfig: ResolvedConfig) => ResolvedConfig | Promise<ResolvedConfig>;
+  config?: (resolvedConfig: ResolvedConfig) => ResolvedConfig | Promise<ResolvedConfig> | null | undefined;
   /**
    * Is called after test files are selected and allows to modify the list.
    */
-  select?: (testFiles: Array<string>) => Array<string | URL> | Promise<Array<string | URL>>;
+  select?: (testFiles: Array<string>) => Array<string | URL> | Promise<Array<string | URL>> | null | undefined;
 }

--- a/source/hooks/types.ts
+++ b/source/hooks/types.ts
@@ -1,15 +1,12 @@
 import type { ResolvedConfig } from "#config";
 
-export type CustomizationHooks = {
-  config: ResolvedConfig;
-  select: Array<string | URL>;
-  // TODO also add 'runner', 'target', 'project', etc
-};
-
-export type Hooks = {
-  [K in keyof CustomizationHooks]?: (
-    options: CustomizationHooks[K],
-  ) => CustomizationHooks[K] extends Array<unknown>
-    ? CustomizationHooks[K] | Promise<CustomizationHooks[K]>
-    : Partial<CustomizationHooks[K]> | Promise<Partial<CustomizationHooks[K]>>;
-};
+export interface Hooks {
+  /**
+   * Is called after configuration is resolved and allows to modify it.
+   */
+  config?: (resolvedConfig: ResolvedConfig) => ResolvedConfig | Promise<ResolvedConfig>;
+  /**
+   * Is called after test files are selected and allows to modify the list.
+   */
+  select?: (testFiles: Array<string>) => Array<string | URL> | Promise<Array<string | URL>>;
+}

--- a/tests/__fixtures__/hooks-config/config-plugin-1.js
+++ b/tests/__fixtures__/hooks-config/config-plugin-1.js
@@ -1,8 +1,8 @@
 /**
- * @type {import("tstyche/tstyche").Plugin}
+ * @type {import("tstyche/tstyche").Hooks}
  */
 export default {
-  config: (options) => {
-    return { ...options, failFast: true };
+  config: (resolvedConfig) => {
+    return { ...resolvedConfig, failFast: true };
   },
 };

--- a/tests/__fixtures__/hooks-config/config-plugin-2.js
+++ b/tests/__fixtures__/hooks-config/config-plugin-2.js
@@ -1,9 +1,9 @@
 /**
- * @type {import("tstyche/tstyche").Plugin}
+ * @type {import("tstyche/tstyche").Hooks}
  */
 export default {
-  config: () => {
-    return { testFileMatch: [] };
+  config: (resolvedConfig) => {
+    return { ...resolvedConfig, testFileMatch: [] };
   },
   select: () => {
     return ["./examples/firstItem.tst.ts"];

--- a/tests/__fixtures__/hooks-config/config-plugin-3.js
+++ b/tests/__fixtures__/hooks-config/config-plugin-3.js
@@ -1,5 +1,5 @@
 /**
- * @type {import("tstyche/tstyche").Plugin}
+ * @type {import("tstyche/tstyche").Hooks}
  */
 export default {
   select: () => {

--- a/tests/__fixtures__/hooks-select/select-plugin-1.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-1.js
@@ -1,5 +1,5 @@
 /**
- * @type {import("tstyche/tstyche").Plugin}
+ * @type {import("tstyche/tstyche").Hooks}
  */
 export default {
   select: (testFiles) => {

--- a/tests/__fixtures__/hooks-select/select-plugin-2.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-2.js
@@ -1,5 +1,5 @@
 /**
- * @type {import("tstyche/tstyche").Plugin}
+ * @type {import("tstyche/tstyche").Hooks}
  */
 export default {
   select: () => {

--- a/tests/__fixtures__/hooks-select/select-plugin-3.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-3.js
@@ -1,8 +1,8 @@
 /**
- * @type {import("tstyche/tstyche").Plugin}
+ * @type {import("tstyche/tstyche").Hooks}
  */
 export default {
-  config: () => {
-    return { failFast: true };
+  config: (resolvedConfig) => {
+    return { ...resolvedConfig, failFast: true };
   },
 };


### PR DESCRIPTION
Hooks must return full object or `null` / `undefined`.