### PR TITLE
feat: add the `rejectAnyType` and `rejectNeverType` configuration options

### DIFF
--- a/examples/Matchers.tst.ts
+++ b/examples/Matchers.tst.ts
@@ -9,14 +9,24 @@ expect<Matchers<void, string>>().type.not.toRaiseError();
 expect<Matchers<void>>().type.not.toRaiseError();
 
 // Substring of the error message
-expect<Matchers>().type.toRaiseError("requires between 1 and 2 type arguments");
+expect(() => {
+  type E = Matchers;
+}).type.toRaiseError("requires between 1 and 2 type arguments");
 
 // The error code
-expect<Matchers>().type.toRaiseError(2707);
+expect(() => {
+  type E = Matchers;
+}).type.toRaiseError(2707);
 
 // Pattern matching the error message
-expect<Matchers>().type.toRaiseError(/between \d and \d type arguments/);
-expect<Matchers>().type.toRaiseError(/generic .+ requires .+ type arguments/i);
+expect(() => {
+  type E = Matchers;
+}).type.toRaiseError(/between \d and \d type arguments/);
+expect(() => {
+  type E = Matchers;
+}).type.toRaiseError(/generic .+ requires .+ type arguments/i);
 
 // The exact error message
-expect<Matchers>().type.toRaiseError(/^Generic type 'Matchers<R, T>' requires between 1 and 2 type arguments.$/);
+expect(() => {
+  type E = Matchers;
+}).type.toRaiseError(/^Generic type 'Matchers<R, T>' requires between 1 and 2 type arguments.$/);

--- a/models/ConfigFileOptions.ts
+++ b/models/ConfigFileOptions.ts
@@ -13,6 +13,14 @@ export interface ConfigFileOptions {
      */
     plugins?: Array<string>;
     /**
+     * Reject the 'any' type passed as an argument to the 'expect()' function or a matcher.
+     */
+    rejectAnyType?: boolean;
+    /**
+     * Reject the 'never' type passed as an argument to the 'expect()' function or a matcher.
+     */
+    rejectNeverType?: boolean;
+    /**
      * The list of reporters to use.
      */
     reporters?: Array<string>;

--- a/models/__tests__/__fixtures__/invalid-rejectAnyType.json
+++ b/models/__tests__/__fixtures__/invalid-rejectAnyType.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "rejectAnyType": "always"
+}

--- a/models/__tests__/__fixtures__/invalid-rejectNeverType.json
+++ b/models/__tests__/__fixtures__/invalid-rejectNeverType.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "rejectNeverType": "always"
+}

--- a/models/__tests__/__fixtures__/valid-all-options.json
+++ b/models/__tests__/__fixtures__/valid-all-options.json
@@ -2,6 +2,8 @@
   "$schema": "../../config-schema.json",
   "failFast": true,
   "plugins": ["./tstyche-plugin.js"],
+  "rejectAnyType": true,
+  "rejectNeverType": true,
   "reporters": ["./tstyche-reporter.js"],
   "rootPath": "../",
   "target": ["4.9", "5.0.4", "beta", "latest", "next", "rc"],

--- a/models/__tests__/__fixtures__/valid-rejectAnyType.json
+++ b/models/__tests__/__fixtures__/valid-rejectAnyType.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "rejectAnyType": true
+}

--- a/models/__tests__/__fixtures__/valid-rejectNeverType.json
+++ b/models/__tests__/__fixtures__/valid-rejectNeverType.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config-schema.json",
+  "rejectNeverType": true
+}

--- a/models/__tests__/config-schema.test.js
+++ b/models/__tests__/config-schema.test.js
@@ -43,6 +43,14 @@ test("config-schema.json", async (t) => {
         testCase: "'plugins' option",
       },
       {
+        fixtureFileName: "valid-rejectAnyType.json",
+        testCase: "'rejectAnyType' option",
+      },
+      {
+        fixtureFileName: "valid-rejectNeverType.json",
+        testCase: "'rejectNeverType' option",
+      },
+      {
         fixtureFileName: "valid-reporters.json",
         testCase: "'reporters' option",
       },
@@ -91,6 +99,14 @@ test("config-schema.json", async (t) => {
       {
         fixtureFileName: "invalid-plugins-3.json",
         testCase: "value of 'plugins' option must be of type Array",
+      },
+      {
+        fixtureFileName: "invalid-rejectAnyType.json",
+        testCase: "value of 'rejectAnyType' option must be of type boolean",
+      },
+      {
+        fixtureFileName: "invalid-rejectNeverType.json",
+        testCase: "value of 'rejectNeverType' option must be of type boolean",
       },
       {
         fixtureFileName: "invalid-reporters-1.json",

--- a/models/__typetests__/CommandLineOptions.tst.ts
+++ b/models/__typetests__/CommandLineOptions.tst.ts
@@ -1,11 +1,9 @@
 import { describe, expect, test } from "tstyche";
 import type * as tstyche from "tstyche/tstyche";
 
-const options: tstyche.CommandLineOptions = {};
-
 describe("CommandLineOptions", () => {
   test("all options", () => {
-    expect(options).type.toBeAssignableWith({
+    expect<tstyche.CommandLineOptions>().type.toBeAssignableWith({
       config: "./config/tstyche.json",
       failFast: true,
       help: true,
@@ -24,6 +22,10 @@ describe("CommandLineOptions", () => {
       version: true,
       watch: true,
     });
+  });
+
+  test("all options are optional", () => {
+    expect<tstyche.CommandLineOptions>().type.toBeAssignableWith({});
   });
 
   test("'config' option", () => {

--- a/models/__typetests__/ConfigFileOptions.tst.ts
+++ b/models/__typetests__/ConfigFileOptions.tst.ts
@@ -1,19 +1,23 @@
 import { describe, expect, test } from "tstyche";
 import type * as tstyche from "tstyche/tstyche";
 
-const options: tstyche.ConfigFileOptions = {};
-
 describe("ConfigFileOptions", () => {
   test("all options", () => {
-    expect(options).type.toBeAssignableWith({
+    expect<tstyche.ConfigFileOptions>().type.toBeAssignableWith({
       failFast: true,
       plugins: ["./tstyche-plugin.js"],
+      rejectAnyType: true,
+      rejectNeverType: true,
       reporters: ["./tstyche-reporter.js"],
       rootPath: "../",
       target: ["4.9.5" as const, "5.0" as const, "latest" as const],
       testFileMatch: ["**/tests/types/**/*"],
       tsconfig: "./tsconfig.test.json",
     });
+  });
+
+  test("all options are optional", () => {
+    expect<tstyche.ConfigFileOptions>().type.toBeAssignableWith({});
   });
 
   test("'failFast' option", () => {
@@ -25,6 +29,18 @@ describe("ConfigFileOptions", () => {
   test("'plugins' option", () => {
     expect<Pick<tstyche.ConfigFileOptions, "plugins">>().type.toBe<{
       plugins?: Array<string>;
+    }>();
+  });
+
+  test("'rejectAnyType' option", () => {
+    expect<Pick<tstyche.ConfigFileOptions, "rejectAnyType">>().type.toBe<{
+      rejectAnyType?: boolean;
+    }>();
+  });
+
+  test("'rejectNeverType' option", () => {
+    expect<Pick<tstyche.ConfigFileOptions, "rejectNeverType">>().type.toBe<{
+      rejectNeverType?: boolean;
     }>();
   });
 

--- a/models/config-schema.json
+++ b/models/config-schema.json
@@ -15,6 +15,14 @@
       "type": "array",
       "uniqueItems": true
     },
+    "rejectAnyType": {
+      "description": "Reject the 'any' type passed as an argument to the 'expect()' function or a matcher.",
+      "type": "boolean"
+    },
+    "rejectNeverType": {
+      "description": "Reject the 'never' type passed as an argument to the 'expect()' function or a matcher.",
+      "type": "boolean"
+    },
     "reporters": {
       "default": [
         "list",

--- a/source/collect/Assertion.ts
+++ b/source/collect/Assertion.ts
@@ -42,11 +42,21 @@ export class Assertion extends TestMember {
     return this.matcherNode.expression.name;
   }
 
+  /** @deprecated Use the 'getSourceNode()' method instead */
   get source(): ts.NodeArray<ts.Expression> | ts.NodeArray<ts.TypeNode> {
+    return this.getSourceNode();
+  }
+
+  getSourceNode(): ts.NodeArray<ts.Expression> | ts.NodeArray<ts.TypeNode> {
     return this.node.typeArguments ?? this.node.arguments;
   }
 
+  /** @deprecated Use the 'getTargetNode()' method instead */
   get target(): ts.NodeArray<ts.Expression> | ts.NodeArray<ts.TypeNode> {
+    return this.getTargetNode();
+  }
+
+  getTargetNode(): ts.NodeArray<ts.Expression> | ts.NodeArray<ts.TypeNode> {
     return this.matcherNode.typeArguments ?? this.matcherNode.arguments;
   }
 }

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -109,6 +109,20 @@ export class Options {
     },
 
     {
+      brand: OptionBrand.Boolean,
+      description: "Reject the 'any' type passed as an argument to the 'expect()' function or a matcher.",
+      group: OptionGroup.ConfigFile,
+      name: "rejectAnyType",
+    },
+
+    {
+      brand: OptionBrand.Boolean,
+      description: "Reject the 'never' type passed as an argument to the 'expect()' function or a matcher.",
+      group: OptionGroup.ConfigFile,
+      name: "rejectNeverType",
+    },
+
+    {
       brand: OptionBrand.List,
       description: "The list of reporters to use.",
       group: OptionGroup.CommandLine | OptionGroup.ConfigFile,

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -5,6 +5,8 @@ import type { ConfigFileOptions } from "./types.js";
 export const defaultOptions: Required<ConfigFileOptions> = {
   failFast: false,
   plugins: [],
+  rejectAnyType: false,
+  rejectNeverType: false,
   reporters: ["list", "summary"],
   rootPath: Path.resolve("./"),
   target: environmentOptions.typescriptModule != null ? ["current"] : ["latest"],

--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -1,4 +1,8 @@
 export class ExpectDiagnosticText {
+  static argumentCannotBeOfType(argumentNameText: string, typeText: string): string {
+    return `An argument for '${argumentNameText}' cannot be of the '${typeText}' type.`;
+  }
+
   static argumentOrTypeArgumentMustBeProvided(argumentNameText: string, typeArgumentNameText: string): string {
     return `An argument for '${argumentNameText}' or type argument for '${typeArgumentNameText}' must be provided.`;
   }
@@ -36,6 +40,10 @@ export class ExpectDiagnosticText {
 
   static raisedTypeError(count = 1): string {
     return `The raised type error${count === 1 ? "" : "s"}:`;
+  }
+
+  static typeArgumentCannotBeOfType(argumentNameText: string, typeText: string): string {
+    return `A type argument for '${argumentNameText}' cannot be of the '${typeText}' type.`;
   }
 
   static typeArgumentMustBe(argumentNameText: string, expectedText: string): string {
@@ -118,5 +126,21 @@ export class ExpectDiagnosticText {
 
   static typesOfPropertyAreNotCompatible(propertyNameText: string): string {
     return `Types of property '${propertyNameText}' are not compatible.`;
+  }
+
+  static #toTitleCase(text: string) {
+    return text.replace(/^./, text.charAt(0).toUpperCase());
+  }
+
+  static typeIsRejected(typeText: string): string {
+    const optionNameText = `reject${ExpectDiagnosticText.#toTitleCase(typeText)}Type`;
+
+    return `The '${typeText}' type was rejected because the '${optionNameText}' option is enabled.`;
+  }
+
+  static usePrimitiveTypeMatcher(typeText: string): string {
+    const matcherNameText = `.toBe${ExpectDiagnosticText.#toTitleCase(typeText)}()`;
+
+    return `If this check is necessary, use the '${matcherNameText}' matcher instead.`;
   }
 }

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -87,38 +87,43 @@ export class ExpectService {
 
     const matchWorker = new MatchWorker(this.#compiler, this.#typeChecker, assertion);
 
-    const sourceType = matchWorker.getType(assertion.source[0]);
-    let targetType: ts.Type | undefined;
-
-    if (assertion.target[0] != null) {
-      targetType = matchWorker.getType(assertion.target[0]);
-    }
-
     if (this.#resolvedConfig.rejectAnyType && matcherNameText !== "toBeAny") {
+      const sourceType = matchWorker.getType(assertion.source[0]);
+
       if (sourceType.flags & this.#compiler.TypeFlags.Any) {
         this.#onSourceArgumentTypeRejected(assertion.source[0], "any", onDiagnostics);
 
         return;
       }
 
-      if (targetType != null && targetType.flags & this.#compiler.TypeFlags.Any) {
-        this.#onSourceArgumentTypeRejected(assertion.source[0], "any", onDiagnostics);
+      if (assertion.target[0] != null) {
+        const targetType = matchWorker.getType(assertion.target[0]);
 
-        return;
+        if (targetType.flags & this.#compiler.TypeFlags.Any) {
+          this.#onTargetArgumentTypeRejected(assertion.target[0], "any", onDiagnostics);
+
+          return;
+        }
       }
     }
 
     if (this.#resolvedConfig.rejectNeverType && matcherNameText !== "toBeNever") {
+      const sourceType = matchWorker.getType(assertion.source[0]);
+
       if (sourceType.flags & this.#compiler.TypeFlags.Never) {
-        this.#onTargetArgumentTypeRejected(assertion.source[0], "never", onDiagnostics);
+        this.#onSourceArgumentTypeRejected(assertion.source[0], "never", onDiagnostics);
 
         return;
       }
 
-      if (targetType != null && targetType.flags & this.#compiler.TypeFlags.Never) {
-        this.#onTargetArgumentTypeRejected(assertion.source[0], "never", onDiagnostics);
+      if (assertion.target[0] != null) {
+        const targetType = matchWorker.getType(assertion.target[0]);
 
-        return;
+        if (targetType.flags & this.#compiler.TypeFlags.Never) {
+          this.#onTargetArgumentTypeRejected(assertion.target[0], "never", onDiagnostics);
+
+          return;
+        }
       }
     }
 

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -38,7 +38,7 @@ export class TestTreeWalker {
     this.#position = options.position;
     this.#taskResult = options.taskResult;
 
-    this.#expectService = new ExpectService(compiler, typeChecker);
+    this.#expectService = new ExpectService(compiler, typeChecker, this.#resolvedConfig);
   }
 
   #resolveRunMode(mode: RunMode, member: TestMember): RunMode {

--- a/tests/__snapshots__/config-rejectAnyType-disabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-disabled-stderr.snap.txt
@@ -1,0 +1,48 @@
+Error: Type 'any' is assignable to type '{ a: number; }'.
+
+  4 |   test("rejects the 'any' type", () => {
+  5 |     expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+  6 |     expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+    |                                                 ~~~~~~~~~~~~~
+  7 |   });
+  8 | 
+  9 |   test("allows '.toBeAny()'", () => {
+
+      at ./__typetests__/isRejected.test.ts:6:49 ❭ argument for 'source' ❭ rejects the 'any' type
+
+Error: Type 'any' is assignable with type '{ a: number; }'.
+
+  15 |   test("rejects the 'any' type", () => {
+  16 |     expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+  17 |     expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+     |                                               ~~~~~~~~~~~~~
+  18 |   });
+  19 | 
+  20 |   test("allows '.toBeAny()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:17:47 ❭ type argument for 'Source' ❭ rejects the 'any' type
+
+Error: Type '{ a: number; }' is not identical to type 'any'.
+
+  25 | describe("argument for 'target'", () => {
+  26 |   test("rejects the 'any' type", () => {
+  27 |     expect({ a: 123 }).type.toBe({} as any); // use '.toBeAny()'
+     |                                  ~~~~~~~~~
+  28 |     expect({ a: 123 }).type.not.toBe({} as any);
+  29 |   });
+  30 | 
+
+       at ./__typetests__/isRejected.test.ts:27:34 ❭ argument for 'target' ❭ rejects the 'any' type
+
+Error: Type '{ a: boolean; }' is assignable to type 'any'.
+
+  37 |   test("rejects the 'any' type", () => {
+  38 |     expect<{ a: boolean }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+  39 |     expect<{ a: boolean }>().type.not.toBeAssignableTo<any>();
+     |                                                        ~~~
+  40 |   });
+  41 | 
+  42 |   test("allows '.toBeAny()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:39:56 ❭ type argument for 'Target' ❭ rejects the 'any' type
+

--- a/tests/__snapshots__/config-rejectAnyType-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-disabled-stdout.snap.txt
@@ -1,0 +1,23 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/isRejected.test.ts
+  argument for 'source'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+  type argument for 'Source'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+  argument for 'target'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+  type argument for 'Target'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      4 failed, 4 passed, 8 total
+Assertions: 4 failed, 8 passed, 12 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/config-rejectAnyType-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-enabled-stderr.snap.txt
@@ -58,7 +58,7 @@ If this check is necessary, use the '.toBeAny()' matcher instead.
 
        at ./__typetests__/isRejected.test.ts:17:12
 
-Error: An argument for 'source' cannot be of the 'any' type.
+Error: An argument for 'target' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, use the '.toBeAny()' matcher instead.
@@ -66,14 +66,14 @@ If this check is necessary, use the '.toBeAny()' matcher instead.
   25 | describe("argument for 'target'", () => {
   26 |   test("rejects the 'any' type", () => {
   27 |     expect({ a: 123 }).type.toBe({} as any); // use '.toBeAny()'
-     |            ~~~~~~~~~~
+     |                                  ~~~~~~~~~
   28 |     expect({ a: 123 }).type.not.toBe({} as any);
   29 |   });
   30 | 
 
-       at ./__typetests__/isRejected.test.ts:27:12
+       at ./__typetests__/isRejected.test.ts:27:34
 
-Error: An argument for 'source' cannot be of the 'any' type.
+Error: An argument for 'target' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, use the '.toBeAny()' matcher instead.
@@ -81,14 +81,14 @@ If this check is necessary, use the '.toBeAny()' matcher instead.
   26 |   test("rejects the 'any' type", () => {
   27 |     expect({ a: 123 }).type.toBe({} as any); // use '.toBeAny()'
   28 |     expect({ a: 123 }).type.not.toBe({} as any);
-     |            ~~~~~~~~~~
+     |                                      ~~~~~~~~~
   29 |   });
   30 | 
   31 |   test("allows '.toBeAny()'", () => {
 
-       at ./__typetests__/isRejected.test.ts:28:12
+       at ./__typetests__/isRejected.test.ts:28:38
 
-Error: A type argument for 'Source' cannot be of the 'any' type.
+Error: A type argument for 'Target' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, use the '.toBeAny()' matcher instead.
@@ -96,14 +96,14 @@ If this check is necessary, use the '.toBeAny()' matcher instead.
   36 | describe("type argument for 'Target'", () => {
   37 |   test("rejects the 'any' type", () => {
   38 |     expect<{ a: boolean }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
-     |            ~~~~~~~~~~~~~~
+     |                                                    ~~~
   39 |     expect<{ a: boolean }>().type.not.toBeAssignableTo<any>();
   40 |   });
   41 | 
 
-       at ./__typetests__/isRejected.test.ts:38:12
+       at ./__typetests__/isRejected.test.ts:38:52
 
-Error: A type argument for 'Source' cannot be of the 'any' type.
+Error: A type argument for 'Target' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, use the '.toBeAny()' matcher instead.
@@ -111,10 +111,10 @@ If this check is necessary, use the '.toBeAny()' matcher instead.
   37 |   test("rejects the 'any' type", () => {
   38 |     expect<{ a: boolean }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
   39 |     expect<{ a: boolean }>().type.not.toBeAssignableTo<any>();
-     |            ~~~~~~~~~~~~~~
+     |                                                        ~~~
   40 |   });
   41 | 
   42 |   test("allows '.toBeAny()'", () => {
 
-       at ./__typetests__/isRejected.test.ts:39:12
+       at ./__typetests__/isRejected.test.ts:39:56
 

--- a/tests/__snapshots__/config-rejectAnyType-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-enabled-stderr.snap.txt
@@ -1,0 +1,120 @@
+Error: An argument for 'source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  3 | describe("argument for 'source'", () => {
+  4 |   test("rejects the 'any' type", () => {
+  5 |     expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+    |            ~~~~~~~~~
+  6 |     expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+  7 |   });
+  8 | 
+
+      at ./__typetests__/isRejected.test.ts:5:12
+
+Error: An argument for 'source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  4 |   test("rejects the 'any' type", () => {
+  5 |     expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+  6 |     expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+    |            ~~~~~~~~~
+  7 |   });
+  8 | 
+  9 |   test("allows '.toBeAny()'", () => {
+
+      at ./__typetests__/isRejected.test.ts:6:12
+
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  14 | describe("type argument for 'Source'", () => {
+  15 |   test("rejects the 'any' type", () => {
+  16 |     expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+     |            ~~~
+  17 |     expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+  18 |   });
+  19 | 
+
+       at ./__typetests__/isRejected.test.ts:16:12
+
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  15 |   test("rejects the 'any' type", () => {
+  16 |     expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+  17 |     expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+     |            ~~~
+  18 |   });
+  19 | 
+  20 |   test("allows '.toBeAny()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:17:12
+
+Error: An argument for 'source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  25 | describe("argument for 'target'", () => {
+  26 |   test("rejects the 'any' type", () => {
+  27 |     expect({ a: 123 }).type.toBe({} as any); // use '.toBeAny()'
+     |            ~~~~~~~~~~
+  28 |     expect({ a: 123 }).type.not.toBe({} as any);
+  29 |   });
+  30 | 
+
+       at ./__typetests__/isRejected.test.ts:27:12
+
+Error: An argument for 'source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  26 |   test("rejects the 'any' type", () => {
+  27 |     expect({ a: 123 }).type.toBe({} as any); // use '.toBeAny()'
+  28 |     expect({ a: 123 }).type.not.toBe({} as any);
+     |            ~~~~~~~~~~
+  29 |   });
+  30 | 
+  31 |   test("allows '.toBeAny()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:28:12
+
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  36 | describe("type argument for 'Target'", () => {
+  37 |   test("rejects the 'any' type", () => {
+  38 |     expect<{ a: boolean }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+     |            ~~~~~~~~~~~~~~
+  39 |     expect<{ a: boolean }>().type.not.toBeAssignableTo<any>();
+  40 |   });
+  41 | 
+
+       at ./__typetests__/isRejected.test.ts:38:12
+
+Error: A type argument for 'Source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, use the '.toBeAny()' matcher instead.
+
+  37 |   test("rejects the 'any' type", () => {
+  38 |     expect<{ a: boolean }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+  39 |     expect<{ a: boolean }>().type.not.toBeAssignableTo<any>();
+     |            ~~~~~~~~~~~~~~
+  40 |   });
+  41 | 
+  42 |   test("allows '.toBeAny()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:39:12
+

--- a/tests/__snapshots__/config-rejectAnyType-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-enabled-stdout.snap.txt
@@ -1,0 +1,23 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/isRejected.test.ts
+  argument for 'source'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+  type argument for 'Source'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+  argument for 'target'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+  type argument for 'Target'
+    × rejects the 'any' type
+    + allows '.toBeAny()'
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      4 failed, 4 passed, 8 total
+Assertions: 8 failed, 4 passed, 12 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/config-rejectNeverType-disabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-disabled-stderr.snap.txt
@@ -1,0 +1,84 @@
+Error: Type 'never' is not identical to type '{ a: number; }'.
+
+  3 | describe("argument for 'source'", () => {
+  4 |   test("rejects the 'never' type", () => {
+  5 |     expect({} as never).type.toBe<{ a: number }>(); // use '.toBeNever()'
+    |                                   ~~~~~~~~~~~~~
+  6 |     expect({} as never).type.not.toBe<{ a: number }>();
+  7 |   });
+  8 | 
+
+      at ./__typetests__/isRejected.test.ts:5:35 ❭ argument for 'source' ❭ rejects the 'never' type
+
+Error: Type 'never' is not assignable with type '{ a: number; }'.
+
+  14 | describe("type argument for 'Source'", () => {
+  15 |   test("rejects the 'never' type", () => {
+  16 |     expect<never>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+     |                                             ~~~~~~~~~~~~~
+  17 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>();
+  18 |   });
+  19 | 
+
+       at ./__typetests__/isRejected.test.ts:16:45 ❭ type argument for 'Source' ❭ rejects the 'never' type
+
+Error: Type '{ b: string; }' is assignable with type 'never'.
+
+  26 |   test("rejects the 'never' type", () => {
+  27 |     expect({ b: "abc" }).type.toBeAssignableWith({} as never); // use '.toBeNever()'
+  28 |     expect({ b: "abc" }).type.not.toBeAssignableWith({} as never);
+     |                                                      ~~~~~~~~~~~
+  29 |   });
+  30 | 
+  31 |   test("allows '.toBeNever()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:28:54 ❭ argument for 'target' ❭ rejects the 'never' type
+
+Error: A type argument for 'Source' must be of a function or class type.
+
+  36 | describe("type argument for 'Target'", () => {
+  37 |   test("rejects the 'never' type", () => {
+  38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+     |            ~~~~~~~~~~~~~
+  39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
+  40 |   });
+  41 | 
+
+       at ./__typetests__/isRejected.test.ts:38:12
+
+Error: A type argument for 'Target' must be of an object type.
+
+  36 | describe("type argument for 'Target'", () => {
+  37 |   test("rejects the 'never' type", () => {
+  38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+     |                                                ~~~~~
+  39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
+  40 |   });
+  41 | 
+
+       at ./__typetests__/isRejected.test.ts:38:48
+
+Error: A type argument for 'Source' must be of a function or class type.
+
+  37 |   test("rejects the 'never' type", () => {
+  38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+  39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
+     |            ~~~~~~~~~~~~~
+  40 |   });
+  41 | 
+  42 |   test("allows '.toBeNever()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:39:12
+
+Error: A type argument for 'Target' must be of an object type.
+
+  37 |   test("rejects the 'never' type", () => {
+  38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+  39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
+     |                                                    ~~~~~
+  40 |   });
+  41 | 
+  42 |   test("allows '.toBeNever()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:39:52
+

--- a/tests/__snapshots__/config-rejectNeverType-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-disabled-stdout.snap.txt
@@ -1,0 +1,23 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/isRejected.test.ts
+  argument for 'source'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+  type argument for 'Source'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+  argument for 'target'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+  type argument for 'Target'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      4 failed, 4 passed, 8 total
+Assertions: 5 failed, 7 passed, 12 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/config-rejectNeverType-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-enabled-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: An argument for 'target' cannot be of the 'never' type.
+Error: An argument for 'source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, use the '.toBeNever()' matcher instead.
@@ -13,7 +13,7 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
 
       at ./__typetests__/isRejected.test.ts:5:12
 
-Error: An argument for 'target' cannot be of the 'never' type.
+Error: An argument for 'source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, use the '.toBeNever()' matcher instead.
@@ -28,7 +28,7 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
 
       at ./__typetests__/isRejected.test.ts:6:12
 
-Error: A type argument for 'Target' cannot be of the 'never' type.
+Error: A type argument for 'Source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, use the '.toBeNever()' matcher instead.
@@ -43,7 +43,7 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
 
        at ./__typetests__/isRejected.test.ts:16:12
 
-Error: A type argument for 'Target' cannot be of the 'never' type.
+Error: A type argument for 'Source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, use the '.toBeNever()' matcher instead.
@@ -66,12 +66,12 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
   25 | describe("argument for 'target'", () => {
   26 |   test("rejects the 'never' type", () => {
   27 |     expect({ b: "abc" }).type.toBeAssignableWith({} as never); // use '.toBeNever()'
-     |            ~~~~~~~~~~~~
+     |                                                  ~~~~~~~~~~~
   28 |     expect({ b: "abc" }).type.not.toBeAssignableWith({} as never);
   29 |   });
   30 | 
 
-       at ./__typetests__/isRejected.test.ts:27:12
+       at ./__typetests__/isRejected.test.ts:27:50
 
 Error: An argument for 'target' cannot be of the 'never' type.
 
@@ -81,12 +81,12 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
   26 |   test("rejects the 'never' type", () => {
   27 |     expect({ b: "abc" }).type.toBeAssignableWith({} as never); // use '.toBeNever()'
   28 |     expect({ b: "abc" }).type.not.toBeAssignableWith({} as never);
-     |            ~~~~~~~~~~~~
+     |                                                      ~~~~~~~~~~~
   29 |   });
   30 | 
   31 |   test("allows '.toBeNever()'", () => {
 
-       at ./__typetests__/isRejected.test.ts:28:12
+       at ./__typetests__/isRejected.test.ts:28:54
 
 Error: A type argument for 'Target' cannot be of the 'never' type.
 
@@ -96,12 +96,12 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
   36 | describe("type argument for 'Target'", () => {
   37 |   test("rejects the 'never' type", () => {
   38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
-     |            ~~~~~~~~~~~~~
+     |                                                ~~~~~
   39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
   40 |   });
   41 | 
 
-       at ./__typetests__/isRejected.test.ts:38:12
+       at ./__typetests__/isRejected.test.ts:38:48
 
 Error: A type argument for 'Target' cannot be of the 'never' type.
 
@@ -111,10 +111,10 @@ If this check is necessary, use the '.toBeNever()' matcher instead.
   37 |   test("rejects the 'never' type", () => {
   38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
   39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
-     |            ~~~~~~~~~~~~~
+     |                                                    ~~~~~
   40 |   });
   41 | 
   42 |   test("allows '.toBeNever()'", () => {
 
-       at ./__typetests__/isRejected.test.ts:39:12
+       at ./__typetests__/isRejected.test.ts:39:52
 

--- a/tests/__snapshots__/config-rejectNeverType-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-enabled-stderr.snap.txt
@@ -1,0 +1,120 @@
+Error: An argument for 'target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  3 | describe("argument for 'source'", () => {
+  4 |   test("rejects the 'never' type", () => {
+  5 |     expect({} as never).type.toBe<{ a: number }>(); // use '.toBeNever()'
+    |            ~~~~~~~~~~~
+  6 |     expect({} as never).type.not.toBe<{ a: number }>();
+  7 |   });
+  8 | 
+
+      at ./__typetests__/isRejected.test.ts:5:12
+
+Error: An argument for 'target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  4 |   test("rejects the 'never' type", () => {
+  5 |     expect({} as never).type.toBe<{ a: number }>(); // use '.toBeNever()'
+  6 |     expect({} as never).type.not.toBe<{ a: number }>();
+    |            ~~~~~~~~~~~
+  7 |   });
+  8 | 
+  9 |   test("allows '.toBeNever()'", () => {
+
+      at ./__typetests__/isRejected.test.ts:6:12
+
+Error: A type argument for 'Target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  14 | describe("type argument for 'Source'", () => {
+  15 |   test("rejects the 'never' type", () => {
+  16 |     expect<never>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+     |            ~~~~~
+  17 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>();
+  18 |   });
+  19 | 
+
+       at ./__typetests__/isRejected.test.ts:16:12
+
+Error: A type argument for 'Target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  15 |   test("rejects the 'never' type", () => {
+  16 |     expect<never>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+  17 |     expect<never>().type.not.toBeAssignableWith<{ a: number }>();
+     |            ~~~~~
+  18 |   });
+  19 | 
+  20 |   test("allows '.toBeNever()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:17:12
+
+Error: An argument for 'target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  25 | describe("argument for 'target'", () => {
+  26 |   test("rejects the 'never' type", () => {
+  27 |     expect({ b: "abc" }).type.toBeAssignableWith({} as never); // use '.toBeNever()'
+     |            ~~~~~~~~~~~~
+  28 |     expect({ b: "abc" }).type.not.toBeAssignableWith({} as never);
+  29 |   });
+  30 | 
+
+       at ./__typetests__/isRejected.test.ts:27:12
+
+Error: An argument for 'target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  26 |   test("rejects the 'never' type", () => {
+  27 |     expect({ b: "abc" }).type.toBeAssignableWith({} as never); // use '.toBeNever()'
+  28 |     expect({ b: "abc" }).type.not.toBeAssignableWith({} as never);
+     |            ~~~~~~~~~~~~
+  29 |   });
+  30 | 
+  31 |   test("allows '.toBeNever()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:28:12
+
+Error: A type argument for 'Target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  36 | describe("type argument for 'Target'", () => {
+  37 |   test("rejects the 'never' type", () => {
+  38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+     |            ~~~~~~~~~~~~~
+  39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
+  40 |   });
+  41 | 
+
+       at ./__typetests__/isRejected.test.ts:38:12
+
+Error: A type argument for 'Target' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, use the '.toBeNever()' matcher instead.
+
+  37 |   test("rejects the 'never' type", () => {
+  38 |     expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+  39 |     expect<{ a: number }>().type.not.toAcceptProps<never>();
+     |            ~~~~~~~~~~~~~
+  40 |   });
+  41 | 
+  42 |   test("allows '.toBeNever()'", () => {
+
+       at ./__typetests__/isRejected.test.ts:39:12
+

--- a/tests/__snapshots__/config-rejectNeverType-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-enabled-stdout.snap.txt
@@ -1,0 +1,23 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/isRejected.test.ts
+  argument for 'source'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+  type argument for 'Source'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+  argument for 'target'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+  type argument for 'Target'
+    × rejects the 'never' type
+    + allows '.toBeNever()'
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      4 failed, 4 passed, 8 total
+Assertions: 8 failed, 4 passed, 12 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/api-toBeAny.test.js
+++ b/tests/api-toBeAny.test.js
@@ -11,7 +11,7 @@ const fixtureUrl = getFixtureFileUrl(testFileName);
 await test("toBeAny", async (t) => {
   await t.test("'toBeAny' implementation", () => {
     tstyche.expect(/** @type {any} */ (null)).type.toBeAny();
-    tstyche.expect(/** @type {never} */ (null)).type.not.toBeAny();
+    tstyche.expect("sample").type.not.toBeAny();
   });
 
   await t.test("toBeAny", async () => {

--- a/tests/api-toBeNever.test.js
+++ b/tests/api-toBeNever.test.js
@@ -11,7 +11,7 @@ const fixtureUrl = getFixtureFileUrl(testFileName);
 await test("toBeNever", async (t) => {
   await t.test("'toBeNever' implementation", () => {
     tstyche.expect(/** @type {never} */ (null)).type.toBeNever();
-    tstyche.expect(/** @type {any} */ (null)).type.not.toBeNever();
+    tstyche.expect("sample").type.not.toBeNever();
   });
 
   await t.test("toBeNever", async () => {

--- a/tests/api-toBeUnknown.test.js
+++ b/tests/api-toBeUnknown.test.js
@@ -11,7 +11,7 @@ const fixtureUrl = getFixtureFileUrl(testFileName);
 await test("toBeUnknown", async (t) => {
   await t.test("'toBeUnknown' implementation", () => {
     tstyche.expect(/** @type {unknown} */ (null)).type.toBeUnknown();
-    tstyche.expect(/** @type {never} */ (null)).type.not.toBeUnknown();
+    tstyche.expect("sample").type.not.toBeUnknown();
   });
 
   await t.test("toBeUnknown", async () => {

--- a/tests/config-rejectAnyType.test.js
+++ b/tests/config-rejectAnyType.test.js
@@ -1,0 +1,118 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const isRejectedText = `import { describe, expect, test } from "tstyche";
+
+describe("argument for 'source'", () => {
+  test("rejects the 'any' type", () => {
+    expect({} as any).type.toBeAssignableTo<{ a: number }>(); // use '.toBeAny()'
+    expect({} as any).type.not.toBeAssignableTo<{ a: number }>();
+  });
+
+  test("allows '.toBeAny()'", () => {
+    expect({} as any).type.toBeAny();
+  });
+});
+
+describe("type argument for 'Source'", () => {
+  test("rejects the 'any' type", () => {
+    expect<any>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeAny()'
+    expect<any>().type.not.toBeAssignableWith<{ a: number }>();
+  });
+
+  test("allows '.toBeAny()'", () => {
+    expect<any>().type.toBeAny();
+  });
+});
+
+describe("argument for 'target'", () => {
+  test("rejects the 'any' type", () => {
+    expect({ a: 123 }).type.toBe({} as any); // use '.toBeAny()'
+    expect({ a: 123 }).type.not.toBe({} as any);
+  });
+
+  test("allows '.toBeAny()'", () => {
+    expect({ a: 123 }).type.not.toBeAny();
+  });
+});
+
+describe("type argument for 'Target'", () => {
+  test("rejects the 'any' type", () => {
+    expect<{ a: boolean }>().type.toBeAssignableTo<any>(); // use '.toBeAny()'
+    expect<{ a: boolean }>().type.not.toBeAssignableTo<any>();
+  });
+
+  test("allows '.toBeAny()'", () => {
+    expect<{ a: boolean }>().type.not.toBeAny();
+  });
+});
+`;
+
+const tsconfig = {
+  extends: "../../tsconfig.json",
+  include: ["**/*"],
+};
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'rejectAnyType' config file option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when enabled", async () => {
+    const config = {
+      rejectAnyType: true,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isRejected.test.ts"]: isRejectedText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-enabled-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-enabled-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when disabled", async () => {
+    const config = {
+      rejectAnyType: false,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isRejected.test.ts"]: isRejectedText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-disabled-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-disabled-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+});

--- a/tests/config-rejectNeverType.test.js
+++ b/tests/config-rejectNeverType.test.js
@@ -1,0 +1,118 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const isRejectedText = `import { describe, expect, test } from "tstyche";
+
+describe("argument for 'source'", () => {
+  test("rejects the 'never' type", () => {
+    expect({} as never).type.toBe<{ a: number }>(); // use '.toBeNever()'
+    expect({} as never).type.not.toBe<{ a: number }>();
+  });
+
+  test("allows '.toBeNever()'", () => {
+    expect({} as never).type.toBeNever();
+  });
+});
+
+describe("type argument for 'Source'", () => {
+  test("rejects the 'never' type", () => {
+    expect<never>().type.toBeAssignableWith<{ a: number }>(); // use '.toBeNever()'
+    expect<never>().type.not.toBeAssignableWith<{ a: number }>();
+  });
+
+  test("allows '.toBeNever()'", () => {
+    expect<never>().type.toBeNever();
+  });
+});
+
+describe("argument for 'target'", () => {
+  test("rejects the 'never' type", () => {
+    expect({ b: "abc" }).type.toBeAssignableWith({} as never); // use '.toBeNever()'
+    expect({ b: "abc" }).type.not.toBeAssignableWith({} as never);
+  });
+
+  test("allows '.toBeNever()'", () => {
+    expect({ b: "abc" }).type.not.toBeNever();
+  });
+});
+
+describe("type argument for 'Target'", () => {
+  test("rejects the 'never' type", () => {
+    expect<{ a: number }>().type.toAcceptProps<never>(); // use '.toBeNever()'
+    expect<{ a: number }>().type.not.toAcceptProps<never>();
+  });
+
+  test("allows '.toBeNever()'", () => {
+    expect<{ a: number }>().type.not.toBeNever();
+  });
+});
+`;
+
+const tsconfig = {
+  extends: "../../tsconfig.json",
+  include: ["**/*"],
+};
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'rejectNeverType' config file option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when enabled", async () => {
+    const config = {
+      rejectNeverType: true,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isRejected.test.ts"]: isRejectedText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-enabled-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-enabled-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when disabled", async () => {
+    const config = {
+      rejectNeverType: false,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isRejected.test.ts"]: isRejectedText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-disabled-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-disabled-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+});

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,4 +1,6 @@
 {
   "$schema": "./models/config-schema.json",
+  "rejectAnyType": true,
+  "rejectNeverType": true,
   "testFileMatch": ["examples/*.t*st.*", "models/__typetests__/*.tst.*", "tests/*.test.*"]
 }


### PR DESCRIPTION
Closes #367
Closes #368

Adding the `rejectAnyType` and `rejectNeverType` configuration options. For now they are left as opt-in, but TSTyche 4 will enable these additional checks by default.

---

The idea is to reject the `any` or `never` types passed as arguments to the `expect()` function or any matcher.

In #367 only assignability matchers are mentioned, but `.toBe()` can create false positives as well. Image a conditional type `Result` and `getResult()` method that returns that type:

```ts
import { type Result, getResult } from "example";
import { expect } from "tstyche";

expect(getResult("sample")).type.toBe<Result<string>>();
expect(getResult(123)).type.toBe<Result<number>>();
```

If after refactoring `Result` would always resolve to `never` or `any`, the above test will continue to pass.

Alternative solution could be adding `.not.toBeAny()` and `.not.toBeNever()`. But that sounds like a repetitive and easy to forget boilerplate. Much better solution is to use `rejectAnyType` and `rejectNeverType`.

---

@SerkanSipahi, thanks for pointing it out! Your https://github.com/tstyche/tstyche/issues/367#issuecomment-2473053987 made me think wider about this problem.