### PR TITLE
feat: add the `--list` command line option

### DIFF
--- a/models/CommandLineOptions.ts
+++ b/models/CommandLineOptions.ts
@@ -21,6 +21,10 @@ export interface CommandLineOptions {
      */
     install?: boolean;
     /**
+     * Print the list of supported TypeScript versions and exit.
+     */
+    list?: boolean;
+    /**
      * Print the list of the selected test files and exit.
      */
     listFiles?: boolean;

--- a/models/CommandLineOptions.ts
+++ b/models/CommandLineOptions.ts
@@ -21,7 +21,7 @@ export interface CommandLineOptions {
      */
     install?: boolean;
     /**
-     * Print the list of supported TypeScript versions and exit.
+     * Print the list of supported versions and tags of the 'typescript' package and exit.
      */
     list?: boolean;
     /**

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -38,6 +38,16 @@ export class Cli {
       return;
     }
 
+    if (commandLine.includes("--list")) {
+      const supportedTags = await Store.getSupportedTags();
+
+      if (supportedTags != null) {
+        OutputService.writeMessage(formattedText(supportedTags));
+      }
+
+      return;
+    }
+
     if (commandLine.includes("--prune")) {
       await Store.prune();
 

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -71,6 +71,13 @@ export class Options {
 
     {
       brand: OptionBrand.BareTrue,
+      description: "Print the list of supported TypeScript versions and exit.",
+      group: OptionGroup.CommandLine,
+      name: "list",
+    },
+
+    {
+      brand: OptionBrand.BareTrue,
       description: "Print the list of the selected test files and exit.",
       group: OptionGroup.CommandLine,
       name: "listFiles",

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -71,7 +71,7 @@ export class Options {
 
     {
       brand: OptionBrand.BareTrue,
-      description: "Print the list of supported TypeScript versions and exit.",
+      description: "Print the list of supported versions and tags of the 'typescript' package and exit.",
       group: OptionGroup.CommandLine,
       name: "list",
     },

--- a/tests/__snapshots__/config-help-stdout.snap.txt
+++ b/tests/__snapshots__/config-help-stdout.snap.txt
@@ -25,7 +25,7 @@ Command Line Options
   Install specified versions of the 'typescript' package and exit.
 
   --list
-  Print the list of supported TypeScript versions and exit.
+  Print the list of supported versions and tags of the 'typescript' package and exit.
 
   --listFiles
   Print the list of the selected test files and exit.

--- a/tests/__snapshots__/config-help-stdout.snap.txt
+++ b/tests/__snapshots__/config-help-stdout.snap.txt
@@ -24,6 +24,9 @@ Command Line Options
   --install
   Install specified versions of the 'typescript' package and exit.
 
+  --list
+  Print the list of supported TypeScript versions and exit.
+
   --listFiles
   Print the list of the selected test files and exit.
 

--- a/tests/config-list.test.js
+++ b/tests/config-list.test.js
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBeString();
+});
+`;
+
+const isNumberTestText = `import { expect, test } from "tstyche";
+test("is number?", () => {
+  expect<number>().type.toBeNumber();
+});
+`;
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+const storeUrl = new URL("./.store/", fixtureUrl);
+
+await test("'--list' command line option", async (t) => {
+  t.after(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await writeFixture(fixtureUrl, {
+    ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+    ["__typetests__/isString.tst.ts"]: isStringTestText,
+  });
+
+  await spawnTyche(fixtureUrl, ["--update"]);
+
+  const manifestText = await fs.readFile(new URL("./store-manifest.json", storeUrl), { encoding: "utf8" });
+
+  const { resolutions, versions } = /** @type {{ resolutions: Record<string, string>, versions: Array<string> }} */ (
+    JSON.parse(manifestText)
+  );
+
+  const expected = `${JSON.stringify([...versions, ...Object.keys(resolutions), "current"].sort(), null, 2)}\n`;
+
+  await t.test("lists tags and versions", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--list"]);
+
+    assert.equal(stdout, expected);
+    assert.equal(stderr, "");
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when search string is specified before the option", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["isNumber", "--list"]);
+
+    assert.equal(stdout, expected);
+    assert.equal(stderr, "");
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when search string is specified after the option", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--list", "isString"]);
+
+    assert.equal(stdout, expected);
+    assert.equal(stderr, "");
+
+    assert.equal(exitCode, 0);
+  });
+});


### PR DESCRIPTION
Closes #363

Add the `--list` command line option. It prints out supported TypeScript tags and versions.