### PR TITLE
fix(runner): always resolve test file paths

### DIFF
--- a/source/task/Task.ts
+++ b/source/task/Task.ts
@@ -6,7 +6,7 @@ export class Task {
   position: number | undefined;
 
   constructor(filePath: string | URL, position?: number) {
-    this.filePath = Path.normalizeSlashes(this.#toPath(filePath));
+    this.filePath = Path.resolve(this.#toPath(filePath));
     this.position = position;
   }
 

--- a/tests/__fixtures__/hooks-select/select-plugin-2.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-2.js
@@ -3,6 +3,6 @@
  */
 export default {
   select: () => {
-    return [new URL("./ts-tests/toBeNumber.test.ts", import.meta.url)];
+    return ["./ts-tests/toBeNumber.test.ts"];
   },
 };


### PR DESCRIPTION
Test file paths must be always resolved.