### PR TITLE
fix: allow specifying unsupported versions in `target` ranges

### DIFF
--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -41,6 +41,10 @@ export class Config {
 
     await commandLineParser.parse(commandLine);
 
+    if (commandLineOptions.target != null) {
+      commandLineOptions.target = await Target.expand(commandLineOptions.target);
+    }
+
     return { commandLineOptions, pathMatch };
   }
 
@@ -67,6 +71,10 @@ export class Config {
       );
 
       await configFileParser.parse();
+
+      if (configFileOptions.target != null) {
+        configFileOptions.target = await Target.expand(configFileOptions.target);
+      }
     }
 
     return { configFileOptions, configFilePath };
@@ -90,8 +98,6 @@ export class Config {
       // biome-ignore lint/performance/noDelete: must clean up
       delete resolvedConfig.config;
     }
-
-    resolvedConfig.target = Target.expand(resolvedConfig.target);
 
     return resolvedConfig;
   }

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -307,22 +307,7 @@ export class Options {
       case "target": {
         // maybe a range?
         if (/[<>=]/.test(optionValue)) {
-          if (Target.isRange(optionValue)) {
-            for (const value of optionValue.split(" ").map((value) => value.replace(/^[<>]=?/, ""))) {
-              if ((await Store.validateTag(value)) === false) {
-                onDiagnostics(
-                  Diagnostic.error(
-                    [
-                      ConfigDiagnosticText.versionIsNotSupported(value),
-                      ...ConfigDiagnosticText.usage(optionName, optionBrand),
-                      ConfigDiagnosticText.inspectSupportedVersions(),
-                    ],
-                    origin,
-                  ),
-                );
-              }
-            }
-          } else {
+          if (!Target.isRange(optionValue)) {
             onDiagnostics(
               Diagnostic.error(
                 [ConfigDiagnosticText.rangeIsNotValid(optionValue), ...ConfigDiagnosticText.rangeUsage()],

--- a/source/store/ManifestService.ts
+++ b/source/store/ManifestService.ts
@@ -92,6 +92,7 @@ export class ManifestService {
       }
     }
 
+    // TODO include 'minorVersions' in the manifest in TSTyche 4
     return new Manifest({ npmRegistry: this.#npmRegistry, packages, resolutions, versions });
   }
 

--- a/tests/config-target.test.js
+++ b/tests/config-target.test.js
@@ -71,8 +71,7 @@ await test("'--target' command line option", async (t) => {
       ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
-    const args = ["--target", '">5.1"', "--showConfig"];
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, args);
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '">5.1"', "--showConfig"]);
 
     assert.match(stdout, /"target": \[\n {4}"5\.2",\n {4}"5\.3",\n {4}"5\.4",\n {4}"5\.5"/);
 
@@ -86,13 +85,26 @@ await test("'--target' command line option", async (t) => {
       ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 
-    const args = ["--target", '">=5.3 <5.5"'];
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, args);
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '">=5.3 <5.5"']);
 
     await assert.matchSnapshot(normalizeOutput(stdout), {
       fileName: `${testFileName}-upper-bound-version-range-stdout`,
       testFileUrl: import.meta.url,
     });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when range with not supported version is specified", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '">=5.4 <8.2"', "--showConfig"]);
+
+    assert.match(stdout, /"target": \[\n {4}"5\.4",\n {4}"5\.5",\n {4}"5\.6",\n {4}"5\.7"/);
 
     assert.equal(stderr, "");
     assert.equal(exitCode, 0);
@@ -275,6 +287,25 @@ await test("'target' configuration file option", async (t) => {
       fileName: `${testFileName}-upper-bound-version-range-stdout`,
       testFileUrl: import.meta.url,
     });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when range with not supported version is specified", async () => {
+    const config = {
+      target: [">=5.4 <8.2"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"]);
+
+    assert.match(stdout, /"target": \[\n {4}"5\.4",\n {4}"5\.5",\n {4}"5\.6",\n {4}"5\.7"/);
 
     assert.equal(stderr, "");
     assert.equal(exitCode, 0);

--- a/tests/validation-target.test.js
+++ b/tests/validation-target.test.js
@@ -56,24 +56,6 @@ await test("'--target' command line option", async (t) => {
     assert.equal(exitCode, 1);
   });
 
-  await t.test("when range with not supported version is specified", async () => {
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '">=3.2"']);
-
-    assert.equal(stdout, "");
-
-    const expected = [
-      "Error: TypeScript version '3.2' is not supported.",
-      "",
-      "Value for the '--target' option must be a string or a comma separated list.",
-      "Examples: '--target 5.2', '--target next', '--target '>=5.0 <5.3, 5.4.2, >=5.5''.",
-      "Use the '--list' command line option to inspect the list of supported versions.",
-      "\n",
-    ].join("\n");
-
-    assert.equal(stderr, expected);
-    assert.equal(exitCode, 1);
-  });
-
   await t.test("when not valid range is specified", async () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '"5.2 >=5.4"']);
 
@@ -181,29 +163,6 @@ await test("'target' configuration file option", async (t) => {
 
     await assert.matchSnapshot(stderr, {
       fileName: `${testFileName}-not-supported-version-stderr`,
-      testFileUrl: import.meta.url,
-    });
-
-    assert.equal(exitCode, 1);
-  });
-
-  await t.test("when range with not supported version is specified", async () => {
-    const config = {
-      target: [">=3.2"],
-      testFileMatch: ["examples/*.tst.*"],
-    };
-
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
-    });
-
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
-
-    assert.equal(stdout, "");
-
-    await assert.matchSnapshot(stderr, {
-      fileName: `${testFileName}-range-with-not-supported-version-stderr`,
       testFileUrl: import.meta.url,
     });
 


### PR DESCRIPTION
Closes #380

Currently `target` ranges only allow specifying supported minor versions. The following does not work: `--target '>=5.2 <5.8'`. But it should be allowed.