### PR TITLE
fix(expect): take into account `exactOptionalPropertyTypes` option when comparing types

### DIFF
--- a/examples/exact-optional-properties.tst.ts
+++ b/examples/exact-optional-properties.tst.ts
@@ -1,0 +1,9 @@
+import { expect } from "tstyche";
+
+// all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+
+expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+
+expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -31,7 +31,13 @@ export class MatchWorker {
   checkIsIdenticalTo(sourceNode: ArgumentNode, targetNode: ArgumentNode): boolean {
     const relation = this.#typeChecker.relation.identity;
 
-    return this.#checkIsRelatedTo(sourceNode, targetNode, relation);
+    return (
+      this.#checkIsRelatedTo(sourceNode, targetNode, relation) &&
+      // following assignability checks ensure '{ a?: number }' and '{ a?: number | undefined }'
+      // are reported as not identical when '"exactOptionalPropertyTypes": true' is set
+      this.checkIsAssignableTo(sourceNode, targetNode) &&
+      this.checkIsAssignableWith(sourceNode, targetNode)
+    );
   }
 
   checkIsSubtype(sourceNode: ArgumentNode, targetNode: ArgumentNode): boolean {

--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -19,6 +19,16 @@ test("edge cases", () => {
   expect(Date).type.toBe<typeof Date>();
 });
 
+test("exact optional property types", () => {
+  // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+
+  expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+
+  expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+});
+
 describe("source type", () => {
   test("is identical to target type", () => {
     expect<{ a: string; b: number }>().type.toBe<{ a: string; b: number }>();

--- a/tests/__fixtures__/api-toBe/tsconfig-exact.json
+++ b/tests/__fixtures__/api-toBe/tsconfig-exact.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["**/*"]
+}

--- a/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
@@ -1,0 +1,23 @@
+uses TypeScript <<version>> with ./tsconfig-exact.json
+
+pass ./__typetests__/toBe.tst.ts
+  - skip edge cases
+  + exact optional property types
+  source type
+    - skip is identical to target type
+    - skip is NOT identical to target type
+    - skip is identical to target expression
+    - skip is NOT identical to target expression
+  source expression
+    - skip identical to target type
+    - skip is NOT identical to target type
+    - skip identical to target expression
+    - skip is NOT identical to target expression
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      9 skipped, 1 passed, 10 total
+Assertions: 22 skipped, 4 passed, 26 total
+Duration:   <<timestamp>>
+
+Ran tests matching 'exact' in all test files.

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -1,96 +1,144 @@
+Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
+
+  23 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  24 | 
+  25 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+     |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  26 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  27 | 
+  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+
+       at ./__typetests__/toBe.tst.ts:25:42 ❭ exact optional property types
+
+Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
+
+  24 | 
+  25 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  26 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+     |                                                      ~~~~~~~~~~~~~~
+  27 | 
+  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  29 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+
+       at ./__typetests__/toBe.tst.ts:26:54 ❭ exact optional property types
+
+Error: Type '{ a?: number | undefined; }' is assignable with type '{ a?: number | undefined; }'.
+
+  26 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  27 | 
+  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+     |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  29 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  30 | });
+  31 | 
+
+       at ./__typetests__/toBe.tst.ts:28:56 ❭ exact optional property types
+
+Error: Type '{ a?: number | undefined; }' is assignable to type '{ a?: number | undefined; }'.
+
+  27 | 
+  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  29 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+     |                                                                  ~~~~~~~~~~~~~~
+  30 | });
+  31 | 
+  32 | describe("source type", () => {
+
+       at ./__typetests__/toBe.tst.ts:29:66 ❭ exact optional property types
+
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  25 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
-  26 | 
-  27 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+  35 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
+  36 | 
+  37 |     expect<Names>().type.toBe<{ first: string; last: string }>();
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  28 |   });
-  29 | 
-  30 |   test("is NOT identical to target type", () => {
+  38 |   });
+  39 | 
+  40 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:27:31 ❭ source type ❭ is identical to target type
+       at ./__typetests__/toBe.tst.ts:37:31 ❭ source type ❭ is identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  31 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
-  32 | 
-  33 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+  41 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
+  42 | 
+  43 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  34 |   });
-  35 | 
-  36 |   test("is identical to target expression", () => {
+  44 |   });
+  45 | 
+  46 |   test("is identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:33:35 ❭ source type ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:43:35 ❭ source type ❭ is NOT identical to target type
 
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
-  38 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
-  39 | 
-  40 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+  48 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
+  49 | 
+  50 |     expect<{ first: string; last: string }>().type.toBe(getNames());
      |                                                         ~~~~~~~~~~
-  41 |   });
-  42 | 
-  43 |   test("is NOT identical to target expression", () => {
+  51 |   });
+  52 | 
+  53 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:40:57 ❭ source type ❭ is identical to target expression
+       at ./__typetests__/toBe.tst.ts:50:57 ❭ source type ❭ is identical to target expression
 
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
-  44 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
-  45 | 
-  46 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+  54 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
+  55 | 
+  56 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
      |                                                              ~~~~~~~~~~
-  47 |   });
-  48 | });
-  49 | 
+  57 |   });
+  58 | });
+  59 | 
 
-       at ./__typetests__/toBe.tst.ts:46:62 ❭ source type ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:56:62 ❭ source type ❭ is NOT identical to target expression
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  53 |     expect(getNames()).type.toBe<Names>();
-  54 | 
-  55 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+  63 |     expect(getNames()).type.toBe<Names>();
+  64 | 
+  65 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  56 |   });
-  57 | 
-  58 |   test("is NOT identical to target type", () => {
+  66 |   });
+  67 | 
+  68 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:55:34 ❭ source expression ❭ identical to target type
+       at ./__typetests__/toBe.tst.ts:65:34 ❭ source expression ❭ identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  59 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
-  60 | 
-  61 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+  69 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
+  70 | 
+  71 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  62 |   });
-  63 | 
-  64 |   test("identical to target expression", () => {
+  72 |   });
+  73 | 
+  74 |   test("identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:61:38 ❭ source expression ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:71:38 ❭ source expression ❭ is NOT identical to target type
 
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
-  65 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
-  66 | 
-  67 |     expect({ height: 14 }).type.toBe(getSize());
+  75 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
+  76 | 
+  77 |     expect({ height: 14 }).type.toBe(getSize());
      |                                      ~~~~~~~~~
-  68 |   });
-  69 | 
-  70 |   test("is NOT identical to target expression", () => {
+  78 |   });
+  79 | 
+  80 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:67:38 ❭ source expression ❭ identical to target expression
+       at ./__typetests__/toBe.tst.ts:77:38 ❭ source expression ❭ identical to target expression
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
-  71 |     expect({ height: 14 }).type.not.toBe(getSize());
-  72 | 
-  73 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+  81 |     expect({ height: 14 }).type.not.toBe(getSize());
+  82 | 
+  83 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
      |                                                     ~~~~~~~~~
-  74 |   });
-  75 | });
-  76 | 
+  84 |   });
+  85 | });
+  86 | 
 
-       at ./__typetests__/toBe.tst.ts:73:53 ❭ source expression ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:83:53 ❭ source expression ❭ is NOT identical to target expression
 

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -2,6 +2,7 @@ uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBe.tst.ts
   + edge cases
+  × exact optional property types
   source type
     × is identical to target type
     × is NOT identical to target type
@@ -15,8 +16,8 @@ fail ./__typetests__/toBe.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      8 failed, 1 passed, 9 total
-Assertions: 8 failed, 14 passed, 22 total
+Tests:      9 failed, 1 passed, 10 total
+Assertions: 12 failed, 14 passed, 26 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/api-toBe.test.js
+++ b/tests/api-toBe.test.js
@@ -29,4 +29,21 @@ await test("toBe", async (t) => {
 
     assert.equal(exitCode, 1);
   });
+
+  await t.test("exact optional property types", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [
+      "--only",
+      "exact",
+      "--tsconfig",
+      "./tsconfig-exact.json",
+    ]);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-exact-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
 });


### PR DESCRIPTION
The following must pass when `"exactOptionalPropertyTypes": true` is set:

```ts
import { expect } from "tstyche";

expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
```

---

Related: https://github.com/mmkal/expect-type/issues/128

