### PR TITLE
refactor: remove the `Hooks` interface

### DIFF
--- a/source/plugins/PluginService.ts
+++ b/source/plugins/PluginService.ts
@@ -1,7 +1,9 @@
-import type { Hooks, Plugin } from "./types.js";
+import type { Plugin } from "./types.js";
+
+type Hooks = Required<Omit<Plugin, "name">>;
 
 export class PluginService {
-  static #handlers = new Map<string, Hooks>();
+  static #handlers = new Map<string, Plugin>();
 
   static addHandler(plugin: Plugin): void {
     PluginService.#handlers.set(plugin.name, plugin);
@@ -9,10 +11,10 @@ export class PluginService {
 
   static async call<T extends keyof Hooks>(
     hook: T,
-    argument: Parameters<Required<Hooks>[T]>[0],
-    context: ThisParameterType<Required<Hooks>[T]>,
-  ): Promise<Awaited<ReturnType<Required<Hooks>[T]>>> {
-    let result = argument as Awaited<ReturnType<Required<Hooks>[T]>>;
+    argument: Parameters<Hooks[T]>[0],
+    context: ThisParameterType<Hooks[T]>,
+  ): Promise<Awaited<ReturnType<Hooks[T]>>> {
+    let result = argument as Awaited<ReturnType<Hooks[T]>>;
 
     for (const [, plugin] of PluginService.#handlers) {
       if (hook in plugin) {

--- a/source/plugins/index.ts
+++ b/source/plugins/index.ts
@@ -1,2 +1,2 @@
 export { PluginService } from "./PluginService.js";
-export type { Hooks, Plugin } from "./types.js";
+export type { Plugin } from "./types.js";

--- a/source/plugins/types.ts
+++ b/source/plugins/types.ts
@@ -4,7 +4,11 @@ interface SelectHookContext {
   resolvedConfig: ResolvedConfig;
 }
 
-export interface Hooks {
+export interface Plugin {
+  /**
+   * The name of this plugin.
+   */
+  name: string;
   /**
    * Is called after configuration is resolved and allows to modify it.
    */
@@ -13,11 +17,4 @@ export interface Hooks {
    * Is called after test files are selected and allows to modify the list.
    */
   select?: (this: SelectHookContext, testFiles: Array<string>) => Array<string | URL> | Promise<Array<string | URL>>;
-}
-
-export interface Plugin extends Hooks {
-  /**
-   * The name of this plugin.
-   */
-  name: string;
 }


### PR DESCRIPTION
Removing the `Hooks` interface. The `Plugin` interface must be used instead.