### PR TITLE
feat: pass context to the `select` hook

### DIFF
--- a/examples/example-plugin.tst.js
+++ b/examples/example-plugin.tst.js
@@ -4,7 +4,7 @@
 export default {
   name: "example-plugin",
 
-  config: (resolvedConfig) => {
+  config(resolvedConfig) {
     return {
       ...resolvedConfig,
       reporters: [new URL("./custom-reporter.js", import.meta.url).toString()],
@@ -12,7 +12,7 @@ export default {
     };
   },
 
-  select: (testFiles) => {
+  select(testFiles) {
     return testFiles.filter((testFile) => !testFile.endsWith("toBeNumber.test.ts"));
   },
 };

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -88,7 +88,7 @@ export class Cli {
         PluginService.addHandler(plugin);
       }
 
-      resolvedConfig = await PluginService.call("config", resolvedConfig);
+      resolvedConfig = await PluginService.call("config", resolvedConfig, /* context */ {});
 
       if (commandLine.includes("--showConfig")) {
         OutputService.writeMessage(formattedText({ ...resolvedConfig, ...environmentOptions }));
@@ -115,7 +115,7 @@ export class Cli {
         }
       }
 
-      testFiles = await PluginService.call("select", testFiles as Array<string>);
+      testFiles = await PluginService.call("select", testFiles as Array<string>, { resolvedConfig });
 
       if (commandLine.includes("--listFiles")) {
         OutputService.writeMessage(formattedText(testFiles.map((testFile) => testFile.toString())));

--- a/source/plugins/PluginService.ts
+++ b/source/plugins/PluginService.ts
@@ -10,7 +10,7 @@ export class PluginService {
   static async call<T extends keyof Hooks>(
     hook: T,
     argument: Parameters<Required<Hooks>[T]>[0],
-    context?: Parameters<Required<Hooks>[T]>[1],
+    context: ThisParameterType<Required<Hooks>[T]>,
   ): Promise<Awaited<ReturnType<Required<Hooks>[T]>>> {
     let result = argument as Awaited<ReturnType<Required<Hooks>[T]>>;
 

--- a/source/plugins/types.ts
+++ b/source/plugins/types.ts
@@ -1,10 +1,7 @@
 import type { ResolvedConfig } from "#config";
 
-export interface Plugin extends Hooks {
-  /**
-   * The name of this plugin.
-   */
-  name: string;
+interface SelectHookContext {
+  resolvedConfig: ResolvedConfig;
 }
 
 export interface Hooks {
@@ -15,5 +12,12 @@ export interface Hooks {
   /**
    * Is called after test files are selected and allows to modify the list.
    */
-  select?: (testFiles: Array<string>) => Array<string | URL> | Promise<Array<string | URL>>;
+  select?: (this: SelectHookContext, testFiles: Array<string>) => Array<string | URL> | Promise<Array<string | URL>>;
+}
+
+export interface Plugin extends Hooks {
+  /**
+   * The name of this plugin.
+   */
+  name: string;
 }

--- a/tests/__fixtures__/hooks-config/config-plugin-1.js
+++ b/tests/__fixtures__/hooks-config/config-plugin-1.js
@@ -4,7 +4,7 @@
 export default {
   name: "config-plugin-1",
 
-  config: (resolvedConfig) => {
+  config(resolvedConfig) {
     return { ...resolvedConfig, failFast: true };
   },
 };

--- a/tests/__fixtures__/hooks-config/config-plugin-2.js
+++ b/tests/__fixtures__/hooks-config/config-plugin-2.js
@@ -4,11 +4,11 @@
 export default {
   name: "config-plugin-2",
 
-  config: (resolvedConfig) => {
+  config(resolvedConfig) {
     return { ...resolvedConfig, testFileMatch: [] };
   },
 
-  select: () => {
+  select() {
     return ["./examples/firstItem.tst.ts"];
   },
 };

--- a/tests/__fixtures__/hooks-config/config-plugin-3.js
+++ b/tests/__fixtures__/hooks-config/config-plugin-3.js
@@ -4,7 +4,7 @@
 export default {
   name: "config-plugin-3",
 
-  select: () => {
+  select() {
     return ["./examples/firstItem.tst.ts"];
   },
 };

--- a/tests/__fixtures__/hooks-select/select-plugin-1.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-1.js
@@ -4,7 +4,7 @@
 export default {
   name: "select-plugin-1",
 
-  select: (testFiles) => {
+  select(testFiles) {
     return [...testFiles, new URL("./ts-tests/toBeString.test.ts", import.meta.url)];
   },
 };

--- a/tests/__fixtures__/hooks-select/select-plugin-2.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-2.js
@@ -1,10 +1,12 @@
+import path from "node:path";
+
 /**
  * @type {import("tstyche/tstyche").Plugin}
  */
 export default {
   name: "select-plugin-2",
 
-  select: () => {
-    return ["./ts-tests/toBeNumber.test.ts"];
+  select() {
+    return [path.join(this.resolvedConfig.rootPath, "./ts-tests/toBeNumber.test.ts")];
   },
 };

--- a/tests/__fixtures__/hooks-select/select-plugin-3.js
+++ b/tests/__fixtures__/hooks-select/select-plugin-3.js
@@ -4,7 +4,7 @@
 export default {
   name: "select-plugin-3",
 
-  config: (resolvedConfig) => {
+  config(resolvedConfig) {
     return { ...resolvedConfig, failFast: true };
   },
 };

--- a/tests/__fixtures__/hooks-select/tsconfig.json
+++ b/tests/__fixtures__/hooks-select/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "extends": "../tsconfig.json",
   "include": ["**/*"]
 }

--- a/tests/validation-select.test.js
+++ b/tests/validation-select.test.js
@@ -12,13 +12,13 @@ test("is string?", () => {
 
 const pluginText = `import path from "node:path";
 export default {
-  config: (resolvedConfig) => {
+  config(resolvedConfig) {
     return { ...resolvedConfig, testFileMatch: [] /* disables look up */ };
   },
-  select: () => {
+  select() {
     return [
-      path.resolve("./__typetests__/toBeNotfound.test.ts"),
-      path.resolve("./__typetests__/isString.test.ts")
+      path.join(this.resolvedConfig.rootPath, "./__typetests__/toBeNotfound.test.ts"),
+      path.join(this.resolvedConfig.rootPath, "./__typetests__/isString.test.ts")
     ];
   },
 };


### PR DESCRIPTION
Sounds useful to pass `ResolvedConfig` as context to the `select` hook.