### PR TITLE
refactor: make the `--list` command line option more useful

### DIFF
--- a/models/CommandLineOptions.ts
+++ b/models/CommandLineOptions.ts
@@ -21,7 +21,7 @@ export interface CommandLineOptions {
      */
     install?: boolean;
     /**
-     * Print the list of supported versions and tags of the 'typescript' package and exit.
+     * Print the list of tag resolutions and supported versions of the 'typescript' package and exit.
      */
     list?: boolean;
     /**

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -39,10 +39,12 @@ export class Cli {
     }
 
     if (commandLine.includes("--list")) {
-      const supportedTags = await Store.getSupportedTags();
+      await Store.open();
 
-      if (supportedTags != null) {
-        OutputService.writeMessage(formattedText(supportedTags));
+      if (Store.manifest != null) {
+        OutputService.writeMessage(
+          formattedText({ resolutions: Store.manifest.resolutions, versions: Store.manifest.versions }),
+        );
       }
 
       return;

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -71,7 +71,7 @@ export class Options {
 
     {
       brand: OptionBrand.BareTrue,
-      description: "Print the list of supported versions and tags of the 'typescript' package and exit.",
+      description: "Print the list of tag resolutions and supported versions of the 'typescript' package and exit.",
       group: OptionGroup.CommandLine,
       name: "list",
     },

--- a/source/store/Store.ts
+++ b/source/store/Store.ts
@@ -19,7 +19,7 @@ export class Store {
   static #compilerInstanceCache = new Map<string, typeof ts>();
   static #fetcher: Fetcher;
   static #lockService: LockService;
-  static #manifest: Manifest | undefined;
+  static manifest: Manifest | undefined;
   static #manifestService: ManifestService;
   static #packageService: PackageService;
   static #npmRegistry = environmentOptions.npmRegistry;
@@ -48,7 +48,7 @@ export class Store {
 
     await Store.open();
 
-    const version = Store.#manifest?.resolve(tag);
+    const version = Store.manifest?.resolve(tag);
 
     if (!version) {
       Store.#onDiagnostics(Diagnostic.error(StoreDiagnosticText.cannotAddTypeScriptPackage(tag)));
@@ -56,7 +56,7 @@ export class Store {
       return;
     }
 
-    await Store.#packageService.ensure(version, Store.#manifest);
+    await Store.#packageService.ensure(version, Store.manifest);
   }
 
   static async load(tag: string): Promise<typeof ts | undefined> {
@@ -73,7 +73,7 @@ export class Store {
     } else {
       await Store.open();
 
-      const version = Store.#manifest?.resolve(tag);
+      const version = Store.manifest?.resolve(tag);
 
       if (!version) {
         Store.#onDiagnostics(Diagnostic.error(StoreDiagnosticText.cannotAddTypeScriptPackage(tag)));
@@ -87,7 +87,7 @@ export class Store {
         return compilerInstance;
       }
 
-      const packagePath = await Store.#packageService.ensure(version, Store.#manifest);
+      const packagePath = await Store.#packageService.ensure(version, Store.manifest);
 
       if (packagePath != null) {
         modulePath = Path.join(packagePath, "lib", "typescript.js");
@@ -156,14 +156,10 @@ export class Store {
     // ensure '.open()' can only be called once
     Store.open = () => Promise.resolve();
 
-    Store.#manifest = await Store.#manifestService.open();
+    Store.manifest = await Store.#manifestService.open();
 
-    if (Store.#manifest != null) {
-      Store.#supportedTags = [
-        ...Object.keys(Store.#manifest.resolutions),
-        ...Store.#manifest.versions,
-        "current",
-      ].sort();
+    if (Store.manifest != null) {
+      Store.#supportedTags = [...Object.keys(Store.manifest.resolutions), ...Store.manifest.versions, "current"].sort();
     }
   }
 
@@ -183,10 +179,10 @@ export class Store {
     await Store.open();
 
     if (
-      Store.#manifest?.isOutdated({ ageTolerance: 60 /* one minute */ }) &&
+      Store.manifest?.isOutdated({ ageTolerance: 60 /* one minute */ }) &&
       (!Version.isVersionTag(tag) ||
-        (Store.#manifest.resolutions["latest"] != null &&
-          Version.isGreaterThan(tag, Store.#manifest.resolutions["latest"])))
+        (Store.manifest.resolutions["latest"] != null &&
+          Version.isGreaterThan(tag, Store.manifest.resolutions["latest"])))
     ) {
       Store.#onDiagnostics(
         Diagnostic.warning([

--- a/tests/__snapshots__/config-help-stdout.snap.txt
+++ b/tests/__snapshots__/config-help-stdout.snap.txt
@@ -25,7 +25,7 @@ Command Line Options
   Install specified versions of the 'typescript' package and exit.
 
   --list
-  Print the list of supported versions and tags of the 'typescript' package and exit.
+  Print the list of tag resolutions and supported versions of the 'typescript' package and exit.
 
   --listFiles
   Print the list of the selected test files and exit.

--- a/tests/config-list.test.js
+++ b/tests/config-list.test.js
@@ -38,7 +38,7 @@ await test("'--list' command line option", async (t) => {
     JSON.parse(manifestText)
   );
 
-  const expected = `${JSON.stringify([...versions, ...Object.keys(resolutions), "current"].sort(), null, 2)}\n`;
+  const expected = `${JSON.stringify({ resolutions, versions }, null, 2)}\n`;
 
   await t.test("lists tags and versions", async () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--list"]);


### PR DESCRIPTION
This PR makes the `--list` command line option more useful. It will print tag resolutions and supported versions. To have more details is always good idea.