### PR TITLE
feat: add the `noAssignableAny` and `noAssignableNever` options

### DIFF
--- a/models/ConfigFileOptions.ts
+++ b/models/ConfigFileOptions.ts
@@ -9,6 +9,14 @@ export interface ConfigFileOptions {
      */
     failFast?: boolean;
     /**
+     * Report the 'any' type as not assignable to and with all types.
+     */
+    noAssignableAny?: boolean;
+    /**
+     * Report the 'never' type as not assignable to all types.
+     */
+    noAssignableNever?: boolean;
+    /**
      * The list of plugins to use.
      */
     plugins?: Array<string>;

--- a/models/config-schema.json
+++ b/models/config-schema.json
@@ -6,6 +6,14 @@
       "description": "Stop running tests after the first failed assertion.",
       "type": "boolean"
     },
+    "noAssignableAny": {
+      "description": "Report the 'any' type as not assignable to and with all types.",
+      "type": "boolean"
+    },
+    "noAssignableNever": {
+      "description": "Report the 'never' type as not assignable to all types.",
+      "type": "boolean"
+    },
     "plugins": {
       "default": [],
       "description": "The list of plugins to use.",

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -84,6 +84,20 @@ export class Options {
     },
 
     {
+      brand: OptionBrand.Boolean,
+      description: "Report the 'any' type as not assignable to and with all types.",
+      group: OptionGroup.ConfigFile,
+      name: "noAssignableAny",
+    },
+
+    {
+      brand: OptionBrand.Boolean,
+      description: "Report the 'never' type as not assignable to all types.",
+      group: OptionGroup.ConfigFile,
+      name: "noAssignableNever",
+    },
+
+    {
       brand: OptionBrand.String,
       description: "Only run tests with matching name.",
       group: OptionGroup.CommandLine,

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -4,6 +4,8 @@ import type { ConfigFileOptions } from "./types.js";
 
 export const defaultOptions: Required<ConfigFileOptions> = {
   failFast: false,
+  noAssignableAny: false,
+  noAssignableNever: false,
   plugins: [],
   reporters: ["list", "summary"],
   rootPath: Path.resolve("./"),

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -82,7 +82,7 @@ export class Runner {
 
       EventEmitter.dispatch(["target:start", { result: targetResult }]);
 
-      const compiler = await Store.load(target);
+      const compiler = await Store.load(target, this.#resolvedConfig);
 
       if (compiler) {
         // TODO to improve performance, task runners (or even test projects) could be cached in the future

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,4 +1,6 @@
 {
   "$schema": "./models/config-schema.json",
+  "noAssignableAny": true,
+  "noAssignableNever": true,
   "testFileMatch": ["examples/*.t*st.*", "models/__typetests__/*.tst.*", "tests/*.test.*"]
 }


### PR DESCRIPTION
Fixes #367
Closes #367 

Adding the `noAssignableAny` and `noAssignableNever` options seems to be a better way to make assignability matchers protect against `any` and `never`.

The options are changing behaviour of compiler, hence all deep nested `any`s and `never`s are caught.

When `noAssignableAny: true` and `noAssignableNever: true` are set, all the following assertions fail:

```ts
import { expect } from "tstyche";

expect<any>().type.toBe<{ one: string }>();
expect<any>().type.toBeAssignableTo<{ one: string }>();
expect<never>().type.toBeAssignableTo<{ one: string }>();

expect<{ one: { two: any } }>().type.toBe<{ one: { two: number } }>();
expect<{ one: { two: any } }>().type.toBeAssignableTo<{ one: { two: number } }>();
expect<{ one: { two: never } }>().type.toBeAssignableTo<{ one: { two: number } }>();

expect<Array<any>>().type.toBe<Array<number>>();
expect<Array<any>>().type.toBeAssignableTo<Array<number>>();
expect<Array<never>>().type.toBeAssignableTo<Array<number>>();
```

This means:

- `.toBeAssignable*()` and `.toBe()` matchers become equally strict about `any` and `never`,
- same about `.toAcceptProps()`, because TSTyche checks if type of each prop is assignable,
- `any` and `never` assignments will fails in the whole code, that’s tricky,
- but that is why these are opt-in options!