### PR TITLE
fix: mark not existing test file as failed

### DIFF
--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import type ts from "typescript";
 import { CollectService } from "#collect";
 import type { ResolvedConfig } from "#config";
@@ -44,6 +45,15 @@ export class TaskRunner {
   }
 
   #run(task: Task, taskResult: TaskResult, cancellationToken?: CancellationToken) {
+    if (!existsSync(task.filePath)) {
+      EventEmitter.dispatch([
+        "task:error",
+        { diagnostics: [Diagnostic.error(`Test file '${task.filePath}' does not exist.`)], result: taskResult },
+      ]);
+
+      return;
+    }
+
     // wrapping around the language service allows querying on per file basis
     // reference: https://github.com/microsoft/TypeScript/wiki/Using-the-Language-Service-API#design-goals
     const languageService = this.#projectService.getLanguageService(task.filePath);

--- a/tests/__snapshots__/validation-select-stderr.snap.txt
+++ b/tests/__snapshots__/validation-select-stderr.snap.txt
@@ -1,0 +1,2 @@
+Error: Test file '<<basePath>>/tests/__fixtures__/.generated/validation-select/__typetests__/toBeNotfound.test.ts' does not exist.
+

--- a/tests/__snapshots__/validation-select-stdout.snap.txt
+++ b/tests/__snapshots__/validation-select-stdout.snap.txt
@@ -1,0 +1,13 @@
+uses TypeScript <<version>>
+
+fail ./__typetests__/toBeNotfound.test.ts
+
+pass ./__typetests__/isString.test.ts
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 passed, 2 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/validation-select.test.js
+++ b/tests/validation-select.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+const pluginText = `import path from "node:path";
+export default {
+  config: (resolvedConfig) => {
+    return { ...resolvedConfig, testFileMatch: [] /* disables look up */ };
+  },
+  select: () => {
+    return [
+      path.resolve("./__typetests__/toBeNotfound.test.ts"),
+      path.resolve("./__typetests__/isString.test.ts")
+    ];
+  },
+};
+`;
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'select' hook", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when test file does not exist", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["plugin.js"]: pluginText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--plugins", "./plugin.js"]);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+});


### PR DESCRIPTION
Currently a plugin could provide a path to not existing test file. And it will be marked as passed. That’s not good.

Fixing that. The missing file must be marked as failed and a message must be printed.