### PR TITLE
fix: print error codes at the end of the first line of diagnostics

### DIFF
--- a/source/expect/ToRaiseError.ts
+++ b/source/expect/ToRaiseError.ts
@@ -29,7 +29,7 @@ export class ToRaiseError {
 
       const related = [
         Diagnostic.error(ExpectDiagnosticText.raisedTypeError(count)),
-        ...Diagnostic.fromDiagnostics([...matchWorker.assertion.diagnostics], this.#compiler),
+        ...Diagnostic.fromDiagnostics([...matchWorker.assertion.diagnostics]),
       ];
 
       return [Diagnostic.error(text, origin).add({ related })];
@@ -49,7 +49,7 @@ export class ToRaiseError {
 
         const related = [
           Diagnostic.error(ExpectDiagnosticText.raisedTypeError()),
-          ...Diagnostic.fromDiagnostics([diagnostic], this.#compiler),
+          ...Diagnostic.fromDiagnostics([diagnostic]),
         ];
 
         accumulator.push(Diagnostic.error(text, origin).add({ related }));

--- a/source/output/diagnosticText.tsx
+++ b/source/output/diagnosticText.tsx
@@ -16,7 +16,7 @@ function DiagnosticText({ diagnostic }: DiagnosticTextProps) {
       {index === 1 ? <Line /> : undefined}
       <Line>
         {text}
-        {code}
+        {index === 0 ? code : undefined}
       </Line>
     </Text>
   ));

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -142,7 +142,7 @@ export class ProjectService {
     if (configFileErrors && configFileErrors.length > 0) {
       EventEmitter.dispatch([
         "project:error",
-        { diagnostics: Diagnostic.fromDiagnostics(configFileErrors as Array<ts.Diagnostic>, this.#compiler) },
+        { diagnostics: Diagnostic.fromDiagnostics(configFileErrors as Array<ts.Diagnostic>) },
       ]);
     }
 
@@ -176,10 +176,7 @@ export class ProjectService {
       }
 
       if (diagnostics.length > 0) {
-        EventEmitter.dispatch([
-          "project:error",
-          { diagnostics: Diagnostic.fromDiagnostics(diagnostics, this.#compiler) },
-        ]);
+        EventEmitter.dispatch(["project:error", { diagnostics: Diagnostic.fromDiagnostics(diagnostics) }]);
 
         return;
       }

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -67,7 +67,7 @@ export class TaskRunner {
     if (syntacticDiagnostics.length > 0) {
       EventEmitter.dispatch([
         "task:error",
-        { diagnostics: Diagnostic.fromDiagnostics(syntacticDiagnostics, this.#compiler), result: taskResult },
+        { diagnostics: Diagnostic.fromDiagnostics(syntacticDiagnostics), result: taskResult },
       ]);
 
       return;
@@ -92,7 +92,7 @@ export class TaskRunner {
     if (testTree.diagnostics.size > 0) {
       EventEmitter.dispatch([
         "task:error",
-        { diagnostics: Diagnostic.fromDiagnostics([...testTree.diagnostics], this.#compiler), result: taskResult },
+        { diagnostics: Diagnostic.fromDiagnostics([...testTree.diagnostics]), result: taskResult },
       ]);
 
       return;

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -130,7 +130,7 @@ export class TestTreeWalker {
     };
 
     if (assertion.diagnostics.size > 0 && assertion.matcherName.getText() !== "toRaiseError") {
-      onExpectDiagnostics(Diagnostic.fromDiagnostics([...assertion.diagnostics], this.#compiler));
+      onExpectDiagnostics(Diagnostic.fromDiagnostics([...assertion.diagnostics]));
 
       return;
     }
@@ -172,7 +172,7 @@ export class TestTreeWalker {
       EventEmitter.dispatch([
         "task:error",
         {
-          diagnostics: Diagnostic.fromDiagnostics([...describe.diagnostics], this.#compiler),
+          diagnostics: Diagnostic.fromDiagnostics([...describe.diagnostics]),
           result: this.#taskResult,
         },
       ]);
@@ -200,7 +200,7 @@ export class TestTreeWalker {
       EventEmitter.dispatch([
         "test:error",
         {
-          diagnostics: Diagnostic.fromDiagnostics([...test.diagnostics], this.#compiler),
+          diagnostics: Diagnostic.fromDiagnostics([...test.diagnostics]),
           result: testResult,
         },
       ]);

--- a/tests/__fixtures__/validation-type-errors/__typetests__/top-level.tst.ts
+++ b/tests/__fixtures__/validation-type-errors/__typetests__/top-level.tst.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "tstyche";
+import type ts from "typescript";
 
 test("is string?", () => {
   expect<string>().type.toBeString();
@@ -13,3 +14,7 @@ if (a > 9) {
 test(284963, () => {
   expect<string>().type.toBeString();
 });
+
+declare function silence(d: ts.DiagnosticWithLocation): void;
+
+silence({} as ts.Diagnostic);

--- a/tests/__snapshots__/config-checkSourceFiles-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-checkSourceFiles-enabled-stderr.snap.txt
@@ -1,5 +1,6 @@
-Error: This expression is not callable.
-  Type 'Boolean' has no call signatures. ts(2349)
+Error: This expression is not callable. ts(2349)
+
+Type 'Boolean' has no call signatures.
 
   1 | export type Sample = { a: string };
   2 | 
@@ -31,8 +32,9 @@ Error: Statements are not allowed in ambient contexts. ts(1036)
 
        at ./__typetests__/ambient.d.ts:9:1
 
-Error: This expression is not callable.
-  Type 'Boolean' has no call signatures. ts(2349)
+Error: This expression is not callable. ts(2349)
+
+Type 'Boolean' has no call signatures.
 
    7 | export type ParseKeys<const Context extends {}> = Context;
    8 | 

--- a/tests/__snapshots__/validation-type-errors-top-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-top-level-errors-stderr.snap.txt
@@ -1,24 +1,38 @@
 Error: Type 'string' is not assignable to type 'number'. ts(2322)
 
-   5 | });
-   6 | 
-   7 | const a: number = "nine";
+   6 | });
+   7 | 
+   8 | const a: number = "nine";
      |       ~
-   8 | 
-   9 | if (a > 9) {
-  10 |   //
+   9 | 
+  10 | if (a > 9) {
+  11 |   //
 
-       at ./__typetests__/top-level.tst.ts:7:7
+       at ./__typetests__/top-level.tst.ts:8:7
 
 Error: Argument of type 'number' is not assignable to parameter of type 'string'. ts(2345)
 
-  11 | }
-  12 | 
-  13 | test(284963, () => {
+  12 | }
+  13 | 
+  14 | test(284963, () => {
      |      ~~~~~~
-  14 |   expect<string>().type.toBeString();
-  15 | });
-  16 | 
+  15 |   expect<string>().type.toBeString();
+  16 | });
+  17 | 
 
-       at ./__typetests__/top-level.tst.ts:13:6
+       at ./__typetests__/top-level.tst.ts:14:6
+
+Error: Argument of type 'Diagnostic' is not assignable to parameter of type 'DiagnosticWithLocation'. ts(2345)
+
+Types of property 'file' are incompatible.
+Type 'SourceFile | undefined' is not assignable to type 'SourceFile'.
+Type 'undefined' is not assignable to type 'SourceFile'.
+
+  18 | declare function silence(d: ts.DiagnosticWithLocation): void;
+  19 | 
+  20 | silence({} as ts.Diagnostic);
+     |         ~~~~~~~~~~~~~~~~~~~
+  21 | 
+
+       at ./__typetests__/top-level.tst.ts:20:9
 


### PR DESCRIPTION
Error codes belong at the end of the first line of diagnostics. Therefor they must be print like this:

<img width="468" alt="Screenshot 2024-12-24 at 14 29 14" src="https://github.com/user-attachments/assets/f1bb37f0-8140-494c-92b1-f035774b5f4e" />
