### PR TITLE
fix: make assignability matchers protect against `any`, `never` or `unknown`

### DIFF
--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -3,6 +3,10 @@ export class ExpectDiagnosticText {
     return `An argument for '${argumentNameText}' or type argument for '${typeArgumentNameText}' must be provided.`;
   }
 
+  static argumentCannotBeOfType(argumentNameText: string, typeText: string): string {
+    return `An argument for '${argumentNameText}' cannot be of the '${typeText}' type.`;
+  }
+
   static argumentMustBe(argumentNameText: string, expectedText: string): string {
     return `An argument for '${argumentNameText}' must be ${expectedText}.`;
   }
@@ -36,6 +40,10 @@ export class ExpectDiagnosticText {
 
   static raisedTypeError(count = 1): string {
     return `The raised type error${count === 1 ? "" : "s"}:`;
+  }
+
+  static typeArgumentCannotBeOfType(argumentNameText: string, typeText: string): string {
+    return `A type argument for '${argumentNameText}' cannot be of the '${typeText}' type.`;
   }
 
   static typeArgumentMustBe(argumentNameText: string, expectedText: string): string {
@@ -118,5 +126,11 @@ export class ExpectDiagnosticText {
 
   static typesOfPropertyAreNotCompatible(propertyNameText: string): string {
     return `Types of property '${propertyNameText}' are not compatible.`;
+  }
+
+  static usePrimitiveTypeMatcher(typeText: string): string {
+    const matcherNameText = `.toBe${typeText.charAt(0).toUpperCase()}${typeText.slice(1)}()`;
+
+    return `If this check is necessary, use the '${matcherNameText}' matcher instead.`;
   }
 }

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -43,10 +43,10 @@ export class ExpectService {
     this.#typeChecker = typeChecker;
 
     this.toAcceptProps = new ToAcceptProps(compiler, typeChecker);
-    this.toBe = new ToBe();
+    this.toBe = new ToBe(compiler);
     this.toBeAny = new PrimitiveTypeMatcher(compiler.TypeFlags.Any);
-    this.toBeAssignableTo = new ToBeAssignableTo();
-    this.toBeAssignableWith = new ToBeAssignableWith();
+    this.toBeAssignableTo = new ToBeAssignableTo(compiler);
+    this.toBeAssignableWith = new ToBeAssignableWith(compiler);
     this.toBeBigInt = new PrimitiveTypeMatcher(compiler.TypeFlags.BigInt);
     this.toBeBoolean = new PrimitiveTypeMatcher(compiler.TypeFlags.Boolean);
     this.toBeNever = new PrimitiveTypeMatcher(compiler.TypeFlags.Never);
@@ -59,7 +59,7 @@ export class ExpectService {
     this.toBeUnknown = new PrimitiveTypeMatcher(compiler.TypeFlags.Unknown);
     this.toBeVoid = new PrimitiveTypeMatcher(compiler.TypeFlags.Void);
     this.toHaveProperty = new ToHaveProperty(compiler);
-    this.toMatch = new ToMatch();
+    this.toMatch = new ToMatch(compiler);
     this.toRaiseError = new ToRaiseError(compiler);
   }
 

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -147,7 +147,7 @@ export class MatchWorker {
     return type;
   }
 
-  isAnyOrNeverType(type: ts.Type): type is ts.StringLiteralType | ts.NumberLiteralType {
+  isAnyOrNeverType(type: ts.Type) {
     return !!(type.flags & (this.#compiler.TypeFlags.Any | this.#compiler.TypeFlags.Never));
   }
 

--- a/source/expect/RelationMatcherBase.ts
+++ b/source/expect/RelationMatcherBase.ts
@@ -1,8 +1,15 @@
-import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
+import type ts from "typescript";
+import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
 import type { MatchWorker } from "./MatchWorker.js";
 import type { ArgumentNode, MatchResult } from "./types.js";
 
 export abstract class RelationMatcherBase {
+  protected compiler: typeof ts;
+
+  constructor(compiler: typeof ts) {
+    this.compiler = compiler;
+  }
+
   abstract explainText(sourceTypeText: string, targetTypeText: string): string;
   abstract explainNotText(sourceTypeText: string, targetTypeText: string): string;
 
@@ -19,5 +26,10 @@ export abstract class RelationMatcherBase {
     return [Diagnostic.error(text, origin)];
   }
 
-  abstract match(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNode: ArgumentNode): MatchResult;
+  abstract match(
+    matchWorker: MatchWorker,
+    sourceNode: ArgumentNode,
+    targetNode: ArgumentNode,
+    onDiagnostics?: DiagnosticsHandler<Array<Diagnostic>>,
+  ): MatchResult | undefined;
 }

--- a/source/expect/ToBeAssignableTo.ts
+++ b/source/expect/ToBeAssignableTo.ts
@@ -1,3 +1,4 @@
+import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchWorker } from "./MatchWorker.js";
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
@@ -7,7 +8,93 @@ export class ToBeAssignableTo extends RelationMatcherBase {
   explainText = ExpectDiagnosticText.typeIsAssignableTo;
   explainNotText = ExpectDiagnosticText.typeIsNotAssignableTo;
 
-  match(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNode: ArgumentNode): MatchResult {
+  match(
+    matchWorker: MatchWorker,
+    sourceNode: ArgumentNode,
+    targetNode: ArgumentNode,
+    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
+  ): MatchResult | undefined {
+    const diagnostics: Array<Diagnostic> = [];
+
+    const sourceType = matchWorker.getType(sourceNode);
+    const targetType = matchWorker.getType(targetNode);
+
+    if (
+      !matchWorker.assertion.isNot &&
+      sourceType.flags & (this.compiler.TypeFlags.Any | this.compiler.TypeFlags.Never)
+    ) {
+      const typeText = matchWorker.getTypeText(sourceNode);
+
+      const text = [
+        this.compiler.isTypeNode(sourceNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Source", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("source", typeText),
+        `The '${typeText}' type is assignable to every type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(sourceNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (matchWorker.assertion.isNot && sourceType.flags & this.compiler.TypeFlags.Unknown) {
+      const typeText = matchWorker.getTypeText(sourceNode);
+
+      const text = [
+        this.compiler.isTypeNode(sourceNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Source", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("source", typeText),
+        `The '${typeText}' type is not assignable to every type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(sourceNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (
+      !matchWorker.assertion.isNot &&
+      targetType.flags & (this.compiler.TypeFlags.Any | this.compiler.TypeFlags.Unknown)
+    ) {
+      const typeText = matchWorker.getTypeText(targetNode);
+
+      const text = [
+        this.compiler.isTypeNode(targetNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Target", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("target", typeText),
+        `Every type is assignable to the '${typeText}' type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(targetNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (matchWorker.assertion.isNot && targetType.flags & this.compiler.TypeFlags.Never) {
+      const typeText = matchWorker.getTypeText(targetNode);
+
+      const text = [
+        this.compiler.isTypeNode(targetNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Target", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("target", typeText),
+        `Every type is not assignable to the '${typeText}' type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(targetNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (diagnostics.length > 0) {
+      onDiagnostics(diagnostics);
+
+      return;
+    }
+
     return {
       explain: () => this.explain(matchWorker, sourceNode, targetNode),
       isMatch: matchWorker.checkIsAssignableTo(sourceNode, targetNode),

--- a/source/expect/ToBeAssignableWith.ts
+++ b/source/expect/ToBeAssignableWith.ts
@@ -1,3 +1,4 @@
+import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchWorker } from "./MatchWorker.js";
 import { RelationMatcherBase } from "./RelationMatcherBase.js";
@@ -7,7 +8,93 @@ export class ToBeAssignableWith extends RelationMatcherBase {
   explainText = ExpectDiagnosticText.typeIsAssignableWith;
   explainNotText = ExpectDiagnosticText.typeIsNotAssignableWith;
 
-  match(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNode: ArgumentNode): MatchResult {
+  match(
+    matchWorker: MatchWorker,
+    sourceNode: ArgumentNode,
+    targetNode: ArgumentNode,
+    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
+  ): MatchResult | undefined {
+    const diagnostics: Array<Diagnostic> = [];
+
+    const sourceType = matchWorker.getType(sourceNode);
+    const targetType = matchWorker.getType(targetNode);
+
+    if (
+      !matchWorker.assertion.isNot &&
+      sourceType.flags & (this.compiler.TypeFlags.Any | this.compiler.TypeFlags.Unknown)
+    ) {
+      const typeText = matchWorker.getTypeText(sourceNode);
+
+      const text = [
+        this.compiler.isTypeNode(sourceNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Source", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("source", typeText),
+        `The '${typeText}' type is assignable with every type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(sourceNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (matchWorker.assertion.isNot && sourceType.flags & this.compiler.TypeFlags.Never) {
+      const typeText = matchWorker.getTypeText(sourceNode);
+
+      const text = [
+        this.compiler.isTypeNode(sourceNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Source", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("source", typeText),
+        `The '${typeText}' type is not assignable with every type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(sourceNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (
+      !matchWorker.assertion.isNot &&
+      targetType.flags & (this.compiler.TypeFlags.Any | this.compiler.TypeFlags.Never)
+    ) {
+      const typeText = matchWorker.getTypeText(targetNode);
+
+      const text = [
+        this.compiler.isTypeNode(targetNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Target", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("target", typeText),
+        `Every type is assignable with the '${typeText}' type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(targetNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (matchWorker.assertion.isNot && targetType.flags & this.compiler.TypeFlags.Unknown) {
+      const typeText = matchWorker.getTypeText(targetNode);
+
+      const text = [
+        this.compiler.isTypeNode(targetNode)
+          ? ExpectDiagnosticText.typeArgumentCannotBeOfType("Target", typeText)
+          : ExpectDiagnosticText.argumentCannotBeOfType("target", typeText),
+        `Every type is not assignable with the '${typeText}' type.`,
+        ExpectDiagnosticText.usePrimitiveTypeMatcher(typeText),
+      ];
+
+      const origin = DiagnosticOrigin.fromNode(targetNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    }
+
+    if (diagnostics.length > 0) {
+      onDiagnostics(diagnostics);
+
+      return;
+    }
+
     return {
       explain: () => this.explain(matchWorker, sourceNode, targetNode),
       isMatch: matchWorker.checkIsAssignableWith(sourceNode, targetNode),

--- a/tests/__fixtures__/api-toMatch/__typetests__/toMatch.tst.ts
+++ b/tests/__fixtures__/api-toMatch/__typetests__/toMatch.tst.ts
@@ -18,7 +18,7 @@ interface Size {
 declare function getSize(): Size;
 
 test("difference from '.toBeAssignableTo()'", () => {
-  expect<any>().type.toBeAssignableTo<string>();
+  expect<any>().type.toBeAssignableTo<string>(); // fails, because TSTyche does not allow 'any' as 'Source' type
   // But all types are not subtypes of the 'any' type
   expect<any>().type.not.toMatch<string>();
 

--- a/tests/__fixtures__/validation-toBeAssignableTo/__typetests__/toBeAssignableTo.tst.ts
+++ b/tests/__fixtures__/validation-toBeAssignableTo/__typetests__/toBeAssignableTo.tst.ts
@@ -4,10 +4,58 @@ describe("argument for 'source'", () => {
   test("must be provided", () => {
     expect().type.toBeAssignableTo<{ test: void }>();
   });
+
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+    expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+
+    expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+    expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+
+    expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+    expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+  });
+});
+
+describe("type argument for 'Source'", () => {
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+    expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+
+    expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+    expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+
+    expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+    expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+  });
 });
 
 describe("argument for 'target'", () => {
   test("must be provided", () => {
     expect<{ test: void }>().type.toBeAssignableTo();
+  });
+
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<{ a: number }>().type.toBeAssignableTo({} as any); // use '.toBeAny()'
+    expect<{ a: number }>().type.not.toBeAssignableTo({} as any);
+
+    expect<{ a: number }>().type.toBeAssignableTo({} as unknown); // use '.toBeUnknown()'
+    expect<{ a: number }>().type.not.toBeAssignableTo({} as unknown);
+
+    expect<{ a: number }>().type.not.toBeAssignableTo({} as never); // use '.toBeNever()'
+    expect<{ a: number }>().type.toBeAssignableTo({} as never);
+  });
+});
+
+describe("type argument for 'Target'", () => {
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<{ a: number }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+    expect<{ a: number }>().type.not.toBeAssignableTo<any>();
+
+    expect<{ a: number }>().type.toBeAssignableTo<unknown>(); // use '.toBeUnknown()'
+    expect<{ a: number }>().type.not.toBeAssignableTo<unknown>();
+
+    expect<{ a: number }>().type.not.toBeAssignableTo<never>(); // use '.toBeNever()'
+    expect<{ a: number }>().type.toBeAssignableTo<never>();
   });
 });

--- a/tests/__fixtures__/validation-toBeAssignableWith/__typetests__/toBeAssignableWith.tst.ts
+++ b/tests/__fixtures__/validation-toBeAssignableWith/__typetests__/toBeAssignableWith.tst.ts
@@ -4,10 +4,58 @@ describe("argument for 'source'", () => {
   test("must be provided", () => {
     expect().type.toBeAssignableWith<{ test: void }>();
   });
+
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+    expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+
+    expect({} as never).type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+    expect({} as never).type.not.toBeAssignableTo<{ a: number }>();
+
+    expect({} as unknown).type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+    expect({} as unknown).type.toBeAssignableTo<{ a: number }>();
+  });
+});
+
+describe("type argument for 'Source'", () => {
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+    expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+
+    expect<unknown>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeUnknown()'
+    expect<unknown>().type.not.toBeAssignableWith<{ a: number }>();
+
+    expect<never>().type.not.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+    expect<never>().type.toBeAssignableWith<{ a: number }>();
+  });
 });
 
 describe("argument for 'target'", () => {
   test("must be provided", () => {
     expect<{ test: void }>().type.toBeAssignableWith();
+  });
+
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<{ a: number }>().type.toBeAssignableWith({} as any); // use '.toBeAny()'
+    expect<{ a: number }>().type.not.toBeAssignableWith({} as any);
+
+    expect<{ a: number }>().type.toBeAssignableWith({} as never); // use '.toBeNever()'
+    expect<{ a: number }>().type.not.toBeAssignableWith({} as never);
+
+    expect<{ a: string }>().type.not.toBeAssignableWith({} as unknown); // use '.toBeUnknown()'
+    expect<{ a: string }>().type.toBeAssignableWith({} as unknown);
+  });
+});
+
+describe("type argument for 'Target'", () => {
+  test("cannot be of type 'any', 'never' or 'unknown'", () => {
+    expect<{ a: number }>().type.toBeAssignableWith<any>(); // use '.toBeAny()'
+    expect<{ a: number }>().type.not.toBeAssignableWith<any>();
+
+    expect<{ a: number }>().type.toBeAssignableWith<never>(); // use '.toBeNever()'
+    expect<{ a: number }>().type.not.toBeAssignableWith<never>();
+
+    expect<{ a: string }>().type.not.toBeAssignableWith<unknown>(); // use '.toBeUnknown()'
+    expect<{ a: string }>().type.toBeAssignableWith<unknown>();
   });
 });

--- a/tests/__snapshots__/api-toMatch-stderr.snap.txt
+++ b/tests/__snapshots__/api-toMatch-stderr.snap.txt
@@ -1,8 +1,23 @@
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type is assignable to every type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  19 | 
+  20 | test("difference from '.toBeAssignableTo()'", () => {
+  21 |   expect<any>().type.toBeAssignableTo<string>(); // fails, because TSTyche does not allow 'any' as 'Source' type
+     |          ~~~
+  22 |   // But all types are not subtypes of the 'any' type
+  23 |   expect<any>().type.not.toMatch<string>();
+  24 | 
+
+       at ./__typetests__/toMatch.tst.ts:21:10
+
 Warning: The '.toMatch()' matcher is deprecated and will be removed in TSTyche 4.
 
 To learn more, visit https://tstyche.org/releases/tstyche-3
 
-  21 |   expect<any>().type.toBeAssignableTo<string>();
+  21 |   expect<any>().type.toBeAssignableTo<string>(); // fails, because TSTyche does not allow 'any' as 'Source' type
   22 |   // But all types are not subtypes of the 'any' type
   23 |   expect<any>().type.not.toMatch<string>();
      |                          ~~~~~~~

--- a/tests/__snapshots__/api-toMatch-stdout.snap.txt
+++ b/tests/__snapshots__/api-toMatch-stdout.snap.txt
@@ -1,7 +1,7 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toMatch.tst.ts
-  + difference from '.toBeAssignableTo()'
+  × difference from '.toBeAssignableTo()'
   received type
     × matches expected type
     × does NOT match expected type
@@ -15,8 +15,8 @@ fail ./__typetests__/toMatch.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      8 failed, 1 passed, 9 total
-Assertions: 8 failed, 30 passed, 38 total
+Tests:      9 failed, 9 total
+Assertions: 9 failed, 29 passed, 38 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/__snapshots__/validation-toBeAssignableTo-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableTo-stderr.snap.txt
@@ -5,20 +5,344 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
   5 |     expect().type.toBeAssignableTo<{ test: void }>();
     |     ~~~~~~
   6 |   });
-  7 | });
-  8 | 
+  7 | 
+  8 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
 
       at ./__typetests__/toBeAssignableTo.tst.ts:5:5
 
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type is assignable to every type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+   7 | 
+   8 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+   9 |     expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+     |            ~~~
+  10 |     expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+  11 | 
+  12 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:9:12
+
+Error: Type 'any' is assignable to type '{ a: number; }'.
+
+   8 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+   9 |     expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+  10 |     expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+     |                                             ~~~~~~~~~~~~~
+  11 | 
+  12 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+  13 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:10:45 ❭ argument for 'source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'never' type.
+
+The 'never' type is assignable to every type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  10 |     expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+  11 | 
+  12 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+     |            ~~~~~
+  13 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+  14 | 
+  15 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:12:12
+
+Error: Type 'never' is assignable to type '{ a: number; }'.
+
+  11 | 
+  12 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+  13 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+     |                                               ~~~~~~~~~~~~~
+  14 | 
+  15 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+  16 |     expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:13:47 ❭ argument for 'source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'unknown' type.
+
+The 'unknown' type is not assignable to every type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  13 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+  14 | 
+  15 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+     |            ~~~~~~~
+  16 |     expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+  17 |   });
+  18 | });
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:15:12
+
+Error: Type 'unknown' is not assignable to type '{ a: number; }'.
+
+  14 | 
+  15 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+  16 |     expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+     |                                             ~~~~~~~~~~~~~
+  17 |   });
+  18 | });
+  19 | 
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:16:45 ❭ argument for 'source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type is assignable to every type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  20 | describe("type argument for 'Source'", () => {
+  21 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  22 |     expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+     |            ~~~
+  23 |     expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+  24 | 
+  25 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:22:12
+
+Error: Type 'any' is assignable to type '{ a: number; }'.
+
+  21 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  22 |     expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+  23 |     expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+     |                                             ~~~~~~~~~~~~~
+  24 | 
+  25 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+  26 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:23:45 ❭ type argument for 'Source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'never' type.
+
+The 'never' type is assignable to every type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  23 |     expect<any>().type.not.toBeAssignableTo<{ a: number }>();
+  24 | 
+  25 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+     |            ~~~~~
+  26 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+  27 | 
+  28 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:25:12
+
+Error: Type 'never' is assignable to type '{ a: number; }'.
+
+  24 | 
+  25 |     expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+  26 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+     |                                               ~~~~~~~~~~~~~
+  27 | 
+  28 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+  29 |     expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:26:47 ❭ type argument for 'Source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'unknown' type.
+
+The 'unknown' type is not assignable to every type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  26 |     expect<never>().type.not.toBeAssignableTo<{ a: number }>();
+  27 | 
+  28 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+     |            ~~~~~~~
+  29 |     expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+  30 |   });
+  31 | });
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:28:12
+
+Error: Type 'unknown' is not assignable to type '{ a: number; }'.
+
+  27 | 
+  28 |     expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+  29 |     expect<unknown>().type.toBeAssignableTo<{ a: number }>();
+     |                                             ~~~~~~~~~~~~~
+  30 |   });
+  31 | });
+  32 | 
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:29:45 ❭ type argument for 'Source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
 Error: An argument for 'target' or type argument for 'Target' must be provided.
 
-   9 | describe("argument for 'target'", () => {
-  10 |   test("must be provided", () => {
-  11 |     expect<{ test: void }>().type.toBeAssignableTo();
+  33 | describe("argument for 'target'", () => {
+  34 |   test("must be provided", () => {
+  35 |     expect<{ test: void }>().type.toBeAssignableTo();
      |                                   ~~~~~~~~~~~~~~~~
-  12 |   });
-  13 | });
-  14 | 
+  36 |   });
+  37 | 
+  38 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
 
-       at ./__typetests__/toBeAssignableTo.tst.ts:11:35
+       at ./__typetests__/toBeAssignableTo.tst.ts:35:35
+
+Error: An argument for 'target' cannot be of the 'any' type.
+
+Every type is assignable to the 'any' type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  37 | 
+  38 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  39 |     expect<{ a: number }>().type.toBeAssignableTo({} as any); // use '.toBeAny()'
+     |                                                   ~~~~~~~~~
+  40 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as any);
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableTo({} as unknown); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:39:51
+
+Error: Type '{ a: number; }' is assignable to type 'any'.
+
+  38 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  39 |     expect<{ a: number }>().type.toBeAssignableTo({} as any); // use '.toBeAny()'
+  40 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as any);
+     |                                                       ~~~~~~~~~
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableTo({} as unknown); // use '.toBeUnknown()'
+  43 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as unknown);
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:40:55 ❭ argument for 'target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: An argument for 'target' cannot be of the 'unknown' type.
+
+Every type is assignable to the 'unknown' type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  40 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as any);
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableTo({} as unknown); // use '.toBeUnknown()'
+     |                                                   ~~~~~~~~~~~~~
+  43 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as unknown);
+  44 | 
+  45 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as never); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:42:51
+
+Error: Type '{ a: number; }' is assignable to type 'unknown'.
+
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableTo({} as unknown); // use '.toBeUnknown()'
+  43 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as unknown);
+     |                                                       ~~~~~~~~~~~~~
+  44 | 
+  45 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as never); // use '.toBeNever()'
+  46 |     expect<{ a: number }>().type.toBeAssignableTo({} as never);
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:43:55 ❭ argument for 'target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: An argument for 'target' cannot be of the 'never' type.
+
+Every type is not assignable to the 'never' type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  43 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as unknown);
+  44 | 
+  45 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as never); // use '.toBeNever()'
+     |                                                       ~~~~~~~~~~~
+  46 |     expect<{ a: number }>().type.toBeAssignableTo({} as never);
+  47 |   });
+  48 | });
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:45:55
+
+Error: Type '{ a: number; }' is not assignable to type 'never'.
+
+  44 | 
+  45 |     expect<{ a: number }>().type.not.toBeAssignableTo({} as never); // use '.toBeNever()'
+  46 |     expect<{ a: number }>().type.toBeAssignableTo({} as never);
+     |                                                   ~~~~~~~~~~~
+  47 |   });
+  48 | });
+  49 | 
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:46:51 ❭ argument for 'target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Target' cannot be of the 'any' type.
+
+Every type is assignable to the 'any' type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  50 | describe("type argument for 'Target'", () => {
+  51 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  52 |     expect<{ a: number }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+     |                                                   ~~~
+  53 |     expect<{ a: number }>().type.not.toBeAssignableTo<any>();
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableTo<unknown>(); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:52:51
+
+Error: Type '{ a: number; }' is assignable to type 'any'.
+
+  51 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  52 |     expect<{ a: number }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+  53 |     expect<{ a: number }>().type.not.toBeAssignableTo<any>();
+     |                                                       ~~~
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableTo<unknown>(); // use '.toBeUnknown()'
+  56 |     expect<{ a: number }>().type.not.toBeAssignableTo<unknown>();
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:53:55 ❭ type argument for 'Target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Target' cannot be of the 'unknown' type.
+
+Every type is assignable to the 'unknown' type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  53 |     expect<{ a: number }>().type.not.toBeAssignableTo<any>();
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableTo<unknown>(); // use '.toBeUnknown()'
+     |                                                   ~~~~~~~
+  56 |     expect<{ a: number }>().type.not.toBeAssignableTo<unknown>();
+  57 | 
+  58 |     expect<{ a: number }>().type.not.toBeAssignableTo<never>(); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:55:51
+
+Error: Type '{ a: number; }' is assignable to type 'unknown'.
+
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableTo<unknown>(); // use '.toBeUnknown()'
+  56 |     expect<{ a: number }>().type.not.toBeAssignableTo<unknown>();
+     |                                                       ~~~~~~~
+  57 | 
+  58 |     expect<{ a: number }>().type.not.toBeAssignableTo<never>(); // use '.toBeNever()'
+  59 |     expect<{ a: number }>().type.toBeAssignableTo<never>();
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:56:55 ❭ type argument for 'Target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Target' cannot be of the 'never' type.
+
+Every type is not assignable to the 'never' type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  56 |     expect<{ a: number }>().type.not.toBeAssignableTo<unknown>();
+  57 | 
+  58 |     expect<{ a: number }>().type.not.toBeAssignableTo<never>(); // use '.toBeNever()'
+     |                                                       ~~~~~
+  59 |     expect<{ a: number }>().type.toBeAssignableTo<never>();
+  60 |   });
+  61 | });
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:58:55
+
+Error: Type '{ a: number; }' is not assignable to type 'never'.
+
+  57 | 
+  58 |     expect<{ a: number }>().type.not.toBeAssignableTo<never>(); // use '.toBeNever()'
+  59 |     expect<{ a: number }>().type.toBeAssignableTo<never>();
+     |                                                   ~~~~~
+  60 |   });
+  61 | });
+  62 | 
+
+       at ./__typetests__/toBeAssignableTo.tst.ts:59:51 ❭ type argument for 'Target' ❭ cannot be of type 'any', 'never' or 'unknown'
 

--- a/tests/__snapshots__/validation-toBeAssignableTo-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableTo-stdout.snap.txt
@@ -3,13 +3,19 @@ uses TypeScript <<version>> with ./tsconfig.json
 fail ./__typetests__/toBeAssignableTo.tst.ts
   argument for 'source'
     × must be provided
+    × cannot be of type 'any', 'never' or 'unknown'
+  type argument for 'Source'
+    × cannot be of type 'any', 'never' or 'unknown'
   argument for 'target'
     × must be provided
+    × cannot be of type 'any', 'never' or 'unknown'
+  type argument for 'Target'
+    × cannot be of type 'any', 'never' or 'unknown'
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      2 failed, 2 total
-Assertions: 2 failed, 2 total
+Tests:      6 failed, 6 total
+Assertions: 26 failed, 26 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/__snapshots__/validation-toBeAssignableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableWith-stderr.snap.txt
@@ -5,20 +5,344 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
   5 |     expect().type.toBeAssignableWith<{ test: void }>();
     |     ~~~~~~
   6 |   });
-  7 | });
-  8 | 
+  7 | 
+  8 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
 
       at ./__typetests__/toBeAssignableWith.tst.ts:5:5
 
+Error: An argument for 'source' cannot be of the 'any' type.
+
+The 'any' type is assignable to every type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+   7 | 
+   8 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+   9 |     expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+     |            ~~~~~~~~~
+  10 |     expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+  11 | 
+  12 |     expect({} as never).type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:9:12
+
+Error: Type 'any' is assignable to type '{ a: number; }'.
+
+   8 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+   9 |     expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+  10 |     expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+     |                                                 ~~~~~~~~~~~~~
+  11 | 
+  12 |     expect({} as never).type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+  13 |     expect({} as never).type.not.toBeAssignableTo<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:10:49 ❭ argument for 'source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: An argument for 'source' cannot be of the 'never' type.
+
+The 'never' type is assignable to every type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  10 |     expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+  11 | 
+  12 |     expect({} as never).type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+     |            ~~~~~~~~~~~
+  13 |     expect({} as never).type.not.toBeAssignableTo<{ a: number }>();
+  14 | 
+  15 |     expect({} as unknown).type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:12:12
+
+Error: Type 'never' is assignable to type '{ a: number; }'.
+
+  11 | 
+  12 |     expect({} as never).type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'
+  13 |     expect({} as never).type.not.toBeAssignableTo<{ a: number }>();
+     |                                                   ~~~~~~~~~~~~~
+  14 | 
+  15 |     expect({} as unknown).type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+  16 |     expect({} as unknown).type.toBeAssignableTo<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:13:51 ❭ argument for 'source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: An argument for 'source' cannot be of the 'unknown' type.
+
+The 'unknown' type is not assignable to every type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  13 |     expect({} as never).type.not.toBeAssignableTo<{ a: number }>();
+  14 | 
+  15 |     expect({} as unknown).type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+     |            ~~~~~~~~~~~~~
+  16 |     expect({} as unknown).type.toBeAssignableTo<{ a: number }>();
+  17 |   });
+  18 | });
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:15:12
+
+Error: Type 'unknown' is not assignable to type '{ a: number; }'.
+
+  14 | 
+  15 |     expect({} as unknown).type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'
+  16 |     expect({} as unknown).type.toBeAssignableTo<{ a: number }>();
+     |                                                 ~~~~~~~~~~~~~
+  17 |   });
+  18 | });
+  19 | 
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:16:49 ❭ argument for 'source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type is assignable with every type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  20 | describe("type argument for 'Source'", () => {
+  21 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  22 |     expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+     |            ~~~
+  23 |     expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+  24 | 
+  25 |     expect<unknown>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:22:12
+
+Error: Type 'any' is assignable with type '{ a: number; }'.
+
+  21 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  22 |     expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+  23 |     expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+     |                                               ~~~~~~~~~~~~~
+  24 | 
+  25 |     expect<unknown>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeUnknown()'
+  26 |     expect<unknown>().type.not.toBeAssignableWith<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:23:47 ❭ type argument for 'Source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'unknown' type.
+
+The 'unknown' type is assignable with every type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  23 |     expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+  24 | 
+  25 |     expect<unknown>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeUnknown()'
+     |            ~~~~~~~
+  26 |     expect<unknown>().type.not.toBeAssignableWith<{ a: number }>();
+  27 | 
+  28 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:25:12
+
+Error: Type 'unknown' is assignable with type '{ a: number; }'.
+
+  24 | 
+  25 |     expect<unknown>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeUnknown()'
+  26 |     expect<unknown>().type.not.toBeAssignableWith<{ a: number }>();
+     |                                                   ~~~~~~~~~~~~~
+  27 | 
+  28 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+  29 |     expect<never>().type.toBeAssignableWith<{ a: number }>();
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:26:51 ❭ type argument for 'Source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Source' cannot be of the 'never' type.
+
+The 'never' type is not assignable with every type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  26 |     expect<unknown>().type.not.toBeAssignableWith<{ a: number }>();
+  27 | 
+  28 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+     |            ~~~~~
+  29 |     expect<never>().type.toBeAssignableWith<{ a: number }>();
+  30 |   });
+  31 | });
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:28:12
+
+Error: Type 'never' is not assignable with type '{ a: number; }'.
+
+  27 | 
+  28 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+  29 |     expect<never>().type.toBeAssignableWith<{ a: number }>();
+     |                                             ~~~~~~~~~~~~~
+  30 |   });
+  31 | });
+  32 | 
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:29:45 ❭ type argument for 'Source' ❭ cannot be of type 'any', 'never' or 'unknown'
+
 Error: An argument for 'target' or type argument for 'Target' must be provided.
 
-   9 | describe("argument for 'target'", () => {
-  10 |   test("must be provided", () => {
-  11 |     expect<{ test: void }>().type.toBeAssignableWith();
+  33 | describe("argument for 'target'", () => {
+  34 |   test("must be provided", () => {
+  35 |     expect<{ test: void }>().type.toBeAssignableWith();
      |                                   ~~~~~~~~~~~~~~~~~~
-  12 |   });
-  13 | });
-  14 | 
+  36 |   });
+  37 | 
+  38 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
 
-       at ./__typetests__/toBeAssignableWith.tst.ts:11:35
+       at ./__typetests__/toBeAssignableWith.tst.ts:35:35
+
+Error: An argument for 'target' cannot be of the 'any' type.
+
+Every type is assignable with the 'any' type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  37 | 
+  38 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  39 |     expect<{ a: number }>().type.toBeAssignableWith({} as any); // use '.toBeAny()'
+     |                                                     ~~~~~~~~~
+  40 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as any);
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableWith({} as never); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:39:53
+
+Error: Type '{ a: number; }' is assignable with type 'any'.
+
+  38 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  39 |     expect<{ a: number }>().type.toBeAssignableWith({} as any); // use '.toBeAny()'
+  40 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as any);
+     |                                                         ~~~~~~~~~
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableWith({} as never); // use '.toBeNever()'
+  43 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as never);
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:40:57 ❭ argument for 'target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: An argument for 'target' cannot be of the 'never' type.
+
+Every type is assignable with the 'never' type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  40 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as any);
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableWith({} as never); // use '.toBeNever()'
+     |                                                     ~~~~~~~~~~~
+  43 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as never);
+  44 | 
+  45 |     expect<{ a: string }>().type.not.toBeAssignableWith({} as unknown); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:42:53
+
+Error: Type '{ a: number; }' is assignable with type 'never'.
+
+  41 | 
+  42 |     expect<{ a: number }>().type.toBeAssignableWith({} as never); // use '.toBeNever()'
+  43 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as never);
+     |                                                         ~~~~~~~~~~~
+  44 | 
+  45 |     expect<{ a: string }>().type.not.toBeAssignableWith({} as unknown); // use '.toBeUnknown()'
+  46 |     expect<{ a: string }>().type.toBeAssignableWith({} as unknown);
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:43:57 ❭ argument for 'target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: An argument for 'target' cannot be of the 'unknown' type.
+
+Every type is not assignable with the 'unknown' type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  43 |     expect<{ a: number }>().type.not.toBeAssignableWith({} as never);
+  44 | 
+  45 |     expect<{ a: string }>().type.not.toBeAssignableWith({} as unknown); // use '.toBeUnknown()'
+     |                                                         ~~~~~~~~~~~~~
+  46 |     expect<{ a: string }>().type.toBeAssignableWith({} as unknown);
+  47 |   });
+  48 | });
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:45:57
+
+Error: Type '{ a: string; }' is not assignable with type 'unknown'.
+
+  44 | 
+  45 |     expect<{ a: string }>().type.not.toBeAssignableWith({} as unknown); // use '.toBeUnknown()'
+  46 |     expect<{ a: string }>().type.toBeAssignableWith({} as unknown);
+     |                                                     ~~~~~~~~~~~~~
+  47 |   });
+  48 | });
+  49 | 
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:46:53 ❭ argument for 'target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Target' cannot be of the 'any' type.
+
+Every type is assignable with the 'any' type.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  50 | describe("type argument for 'Target'", () => {
+  51 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  52 |     expect<{ a: number }>().type.toBeAssignableWith<any>(); // use '.toBeAny()'
+     |                                                     ~~~
+  53 |     expect<{ a: number }>().type.not.toBeAssignableWith<any>();
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableWith<never>(); // use '.toBeNever()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:52:53
+
+Error: Type '{ a: number; }' is assignable with type 'any'.
+
+  51 |   test("cannot be of type 'any', 'never' or 'unknown'", () => {
+  52 |     expect<{ a: number }>().type.toBeAssignableWith<any>(); // use '.toBeAny()'
+  53 |     expect<{ a: number }>().type.not.toBeAssignableWith<any>();
+     |                                                         ~~~
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableWith<never>(); // use '.toBeNever()'
+  56 |     expect<{ a: number }>().type.not.toBeAssignableWith<never>();
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:53:57 ❭ type argument for 'Target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Target' cannot be of the 'never' type.
+
+Every type is assignable with the 'never' type.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  53 |     expect<{ a: number }>().type.not.toBeAssignableWith<any>();
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableWith<never>(); // use '.toBeNever()'
+     |                                                     ~~~~~
+  56 |     expect<{ a: number }>().type.not.toBeAssignableWith<never>();
+  57 | 
+  58 |     expect<{ a: string }>().type.not.toBeAssignableWith<unknown>(); // use '.toBeUnknown()'
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:55:53
+
+Error: Type '{ a: number; }' is assignable with type 'never'.
+
+  54 | 
+  55 |     expect<{ a: number }>().type.toBeAssignableWith<never>(); // use '.toBeNever()'
+  56 |     expect<{ a: number }>().type.not.toBeAssignableWith<never>();
+     |                                                         ~~~~~
+  57 | 
+  58 |     expect<{ a: string }>().type.not.toBeAssignableWith<unknown>(); // use '.toBeUnknown()'
+  59 |     expect<{ a: string }>().type.toBeAssignableWith<unknown>();
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:56:57 ❭ type argument for 'Target' ❭ cannot be of type 'any', 'never' or 'unknown'
+
+Error: A type argument for 'Target' cannot be of the 'unknown' type.
+
+Every type is not assignable with the 'unknown' type.
+If this check is necessary, use the '.toBeUnknown()' matcher instead.
+
+  56 |     expect<{ a: number }>().type.not.toBeAssignableWith<never>();
+  57 | 
+  58 |     expect<{ a: string }>().type.not.toBeAssignableWith<unknown>(); // use '.toBeUnknown()'
+     |                                                         ~~~~~~~
+  59 |     expect<{ a: string }>().type.toBeAssignableWith<unknown>();
+  60 |   });
+  61 | });
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:58:57
+
+Error: Type '{ a: string; }' is not assignable with type 'unknown'.
+
+  57 | 
+  58 |     expect<{ a: string }>().type.not.toBeAssignableWith<unknown>(); // use '.toBeUnknown()'
+  59 |     expect<{ a: string }>().type.toBeAssignableWith<unknown>();
+     |                                                     ~~~~~~~
+  60 |   });
+  61 | });
+  62 | 
+
+       at ./__typetests__/toBeAssignableWith.tst.ts:59:53 ❭ type argument for 'Target' ❭ cannot be of type 'any', 'never' or 'unknown'
 

--- a/tests/__snapshots__/validation-toBeAssignableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableWith-stdout.snap.txt
@@ -3,13 +3,19 @@ uses TypeScript <<version>> with ./tsconfig.json
 fail ./__typetests__/toBeAssignableWith.tst.ts
   argument for 'source'
     × must be provided
+    × cannot be of type 'any', 'never' or 'unknown'
+  type argument for 'Source'
+    × cannot be of type 'any', 'never' or 'unknown'
   argument for 'target'
     × must be provided
+    × cannot be of type 'any', 'never' or 'unknown'
+  type argument for 'Target'
+    × cannot be of type 'any', 'never' or 'unknown'
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      2 failed, 2 total
-Assertions: 2 failed, 2 total
+Tests:      6 failed, 6 total
+Assertions: 26 failed, 26 total
 Duration:   <<timestamp>>
 
 Ran all test files.


### PR DESCRIPTION
Fixes #367

I think it is useful to make assignability matchers protect against `any`, `never` or `unknown`. Current assignability checks are correct, obviously. But.. It can be that after refactoring logic a generic type it would accidentally resolve to `never`:

```ts
import { expect } from "tstyche";

expect<Sample<string>>().type.toBeAssignableTo<string>(); // pass!
       ^^^ Also if this is 'any' or 'never'?
```

---

After this change the following is not allowed:

```ts
import { expect } from "tstyche";

expect<any>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
expect<never>().type.toBeAssignableTo<{ a: number }>(); // use '.toBeNever()'

expect<unknown>().type.not.toBeAssignableTo<{ a: number }>(); // use '.toBeUnknown()'

expect<{ a: number }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
expect<{ a: number }>().type.toBeAssignableTo<unknown>(); // use '.toBeUnknown()'

expect<{ a: number }>().type.not.toBeAssignableTo<never>(); // use '.toBeNever()'

///

expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
expect<unknown>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeUnknown()'

expect<never>().type.not.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'

expect<{ a: number }>().type.toBeAssignableWith<any>(); // use '.toBeAny()'
expect<{ a: number }>().type.toBeAssignableWith<never>(); // use '.toBeNever()'

expect<{ a: string }>().type.not.toBeAssignableWith<unknown>(); // use '.toBeUnknown()'
```

If these checks are necessary, primitive type matchers can be used instead.

---

These checks do not protect agains nested `any`, `never` or `unknown`:

```ts
import { expect } from "tstyche";

interface Sample {
  ups: any;
}

// This will pass
expect<Sample>().type.toBeAssignableTo<{ ups: string }>();
```