### PR TITLE
perf: alter compiler options only when needed

### DIFF
--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -107,8 +107,10 @@ export class ProjectService {
       /* ensureProject */ true,
     );
 
-    if (this.#resolvedConfig.checkSourceFiles) {
-      project?.setCompilerOptions({ ...project?.getCompilerOptions(), skipLibCheck: false });
+    const compilerOptions = project?.getCompilerOptions();
+
+    if (this.#resolvedConfig.checkSourceFiles && compilerOptions?.skipLibCheck) {
+      project?.setCompilerOptions({ ...compilerOptions, skipLibCheck: false });
     }
 
     return project;
@@ -149,8 +151,6 @@ export class ProjectService {
 
       const program = languageService?.getProgram();
 
-      // TODO
-      //      - check how inferred projects are handled
       if (!program || this.#seenPrograms.has(program)) {
         return;
       }


### PR DESCRIPTION
To maximise performance, compiler options must be altered only when needed.