### PR TITLE
feat: add the `project` hook

### DIFF
--- a/source/fs/FileSystem.ts
+++ b/source/fs/FileSystem.ts
@@ -44,8 +44,8 @@ export class FileSystem {
     const inMemoryEntries = FileSystem.#inMemoryFiles.getEntries(path);
 
     return {
-      directories: [...new Set(...directories, ...inMemoryEntries.directories)].sort(),
-      files: [...new Set(...files, ...inMemoryEntries.files)].sort(),
+      directories: [...new Set(directories.concat(inMemoryEntries.directories))].sort(),
+      files: [...new Set(files.concat(inMemoryEntries.files))].sort(),
     };
   }
 

--- a/source/fs/FileSystem.ts
+++ b/source/fs/FileSystem.ts
@@ -1,0 +1,75 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import type { MemoryFiles } from "./MemoryFiles.js";
+import type { FileSystemEntries, FileSystemEntryMeta } from "./types.js";
+
+export class FileSystem {
+  static #memoryFiles: MemoryFiles | undefined;
+
+  static addMemoryFiles(memoryFiles: MemoryFiles) {
+    FileSystem.#memoryFiles = memoryFiles;
+  }
+
+  static directoryExists(path: string): boolean {
+    return FileSystem.#memoryFiles?.hasDirectory(path) || !!statSync(path, { throwIfNoEntry: false })?.isDirectory();
+  }
+
+  static getAccessibleFileSystemEntries(path: string): FileSystemEntries {
+    const directories: Array<string> = [];
+    const files: Array<string> = [];
+
+    try {
+      const entries = readdirSync(path, { withFileTypes: true });
+
+      for (const entry of entries) {
+        let entryMeta: FileSystemEntryMeta | undefined = entry;
+
+        if (entry.isSymbolicLink()) {
+          entryMeta = statSync([path, entry.name].join("/"), { throwIfNoEntry: false });
+        }
+
+        if (entryMeta?.isDirectory() === true) {
+          directories.push(entry.name);
+        } else if (entryMeta?.isFile() === true) {
+          files.push(entry.name);
+        }
+      }
+    } catch {
+      // continue regardless of error
+    }
+
+    if (!FileSystem.#memoryFiles) {
+      return { directories, files };
+    }
+
+    const memoryEntries = FileSystem.#memoryFiles.getEntries(path);
+
+    return {
+      directories: [...new Set(...directories, ...memoryEntries.directories)].sort(),
+      files: [...new Set(...files, ...memoryEntries.files)].sort(),
+    };
+  }
+
+  static fileExists(path: string): boolean {
+    return FileSystem.#memoryFiles?.hasFile(path) || !!statSync(path, { throwIfNoEntry: false })?.isFile();
+  }
+
+  static readFile(path: string): string | undefined {
+    let contents = FileSystem.#memoryFiles?.getFile(path);
+
+    if (contents != null) {
+      return contents;
+    }
+
+    try {
+      contents = readFileSync(path, { encoding: "utf8" });
+    } catch {
+      // continue regardless of error
+    }
+
+    return contents;
+  }
+
+  static removeMemoryFiles() {
+    FileSystem.#memoryFiles = undefined;
+  }
+}

--- a/source/fs/FileSystem.ts
+++ b/source/fs/FileSystem.ts
@@ -1,16 +1,16 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import type { MemoryFiles } from "./MemoryFiles.js";
+import type { InMemoryFiles } from "./InMemoryFiles.js";
 import type { FileSystemEntries, FileSystemEntryMeta } from "./types.js";
 
 export class FileSystem {
-  static #memoryFiles: MemoryFiles | undefined;
+  static #inMemoryFiles: InMemoryFiles | undefined;
 
-  static addMemoryFiles(memoryFiles: MemoryFiles) {
-    FileSystem.#memoryFiles = memoryFiles;
+  static addInMemoryFiles(inMemoryFiles: InMemoryFiles) {
+    FileSystem.#inMemoryFiles = inMemoryFiles;
   }
 
   static directoryExists(path: string): boolean {
-    return FileSystem.#memoryFiles?.hasDirectory(path) || !!statSync(path, { throwIfNoEntry: false })?.isDirectory();
+    return FileSystem.#inMemoryFiles?.hasDirectory(path) || !!statSync(path, { throwIfNoEntry: false })?.isDirectory();
   }
 
   static getAccessibleFileSystemEntries(path: string): FileSystemEntries {
@@ -37,24 +37,24 @@ export class FileSystem {
       // continue regardless of error
     }
 
-    if (!FileSystem.#memoryFiles) {
+    if (!FileSystem.#inMemoryFiles) {
       return { directories, files };
     }
 
-    const memoryEntries = FileSystem.#memoryFiles.getEntries(path);
+    const inMemoryEntries = FileSystem.#inMemoryFiles.getEntries(path);
 
     return {
-      directories: [...new Set(...directories, ...memoryEntries.directories)].sort(),
-      files: [...new Set(...files, ...memoryEntries.files)].sort(),
+      directories: [...new Set(...directories, ...inMemoryEntries.directories)].sort(),
+      files: [...new Set(...files, ...inMemoryEntries.files)].sort(),
     };
   }
 
   static fileExists(path: string): boolean {
-    return FileSystem.#memoryFiles?.hasFile(path) || !!statSync(path, { throwIfNoEntry: false })?.isFile();
+    return FileSystem.#inMemoryFiles?.hasFile(path) || !!statSync(path, { throwIfNoEntry: false })?.isFile();
   }
 
   static readFile(path: string): string | undefined {
-    let contents = FileSystem.#memoryFiles?.getFile(path);
+    let contents = FileSystem.#inMemoryFiles?.getFile(path);
 
     if (contents != null) {
       return contents;
@@ -69,7 +69,7 @@ export class FileSystem {
     return contents;
   }
 
-  static removeMemoryFiles() {
-    FileSystem.#memoryFiles = undefined;
+  static removeInMemoryFiles() {
+    FileSystem.#inMemoryFiles = undefined;
   }
 }

--- a/source/fs/InMemoryFiles.ts
+++ b/source/fs/InMemoryFiles.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { Path } from "#path";
 import type { FileSystemEntries } from "./types.js";
 
-export class MemoryFiles {
+export class InMemoryFiles {
   #directories = new Map<string, { directories: Set<string>; files: Set<string> }>();
   #files = new Map<string, string>();
   #rootPath: string;

--- a/source/fs/MemoryFiles.ts
+++ b/source/fs/MemoryFiles.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { Path } from "#path";
+import type { FileSystemEntries } from "./types.js";
+
+export class MemoryFiles {
+  #directories = new Map<string, { directories: Set<string>; files: Set<string> }>();
+  #files = new Map<string, string>();
+  #rootPath: string;
+
+  constructor(rootPath: string) {
+    this.#rootPath = rootPath;
+  }
+
+  add(files: Record<string, string>) {
+    for (const filePath in files) {
+      if (path.isAbsolute(filePath)) {
+        Path.relative(this.#rootPath, filePath);
+      }
+
+      if (!filePath.startsWith(".")) {
+        // TODO log a warning fist, perhaps via 'fs:info' or general 'warnings' event?
+        continue;
+      }
+
+      const pathSegments = filePath.split("/");
+      let pathSegmentIndex = 0;
+      let currentPath = this.#rootPath;
+
+      for (const pathSegment of pathSegments) {
+        ++pathSegmentIndex;
+
+        let entries = this.#directories.get(currentPath);
+
+        if (!entries) {
+          entries = { directories: new Set(), files: new Set() };
+          this.#directories.set(currentPath, entries);
+        }
+
+        if (pathSegmentIndex === pathSegments.length) {
+          entries.files.add(currentPath);
+
+          // biome-ignore lint/style/noNonNullAssertion: this is fine
+          this.#files.set(filePath, files[filePath]!);
+        } else {
+          entries.directories.add(currentPath);
+        }
+
+        currentPath = Path.join(currentPath, pathSegment);
+      }
+    }
+  }
+
+  getEntries(path: string): FileSystemEntries {
+    const entries = this.#directories.get(path);
+
+    if (!entries) {
+      return { directories: [], files: [] };
+    }
+
+    return { directories: [...entries.directories], files: [...entries.files] };
+  }
+
+  getFile(path: string): string | undefined {
+    return this.#files.get(path);
+  }
+
+  hasDirectory(path: string): boolean {
+    return this.#directories.has(path);
+  }
+
+  hasFile(path: string): boolean {
+    return this.#files.has(path);
+  }
+}

--- a/source/fs/__tests__/FileSystem.test.js
+++ b/source/fs/__tests__/FileSystem.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert";
+import path from "node:path";
+import test from "node:test";
+import { FileSystem, InMemoryFiles } from "tstyche/tstyche";
+
+/**
+ * @type {import("tstyche/tstyche").FileTree}
+ */
+const testFiles = {
+  ["./__typetests__/isString.test.ts"]: "isStringText",
+  [path.resolve("./ts-tests/isNumber.test.ts")]: "isNumberText",
+  ["isBoolean.test.ts"]: "isBooleanText",
+  ["../isIgnored.test.ts"]: "isIgnored",
+};
+
+const inMemoryFiles = new InMemoryFiles(".").add(testFiles);
+
+FileSystem.addInMemoryFiles(inMemoryFiles);
+
+// TODO add a fixture with real files and check if 'FileSystem' is merging real and memory files
+
+test("FileSystem", async (t) => {
+  await t.test("'directoryExists()' method", () => {
+    assert(FileSystem.directoryExists(path.resolve(".").replace(/\\/g, "/")));
+
+    assert(FileSystem.directoryExists(path.resolve("./__typetests__").replace(/\\/g, "/")));
+
+    assert(FileSystem.directoryExists(path.resolve("./ts-tests").replace(/\\/g, "/")));
+  });
+
+  await t.test("'fileExists()' method", () => {
+    assert(FileSystem.fileExists(path.resolve("./__typetests__/isString.test.ts").replace(/\\/g, "/")));
+
+    assert(FileSystem.fileExists(path.resolve("./ts-tests/isNumber.test.ts").replace(/\\/g, "/")));
+
+    assert(FileSystem.fileExists(path.resolve("./isBoolean.test.ts").replace(/\\/g, "/")));
+
+    assert(!FileSystem.fileExists(path.resolve("../isIgnored.test.ts").replace(/\\/g, "/")));
+  });
+
+  await t.test("'readFile()' method", () => {
+    assert.strictEqual(
+      FileSystem.readFile(path.resolve("./__typetests__/isString.test.ts").replace(/\\/g, "/")),
+      "isStringText",
+    );
+
+    assert.strictEqual(
+      FileSystem.readFile(path.resolve("./ts-tests/isNumber.test.ts").replace(/\\/g, "/")),
+      "isNumberText",
+    );
+
+    assert.strictEqual(FileSystem.readFile(path.resolve("./isBoolean.test.ts").replace(/\\/g, "/")), "isBooleanText");
+
+    assert.strictEqual(FileSystem.readFile(path.resolve("../isIgnored.test.ts").replace(/\\/g, "/")), undefined);
+  });
+
+  await t.test("'getAccessibleFileSystemEntries()' method", () => {
+    // assert.strictEqual(FileSystem.getAccessibleFileSystemEntries(path.resolve(".").replace(/\\/g, "/")), {});
+
+    assert.deepStrictEqual(
+      FileSystem.getAccessibleFileSystemEntries(path.resolve("./__typetests__").replace(/\\/g, "/")),
+      { directories: [], files: ["isString.test.ts"] },
+    );
+
+    assert.deepStrictEqual(FileSystem.getAccessibleFileSystemEntries(path.resolve("./ts-tests").replace(/\\/g, "/")), {
+      directories: [],
+      files: ["isNumber.test.ts"],
+    });
+  });
+
+  await t.test("'removeInMemoryFiles()' method", () => {
+    FileSystem.removeInMemoryFiles();
+
+    assert(!FileSystem.fileExists(path.resolve("./__typetests__/isString.test.ts").replace(/\\/g, "/")));
+    assert(!FileSystem.directoryExists(path.resolve("./__typetests__").replace(/\\/g, "/")));
+  });
+});

--- a/source/fs/__tests__/FileSystem.test.js
+++ b/source/fs/__tests__/FileSystem.test.js
@@ -17,7 +17,9 @@ const inMemoryFiles = new InMemoryFiles(".").add(testFiles);
 
 FileSystem.addInMemoryFiles(inMemoryFiles);
 
-// TODO add a fixture with real files and check if 'FileSystem' is merging real and memory files
+// TODO add a fixture with real files
+//      - check if 'FileSystem' is merging real and memory files
+//      - check is 'FileSystem' is overriding real files
 
 test("FileSystem", async (t) => {
   await t.test("'directoryExists()' method", () => {

--- a/source/fs/__tests__/InMemoryFiles.test.js
+++ b/source/fs/__tests__/InMemoryFiles.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import path from "node:path";
+import test from "node:test";
+import { InMemoryFiles } from "tstyche/tstyche";
+
+/**
+ * @type {import("tstyche/tstyche").FileTree}
+ */
+const testFiles = {
+  ["./__typetests__/isString.test.ts"]: "isStringText",
+  [path.resolve("./ts-tests/isNumber.test.ts")]: "isNumberText",
+  ["isBoolean.test.ts"]: "isBooleanText",
+  ["../isIgnored.test.ts"]: "isIgnored",
+};
+
+const inMemoryFiles = new InMemoryFiles(".").add(testFiles);
+
+test("InMemoryFiles", async (t) => {
+  await t.test("'getEntries()' method", () => {
+    assert.deepEqual(inMemoryFiles.getEntries(path.resolve(".").replace(/\\/g, "/")), {
+      directories: ["__typetests__", "ts-tests"],
+      files: ["isBoolean.test.ts"],
+    });
+
+    assert.deepEqual(inMemoryFiles.getEntries(path.resolve("./__typetests__").replace(/\\/g, "/")), {
+      directories: [],
+      files: ["isString.test.ts"],
+    });
+
+    assert.deepEqual(inMemoryFiles.getEntries(path.resolve("./ts-tests").replace(/\\/g, "/")), {
+      directories: [],
+      files: ["isNumber.test.ts"],
+    });
+  });
+
+  await t.test("'hasDirectory()' method", () => {
+    assert(inMemoryFiles.hasDirectory(path.resolve(".").replace(/\\/g, "/")));
+
+    assert(inMemoryFiles.hasDirectory(path.resolve("./__typetests__").replace(/\\/g, "/")));
+
+    assert(inMemoryFiles.hasDirectory(path.resolve("./ts-tests").replace(/\\/g, "/")));
+
+    assert(!inMemoryFiles.hasDirectory(path.resolve("..").replace(/\\/g, "/")));
+  });
+
+  await t.test("'hasFile()' method", () => {
+    assert(inMemoryFiles.hasFile(path.resolve("./__typetests__/isString.test.ts").replace(/\\/g, "/")));
+
+    assert(inMemoryFiles.hasFile(path.resolve("./ts-tests/isNumber.test.ts").replace(/\\/g, "/")));
+
+    assert(inMemoryFiles.hasFile(path.resolve("./isBoolean.test.ts").replace(/\\/g, "/")));
+
+    assert(!inMemoryFiles.hasFile(path.resolve("../isIgnored.test.ts").replace(/\\/g, "/")));
+  });
+
+  await t.test("'getFile()' method", () => {
+    assert.strictEqual(
+      inMemoryFiles.getFile(path.resolve("./__typetests__/isString.test.ts").replace(/\\/g, "/")),
+      "isStringText",
+    );
+
+    assert.strictEqual(
+      inMemoryFiles.getFile(path.resolve("./ts-tests/isNumber.test.ts").replace(/\\/g, "/")),
+      "isNumberText",
+    );
+
+    assert.strictEqual(inMemoryFiles.getFile(path.resolve("./isBoolean.test.ts").replace(/\\/g, "/")), "isBooleanText");
+
+    assert.strictEqual(inMemoryFiles.getFile(path.resolve("../isIgnored.test.ts").replace(/\\/g, "/")), undefined);
+  });
+});

--- a/source/fs/__tests__/tsconfig.json
+++ b/source/fs/__tests__/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*"],
+  "exclude": []
+}

--- a/source/fs/index.ts
+++ b/source/fs/index.ts
@@ -1,2 +1,3 @@
 export { FileSystem } from "./FileSystem.js";
 export { InMemoryFiles } from "./InMemoryFiles.js";
+export type { FileTree } from "./types.js";

--- a/source/fs/index.ts
+++ b/source/fs/index.ts
@@ -1,0 +1,2 @@
+export { FileSystem } from "./FileSystem.js";
+export { MemoryFiles } from "./MemoryFiles.js";

--- a/source/fs/index.ts
+++ b/source/fs/index.ts
@@ -1,2 +1,2 @@
 export { FileSystem } from "./FileSystem.js";
-export { MemoryFiles } from "./MemoryFiles.js";
+export { InMemoryFiles } from "./InMemoryFiles.js";

--- a/source/fs/types.ts
+++ b/source/fs/types.ts
@@ -8,3 +8,5 @@ export interface FileSystemEntryMeta {
   isFile: () => boolean;
   isSymbolicLink: () => boolean;
 }
+
+export type FileTree = Record<string, string>;

--- a/source/fs/types.ts
+++ b/source/fs/types.ts
@@ -1,0 +1,10 @@
+export interface FileSystemEntries {
+  directories: Array<string>;
+  files: Array<string>;
+}
+
+export interface FileSystemEntryMeta {
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+  isSymbolicLink: () => boolean;
+}

--- a/source/hooks/HooksService.ts
+++ b/source/hooks/HooksService.ts
@@ -1,4 +1,6 @@
+import type ts from "typescript";
 import type { ResolvedConfig } from "#config";
+import type { MemoryFiles } from "#fs";
 import type { Hooks } from "./types.js";
 
 export class HooksService {
@@ -9,13 +11,18 @@ export class HooksService {
   }
 
   static async call(hook: "config", resolvedConfig: ResolvedConfig): Promise<ResolvedConfig>;
+  static async call(hook: "project", memoryFiles: MemoryFiles, compiler: typeof ts): Promise<MemoryFiles>;
   static async call(hook: "select", testFiles: Array<string>): Promise<Array<string | URL>>;
   static async call(
     hook: keyof Hooks,
-    options: ResolvedConfig | Array<string | URL>,
-  ): Promise<ResolvedConfig | Array<string | URL>> {
+    options: ResolvedConfig | MemoryFiles | Array<string | URL>,
+    context?: typeof ts,
+  ): Promise<ResolvedConfig | MemoryFiles | Array<string | URL>> {
     for (const handler of HooksService.#handlers) {
-      const result = await handler[hook]?.(options as ResolvedConfig & Array<string>);
+      const result = await handler[hook]?.(
+        options as ResolvedConfig & MemoryFiles & Array<string>,
+        context as typeof ts,
+      );
 
       if (result != null) {
         options = result;

--- a/source/hooks/HooksService.ts
+++ b/source/hooks/HooksService.ts
@@ -11,7 +11,9 @@ export class HooksService {
   }
 
   static async call(hook: "config", resolvedConfig: ResolvedConfig): Promise<ResolvedConfig>;
-  static async call(hook: "project", inMemoryFiles: InMemoryFiles, compiler: typeof ts): Promise<InMemoryFiles>;
+  static async call(hook: "projectSetup", inMemoryFiles: InMemoryFiles, compiler: typeof ts): Promise<InMemoryFiles>;
+  // @ts-expect-error TODO fix this later
+  static async call(hook: "projectTeardown"): Promise<void>;
   static async call(hook: "select", testFiles: Array<string>): Promise<Array<string | URL>>;
   static async call(
     hook: keyof Hooks,

--- a/source/hooks/HooksService.ts
+++ b/source/hooks/HooksService.ts
@@ -1,6 +1,6 @@
 import type ts from "typescript";
 import type { ResolvedConfig } from "#config";
-import type { MemoryFiles } from "#fs";
+import type { InMemoryFiles } from "#fs";
 import type { Hooks } from "./types.js";
 
 export class HooksService {
@@ -11,16 +11,16 @@ export class HooksService {
   }
 
   static async call(hook: "config", resolvedConfig: ResolvedConfig): Promise<ResolvedConfig>;
-  static async call(hook: "project", memoryFiles: MemoryFiles, compiler: typeof ts): Promise<MemoryFiles>;
+  static async call(hook: "project", inMemoryFiles: InMemoryFiles, compiler: typeof ts): Promise<InMemoryFiles>;
   static async call(hook: "select", testFiles: Array<string>): Promise<Array<string | URL>>;
   static async call(
     hook: keyof Hooks,
-    options: ResolvedConfig | MemoryFiles | Array<string | URL>,
+    options: ResolvedConfig | InMemoryFiles | Array<string | URL>,
     context?: typeof ts,
-  ): Promise<ResolvedConfig | MemoryFiles | Array<string | URL>> {
+  ): Promise<ResolvedConfig | InMemoryFiles | Array<string | URL>> {
     for (const handler of HooksService.#handlers) {
       const result = await handler[hook]?.(
-        options as ResolvedConfig & MemoryFiles & Array<string>,
+        options as ResolvedConfig & InMemoryFiles & Array<string>,
         context as typeof ts,
       );
 

--- a/source/hooks/types.ts
+++ b/source/hooks/types.ts
@@ -1,10 +1,16 @@
+import type ts from "typescript";
 import type { ResolvedConfig } from "#config";
+import type { MemoryFiles } from "#fs";
 
 export interface Hooks {
   /**
    * Is called after configuration is resolved and allows to modify it.
    */
   config?: (resolvedConfig: ResolvedConfig) => ResolvedConfig | Promise<ResolvedConfig>;
+  /**
+   * Is called before a project is created and allows to modify its host.
+   */
+  project?: (memoryFiles: MemoryFiles, compiler: typeof ts) => MemoryFiles | Promise<MemoryFiles>;
   /**
    * Is called after test files are selected and allows to modify the list.
    */

--- a/source/hooks/types.ts
+++ b/source/hooks/types.ts
@@ -8,9 +8,13 @@ export interface Hooks {
    */
   config?: (resolvedConfig: ResolvedConfig) => ResolvedConfig | Promise<ResolvedConfig>;
   /**
-   * Is called before a project is created and allows adding in-memory files.
+   * Is called before creating a test project and allows adding in-memory files.
    */
-  project?: (inMemoryFiles: InMemoryFiles, compiler: typeof ts) => InMemoryFiles | Promise<InMemoryFiles>;
+  projectSetup?: (inMemoryFiles: InMemoryFiles, compiler: typeof ts) => InMemoryFiles | Promise<InMemoryFiles>;
+  /**
+   * Is called after evaluating a test project.
+   */
+  projectTeardown?: () => void | Promise<void>;
   /**
    * Is called after test files are selected and allows to modify the list.
    */

--- a/source/hooks/types.ts
+++ b/source/hooks/types.ts
@@ -1,6 +1,6 @@
 import type ts from "typescript";
 import type { ResolvedConfig } from "#config";
-import type { MemoryFiles } from "#fs";
+import type { InMemoryFiles } from "#fs";
 
 export interface Hooks {
   /**
@@ -8,9 +8,9 @@ export interface Hooks {
    */
   config?: (resolvedConfig: ResolvedConfig) => ResolvedConfig | Promise<ResolvedConfig>;
   /**
-   * Is called before a project is created and allows to modify its host.
+   * Is called before a project is created and allows adding in-memory files.
    */
-  project?: (memoryFiles: MemoryFiles, compiler: typeof ts) => MemoryFiles | Promise<MemoryFiles>;
+  project?: (inMemoryFiles: InMemoryFiles, compiler: typeof ts) => InMemoryFiles | Promise<InMemoryFiles>;
   /**
    * Is called after test files are selected and allows to modify the list.
    */

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -1,6 +1,7 @@
 import type ts from "typescript";
 import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
+import { FileSystem } from "#fs";
 import { Version } from "#version";
 
 export class ProjectService {
@@ -30,6 +31,7 @@ export class ProjectService {
 
     const host: ts.server.ServerHost = {
       ...this.#compiler.sys,
+      ...FileSystem,
       clearImmediate,
       clearTimeout,
       setImmediate,

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -29,16 +29,20 @@ export class ProjectService {
       close: noop,
     };
 
-    const host: ts.server.ServerHost = {
-      ...this.#compiler.sys,
-      ...FileSystem,
+    const host = Object.assign(this.#compiler.sys, {
+      directoryExists: FileSystem.directoryExists,
+      fileExists: FileSystem.fileExists,
+      getAccessibleFileSystemEntries: FileSystem.getAccessibleFileSystemEntries,
+      readFile: FileSystem.readFile,
+
       clearImmediate,
       clearTimeout,
       setImmediate,
       setTimeout,
+
       watchDirectory: () => noopWatcher,
       watchFile: () => noopWatcher,
-    };
+    });
 
     this.#service = new this.#compiler.server.ProjectService({
       allowLocalPluginLoads: true,

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -1,15 +1,17 @@
 import type ts from "typescript";
 import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
-import { FileSystem } from "#fs";
+import { FileSystem, type InMemoryFiles } from "#fs";
 import { Version } from "#version";
 
 export class ProjectService {
   #compiler: typeof ts;
+  #inMemoryFiles: InMemoryFiles;
   #service: ts.server.ProjectService;
 
-  constructor(compiler: typeof ts) {
+  constructor(compiler: typeof ts, inMemoryFiles: InMemoryFiles) {
     this.#compiler = compiler;
+    this.#inMemoryFiles = inMemoryFiles;
 
     const noop = () => undefined;
 
@@ -101,6 +103,8 @@ export class ProjectService {
   }
 
   openFile(filePath: string, sourceText?: string | undefined, projectRootPath?: string | undefined): void {
+    sourceText = this.#inMemoryFiles.getFile(filePath);
+
     const { configFileErrors, configFileName } = this.#service.openClientFile(
       filePath,
       sourceText,

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -88,7 +88,7 @@ export class Runner {
 
       if (compiler) {
         const inMemoryFiles = await HooksService.call(
-          "project",
+          "projectSetup",
           new InMemoryFiles(this.#resolvedConfig.rootPath),
           compiler,
         );
@@ -96,11 +96,13 @@ export class Runner {
         FileSystem.addInMemoryFiles(inMemoryFiles);
 
         // TODO to improve performance, test projects could be cached
-        const testProject = new TestProject(this.#resolvedConfig, compiler);
+        const testProject = new TestProject(this.#resolvedConfig, compiler, inMemoryFiles);
 
         testProject.run(tasks, cancellationToken);
 
         FileSystem.removeInMemoryFiles();
+
+        await HooksService.call("projectTeardown");
       }
 
       EventEmitter.dispatch(["target:end", { result: targetResult }]);

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -1,6 +1,6 @@
 import type { ResolvedConfig } from "#config";
 import { EventEmitter } from "#events";
-import { FileSystem, MemoryFiles } from "#fs";
+import { FileSystem, InMemoryFiles } from "#fs";
 import { CancellationHandler, ResultHandler } from "#handlers";
 import { HooksService } from "#hooks";
 import { ListReporter, type Reporter, SummaryReporter, WatchReporter } from "#reporters";
@@ -87,20 +87,20 @@ export class Runner {
       const compiler = await Store.load(target);
 
       if (compiler) {
-        const memoryFiles = await HooksService.call(
+        const inMemoryFiles = await HooksService.call(
           "project",
-          new MemoryFiles(this.#resolvedConfig.rootPath),
+          new InMemoryFiles(this.#resolvedConfig.rootPath),
           compiler,
         );
 
-        FileSystem.addMemoryFiles(memoryFiles);
+        FileSystem.addInMemoryFiles(inMemoryFiles);
 
         // TODO to improve performance, test projects could be cached
         const testProject = new TestProject(this.#resolvedConfig, compiler);
 
         testProject.run(tasks, cancellationToken);
 
-        FileSystem.removeMemoryFiles();
+        FileSystem.removeInMemoryFiles();
       }
 
       EventEmitter.dispatch(["target:end", { result: targetResult }]);

--- a/source/runner/TestProject.ts
+++ b/source/runner/TestProject.ts
@@ -1,10 +1,10 @@
-import { existsSync } from "node:fs";
 import type ts from "typescript";
 import { CollectService } from "#collect";
 import type { ResolvedConfig } from "#config";
 import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
 import type { TypeChecker } from "#expect";
+import { FileSystem } from "#fs";
 import { ProjectService } from "#project";
 import { TaskResult } from "#result";
 import type { Task } from "#task";
@@ -47,7 +47,7 @@ export class TestProject {
   }
 
   #run(task: Task, taskResult: TaskResult, cancellationToken?: CancellationToken) {
-    if (!existsSync(task.filePath)) {
+    if (!FileSystem.fileExists(task.filePath)) {
       EventEmitter.dispatch([
         "task:error",
         { diagnostics: [Diagnostic.error(`Test file '${task.filePath}' does not exist.`)], result: taskResult },

--- a/source/tstyche.ts
+++ b/source/tstyche.ts
@@ -5,6 +5,7 @@ export * from "#diagnostic";
 export * from "#environment";
 export * from "#events";
 export * from "#expect";
+export * from "#fs";
 export * from "#handlers";
 export * from "#hooks";
 export * from "#input";


### PR DESCRIPTION
Here is one more hook: `project`.

I have to polish it more. Currently it allows providing in-memory files (that also override the real ones):

```js
const isNumberText = `import { expect, test } from "tstyche";

test("is number?", () => {
  expect<number>().type.toBeNumber();
});
`;

/**
 * @type {import("tstyche/tstyche").FileTree}
 */
const testFiles = {
  ["./__typetests__/isNumber.tst.ts"]: isNumberText,
};

/**
 * @type {import("tstyche/tstyche").Hooks}
 */
export default {
  config: (resolvedConfig) => {
    return { ...resolvedConfig, testFileMatch: [] /* disables look up */ };
  },

  select: () => {
    return Object.keys(testFiles);
  },

  project: (inMemoryFiles) => {
    return inMemoryFiles.add(testFiles);
  },
};
```