### PR TITLE
fix: treat intersections or unions of identical types as identical to its constituent type

### DIFF
--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -83,8 +83,13 @@ export class MatchWorker {
 
     let result = this.#typeChecker.isTypeRelatedTo(sourceType, targetType, relation);
 
-    // expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
-    if (!result && relation === this.#typeChecker.relation.identity && sourceType.isUnion()) {
+    if (
+      !result &&
+      relation === this.#typeChecker.relation.identity &&
+      // expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
+      // expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
+      (sourceType.isIntersection() || sourceType.isUnion())
+    ) {
       result = sourceType.types.every((type) => this.#typeChecker.isTypeRelatedTo(type, targetType, relation));
     }
 

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -81,11 +81,14 @@ export class MatchWorker {
     const sourceType = this.getType(sourceNode);
     const targetType = this.getType(targetNode);
 
-    if (relation === this.#typeChecker.relation.identity && sourceType.isUnion()) {
-      return sourceType.types.every((type) => this.#typeChecker.isTypeRelatedTo(type, targetType, relation));
+    let result = this.#typeChecker.isTypeRelatedTo(sourceType, targetType, relation);
+
+    // expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
+    if (!result && relation === this.#typeChecker.relation.identity && sourceType.isUnion()) {
+      result = sourceType.types.every((type) => this.#typeChecker.isTypeRelatedTo(type, targetType, relation));
     }
 
-    return this.#typeChecker.isTypeRelatedTo(sourceType, targetType, relation);
+    return result;
   }
 
   extendsObjectType(type: ts.Type): boolean {

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -81,6 +81,10 @@ export class MatchWorker {
     const sourceType = this.getType(sourceNode);
     const targetType = this.getType(targetNode);
 
+    if (relation === this.#typeChecker.relation.identity && sourceType.isUnion()) {
+      return sourceType.types.every((type) => this.#typeChecker.isTypeRelatedTo(type, targetType, relation));
+    }
+
     return this.#typeChecker.isTypeRelatedTo(sourceType, targetType, relation);
   }
 

--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -19,8 +19,14 @@ test("edge cases", () => {
   expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
   expect<{ a: string } | { a: string }>().type.not.toBe<{ a: string }>();
 
+  expect<{ a: string } | { b: string }>().type.not.toBe<{ a: string }>();
+  expect<{ a: string } | { b: string }>().type.toBe<{ a: string }>();
+
   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
+
+  expect<{ a: string } & { b: string }>().type.not.toBe<{ a: string }>();
+  expect<{ a: string } & { b: string }>().type.toBe<{ a: string }>();
 
   expect(Date).type.toBe<typeof Date>();
 });

--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -16,6 +16,9 @@ test("edge cases", () => {
   expect<any>().type.not.toBe<never>();
   expect<any>().type.not.toBe<unknown>();
 
+  expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
+  expect<{ a: string } | { a: string }>().type.not.toBe<{ a: string }>();
+
   expect(Date).type.toBe<typeof Date>();
 });
 

--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -19,6 +19,9 @@ test("edge cases", () => {
   expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
   expect<{ a: string } | { a: string }>().type.not.toBe<{ a: string }>();
 
+  expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
+  expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
+
   expect(Date).type.toBe<typeof Date>();
 });
 

--- a/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
@@ -17,7 +17,7 @@ pass ./__typetests__/toBe.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      9 skipped, 1 passed, 10 total
-Assertions: 24 skipped, 4 passed, 28 total
+Assertions: 26 skipped, 4 passed, 30 total
 Duration:   <<timestamp>>
 
 Ran tests matching 'exact' in all test files.

--- a/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
@@ -17,7 +17,7 @@ pass ./__typetests__/toBe.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      9 skipped, 1 passed, 10 total
-Assertions: 26 skipped, 4 passed, 30 total
+Assertions: 30 skipped, 4 passed, 34 total
 Duration:   <<timestamp>>
 
 Ran tests matching 'exact' in all test files.

--- a/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
@@ -17,7 +17,7 @@ pass ./__typetests__/toBe.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      9 skipped, 1 passed, 10 total
-Assertions: 22 skipped, 4 passed, 26 total
+Assertions: 24 skipped, 4 passed, 28 total
 Duration:   <<timestamp>>
 
 Ran tests matching 'exact' in all test files.

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -5,164 +5,188 @@ Error: Type '{ a: string; } | { a: string; }' is identical to type '{ a: string;
   20 |   expect<{ a: string } | { a: string }>().type.not.toBe<{ a: string }>();
      |                                                         ~~~~~~~~~~~~~
   21 | 
-  22 |   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
-  23 |   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
+  22 |   expect<{ a: string } | { b: string }>().type.not.toBe<{ a: string }>();
+  23 |   expect<{ a: string } | { b: string }>().type.toBe<{ a: string }>();
 
        at ./__typetests__/toBe.tst.ts:20:57 ❭ edge cases
 
-Error: Type '{ a: string; } & { a: string; }' is identical to type '{ a: string; }'.
+Error: Type '{ a: string; } | { b: string; }' is not identical to type '{ a: string; }'.
 
   21 | 
-  22 |   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
-  23 |   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
-     |                                                         ~~~~~~~~~~~~~
+  22 |   expect<{ a: string } | { b: string }>().type.not.toBe<{ a: string }>();
+  23 |   expect<{ a: string } | { b: string }>().type.toBe<{ a: string }>();
+     |                                                     ~~~~~~~~~~~~~
   24 | 
-  25 |   expect(Date).type.toBe<typeof Date>();
-  26 | });
+  25 |   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
+  26 |   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
 
-       at ./__typetests__/toBe.tst.ts:23:57 ❭ edge cases
+       at ./__typetests__/toBe.tst.ts:23:53 ❭ edge cases
+
+Error: Type '{ a: string; } & { a: string; }' is identical to type '{ a: string; }'.
+
+  24 | 
+  25 |   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
+  26 |   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
+     |                                                         ~~~~~~~~~~~~~
+  27 | 
+  28 |   expect<{ a: string } & { b: string }>().type.not.toBe<{ a: string }>();
+  29 |   expect<{ a: string } & { b: string }>().type.toBe<{ a: string }>();
+
+       at ./__typetests__/toBe.tst.ts:26:57 ❭ edge cases
+
+Error: Type '{ a: string; } & { b: string; }' is not identical to type '{ a: string; }'.
+
+  27 | 
+  28 |   expect<{ a: string } & { b: string }>().type.not.toBe<{ a: string }>();
+  29 |   expect<{ a: string } & { b: string }>().type.toBe<{ a: string }>();
+     |                                                     ~~~~~~~~~~~~~
+  30 | 
+  31 |   expect(Date).type.toBe<typeof Date>();
+  32 | });
+
+       at ./__typetests__/toBe.tst.ts:29:53 ❭ edge cases
 
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  29 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
-  30 | 
-  31 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  35 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  36 | 
+  37 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  32 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  33 | 
-  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  38 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  39 | 
+  40 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
 
-       at ./__typetests__/toBe.tst.ts:31:42 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:37:42 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  30 | 
-  31 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
-  32 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  36 | 
+  37 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  38 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
      |                                                      ~~~~~~~~~~~~~~
-  33 | 
-  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  35 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  39 | 
+  40 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  41 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
 
-       at ./__typetests__/toBe.tst.ts:32:54 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:38:54 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable with type '{ a?: number | undefined; }'.
 
-  32 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  33 | 
-  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  38 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  39 | 
+  40 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  35 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
-  36 | });
-  37 | 
+  41 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  42 | });
+  43 | 
 
-       at ./__typetests__/toBe.tst.ts:34:56 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:40:56 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable to type '{ a?: number | undefined; }'.
 
-  33 | 
-  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  35 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  39 | 
+  40 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  41 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
      |                                                                  ~~~~~~~~~~~~~~
-  36 | });
-  37 | 
-  38 | describe("source type", () => {
+  42 | });
+  43 | 
+  44 | describe("source type", () => {
 
-       at ./__typetests__/toBe.tst.ts:35:66 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:41:66 ❭ exact optional property types
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  41 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
-  42 | 
-  43 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+  47 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
+  48 | 
+  49 |     expect<Names>().type.toBe<{ first: string; last: string }>();
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  44 |   });
-  45 | 
-  46 |   test("is NOT identical to target type", () => {
+  50 |   });
+  51 | 
+  52 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:43:31 ❭ source type ❭ is identical to target type
+       at ./__typetests__/toBe.tst.ts:49:31 ❭ source type ❭ is identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  47 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
-  48 | 
-  49 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+  53 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
+  54 | 
+  55 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  50 |   });
-  51 | 
-  52 |   test("is identical to target expression", () => {
+  56 |   });
+  57 | 
+  58 |   test("is identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:49:35 ❭ source type ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:55:35 ❭ source type ❭ is NOT identical to target type
 
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
-  54 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
-  55 | 
-  56 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+  60 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
+  61 | 
+  62 |     expect<{ first: string; last: string }>().type.toBe(getNames());
      |                                                         ~~~~~~~~~~
-  57 |   });
-  58 | 
-  59 |   test("is NOT identical to target expression", () => {
+  63 |   });
+  64 | 
+  65 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:56:57 ❭ source type ❭ is identical to target expression
+       at ./__typetests__/toBe.tst.ts:62:57 ❭ source type ❭ is identical to target expression
 
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
-  60 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
-  61 | 
-  62 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+  66 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
+  67 | 
+  68 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
      |                                                              ~~~~~~~~~~
-  63 |   });
-  64 | });
-  65 | 
+  69 |   });
+  70 | });
+  71 | 
 
-       at ./__typetests__/toBe.tst.ts:62:62 ❭ source type ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:68:62 ❭ source type ❭ is NOT identical to target expression
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  69 |     expect(getNames()).type.toBe<Names>();
-  70 | 
-  71 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+  75 |     expect(getNames()).type.toBe<Names>();
+  76 | 
+  77 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  72 |   });
-  73 | 
-  74 |   test("is NOT identical to target type", () => {
+  78 |   });
+  79 | 
+  80 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:71:34 ❭ source expression ❭ identical to target type
+       at ./__typetests__/toBe.tst.ts:77:34 ❭ source expression ❭ identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  75 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
-  76 | 
-  77 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+  81 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
+  82 | 
+  83 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  78 |   });
-  79 | 
-  80 |   test("identical to target expression", () => {
+  84 |   });
+  85 | 
+  86 |   test("identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:77:38 ❭ source expression ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:83:38 ❭ source expression ❭ is NOT identical to target type
 
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
-  81 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
-  82 | 
-  83 |     expect({ height: 14 }).type.toBe(getSize());
+  87 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
+  88 | 
+  89 |     expect({ height: 14 }).type.toBe(getSize());
      |                                      ~~~~~~~~~
-  84 |   });
-  85 | 
-  86 |   test("is NOT identical to target expression", () => {
+  90 |   });
+  91 | 
+  92 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:83:38 ❭ source expression ❭ identical to target expression
+       at ./__typetests__/toBe.tst.ts:89:38 ❭ source expression ❭ identical to target expression
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
-  87 |     expect({ height: 14 }).type.not.toBe(getSize());
-  88 | 
-  89 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+  93 |     expect({ height: 14 }).type.not.toBe(getSize());
+  94 | 
+  95 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
      |                                                     ~~~~~~~~~
-  90 |   });
-  91 | });
-  92 | 
+  96 |   });
+  97 | });
+  98 | 
 
-       at ./__typetests__/toBe.tst.ts:89:53 ❭ source expression ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:95:53 ❭ source expression ❭ is NOT identical to target expression
 

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -5,152 +5,164 @@ Error: Type '{ a: string; } | { a: string; }' is identical to type '{ a: string;
   20 |   expect<{ a: string } | { a: string }>().type.not.toBe<{ a: string }>();
      |                                                         ~~~~~~~~~~~~~
   21 | 
-  22 |   expect(Date).type.toBe<typeof Date>();
-  23 | });
+  22 |   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
+  23 |   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
 
        at ./__typetests__/toBe.tst.ts:20:57 ❭ edge cases
 
+Error: Type '{ a: string; } & { a: string; }' is identical to type '{ a: string; }'.
+
+  21 | 
+  22 |   expect<{ a: string } & { a: string }>().type.toBe<{ a: string }>();
+  23 |   expect<{ a: string } & { a: string }>().type.not.toBe<{ a: string }>();
+     |                                                         ~~~~~~~~~~~~~
+  24 | 
+  25 |   expect(Date).type.toBe<typeof Date>();
+  26 | });
+
+       at ./__typetests__/toBe.tst.ts:23:57 ❭ edge cases
+
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  26 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
-  27 | 
-  28 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  29 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  30 | 
+  31 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  29 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  30 | 
-  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  32 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  33 | 
+  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
 
-       at ./__typetests__/toBe.tst.ts:28:42 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:31:42 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  27 | 
-  28 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
-  29 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-     |                                                      ~~~~~~~~~~~~~~
   30 | 
-  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  32 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  31 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  32 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+     |                                                      ~~~~~~~~~~~~~~
+  33 | 
+  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  35 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
 
-       at ./__typetests__/toBe.tst.ts:29:54 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:32:54 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable with type '{ a?: number | undefined; }'.
 
-  29 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  30 | 
-  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  32 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  33 | 
+  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  32 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
-  33 | });
-  34 | 
+  35 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  36 | });
+  37 | 
 
-       at ./__typetests__/toBe.tst.ts:31:56 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:34:56 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable to type '{ a?: number | undefined; }'.
 
-  30 | 
-  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  32 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  33 | 
+  34 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  35 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
      |                                                                  ~~~~~~~~~~~~~~
-  33 | });
-  34 | 
-  35 | describe("source type", () => {
+  36 | });
+  37 | 
+  38 | describe("source type", () => {
 
-       at ./__typetests__/toBe.tst.ts:32:66 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:35:66 ❭ exact optional property types
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  38 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
-  39 | 
-  40 |     expect<Names>().type.toBe<{ first: string; last: string }>();
-     |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  41 |   });
+  41 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
   42 | 
-  43 |   test("is NOT identical to target type", () => {
+  43 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+     |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  44 |   });
+  45 | 
+  46 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:40:31 ❭ source type ❭ is identical to target type
+       at ./__typetests__/toBe.tst.ts:43:31 ❭ source type ❭ is identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  44 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
-  45 | 
-  46 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
-     |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  47 |   });
+  47 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
   48 | 
-  49 |   test("is identical to target expression", () => {
+  49 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+     |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  50 |   });
+  51 | 
+  52 |   test("is identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:46:35 ❭ source type ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:49:35 ❭ source type ❭ is NOT identical to target type
 
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
-  51 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
-  52 | 
-  53 |     expect<{ first: string; last: string }>().type.toBe(getNames());
-     |                                                         ~~~~~~~~~~
-  54 |   });
+  54 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
   55 | 
-  56 |   test("is NOT identical to target expression", () => {
+  56 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+     |                                                         ~~~~~~~~~~
+  57 |   });
+  58 | 
+  59 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:53:57 ❭ source type ❭ is identical to target expression
+       at ./__typetests__/toBe.tst.ts:56:57 ❭ source type ❭ is identical to target expression
 
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
-  57 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
-  58 | 
-  59 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+  60 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
+  61 | 
+  62 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
      |                                                              ~~~~~~~~~~
-  60 |   });
-  61 | });
-  62 | 
+  63 |   });
+  64 | });
+  65 | 
 
-       at ./__typetests__/toBe.tst.ts:59:62 ❭ source type ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:62:62 ❭ source type ❭ is NOT identical to target expression
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  66 |     expect(getNames()).type.toBe<Names>();
-  67 | 
-  68 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
-     |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  69 |   });
+  69 |     expect(getNames()).type.toBe<Names>();
   70 | 
-  71 |   test("is NOT identical to target type", () => {
+  71 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+     |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  72 |   });
+  73 | 
+  74 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:68:34 ❭ source expression ❭ identical to target type
+       at ./__typetests__/toBe.tst.ts:71:34 ❭ source expression ❭ identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  72 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
-  73 | 
-  74 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
-     |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  75 |   });
+  75 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
   76 | 
-  77 |   test("identical to target expression", () => {
+  77 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+     |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  78 |   });
+  79 | 
+  80 |   test("identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:74:38 ❭ source expression ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:77:38 ❭ source expression ❭ is NOT identical to target type
 
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
-  78 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
-  79 | 
-  80 |     expect({ height: 14 }).type.toBe(getSize());
-     |                                      ~~~~~~~~~
-  81 |   });
+  81 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
   82 | 
-  83 |   test("is NOT identical to target expression", () => {
+  83 |     expect({ height: 14 }).type.toBe(getSize());
+     |                                      ~~~~~~~~~
+  84 |   });
+  85 | 
+  86 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:80:38 ❭ source expression ❭ identical to target expression
+       at ./__typetests__/toBe.tst.ts:83:38 ❭ source expression ❭ identical to target expression
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
-  84 |     expect({ height: 14 }).type.not.toBe(getSize());
-  85 | 
-  86 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+  87 |     expect({ height: 14 }).type.not.toBe(getSize());
+  88 | 
+  89 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
      |                                                     ~~~~~~~~~
-  87 |   });
-  88 | });
-  89 | 
+  90 |   });
+  91 | });
+  92 | 
 
-       at ./__typetests__/toBe.tst.ts:86:53 ❭ source expression ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:89:53 ❭ source expression ❭ is NOT identical to target expression
 

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -1,144 +1,156 @@
+Error: Type '{ a: string; } | { a: string; }' is identical to type '{ a: string; }'.
+
+  18 | 
+  19 |   expect<{ a: string } | { a: string }>().type.toBe<{ a: string }>();
+  20 |   expect<{ a: string } | { a: string }>().type.not.toBe<{ a: string }>();
+     |                                                         ~~~~~~~~~~~~~
+  21 | 
+  22 |   expect(Date).type.toBe<typeof Date>();
+  23 | });
+
+       at ./__typetests__/toBe.tst.ts:20:57 ❭ edge cases
+
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  23 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
-  24 | 
-  25 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  26 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  27 | 
+  28 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  26 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  27 | 
-  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  29 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  30 | 
+  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
 
-       at ./__typetests__/toBe.tst.ts:25:42 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:28:42 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  24 | 
-  25 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
-  26 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-     |                                                      ~~~~~~~~~~~~~~
   27 | 
-  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  29 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  28 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  29 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+     |                                                      ~~~~~~~~~~~~~~
+  30 | 
+  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  32 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
 
-       at ./__typetests__/toBe.tst.ts:26:54 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:29:54 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable with type '{ a?: number | undefined; }'.
 
-  26 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  27 | 
-  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  29 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  30 | 
+  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  29 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
-  30 | });
-  31 | 
+  32 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  33 | });
+  34 | 
 
-       at ./__typetests__/toBe.tst.ts:28:56 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:31:56 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable to type '{ a?: number | undefined; }'.
 
-  27 | 
-  28 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  29 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  30 | 
+  31 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  32 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
      |                                                                  ~~~~~~~~~~~~~~
-  30 | });
-  31 | 
-  32 | describe("source type", () => {
+  33 | });
+  34 | 
+  35 | describe("source type", () => {
 
-       at ./__typetests__/toBe.tst.ts:29:66 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:32:66 ❭ exact optional property types
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  35 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
-  36 | 
-  37 |     expect<Names>().type.toBe<{ first: string; last: string }>();
-     |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  38 |   });
+  38 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
   39 | 
-  40 |   test("is NOT identical to target type", () => {
+  40 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+     |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  41 |   });
+  42 | 
+  43 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:37:31 ❭ source type ❭ is identical to target type
+       at ./__typetests__/toBe.tst.ts:40:31 ❭ source type ❭ is identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  41 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
-  42 | 
-  43 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
-     |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  44 |   });
+  44 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
   45 | 
-  46 |   test("is identical to target expression", () => {
+  46 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+     |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  47 |   });
+  48 | 
+  49 |   test("is identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:43:35 ❭ source type ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:46:35 ❭ source type ❭ is NOT identical to target type
 
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
-  48 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
-  49 | 
-  50 |     expect<{ first: string; last: string }>().type.toBe(getNames());
-     |                                                         ~~~~~~~~~~
-  51 |   });
+  51 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
   52 | 
-  53 |   test("is NOT identical to target expression", () => {
+  53 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+     |                                                         ~~~~~~~~~~
+  54 |   });
+  55 | 
+  56 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:50:57 ❭ source type ❭ is identical to target expression
+       at ./__typetests__/toBe.tst.ts:53:57 ❭ source type ❭ is identical to target expression
 
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
-  54 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
-  55 | 
-  56 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+  57 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
+  58 | 
+  59 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
      |                                                              ~~~~~~~~~~
-  57 |   });
-  58 | });
-  59 | 
+  60 |   });
+  61 | });
+  62 | 
 
-       at ./__typetests__/toBe.tst.ts:56:62 ❭ source type ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:59:62 ❭ source type ❭ is NOT identical to target expression
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  63 |     expect(getNames()).type.toBe<Names>();
-  64 | 
-  65 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
-     |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  66 |   });
+  66 |     expect(getNames()).type.toBe<Names>();
   67 | 
-  68 |   test("is NOT identical to target type", () => {
+  68 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+     |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  69 |   });
+  70 | 
+  71 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:65:34 ❭ source expression ❭ identical to target type
+       at ./__typetests__/toBe.tst.ts:68:34 ❭ source expression ❭ identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  69 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
-  70 | 
-  71 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
-     |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  72 |   });
+  72 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
   73 | 
-  74 |   test("identical to target expression", () => {
+  74 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+     |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  75 |   });
+  76 | 
+  77 |   test("identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:71:38 ❭ source expression ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:74:38 ❭ source expression ❭ is NOT identical to target type
 
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
-  75 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
-  76 | 
-  77 |     expect({ height: 14 }).type.toBe(getSize());
-     |                                      ~~~~~~~~~
-  78 |   });
+  78 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
   79 | 
-  80 |   test("is NOT identical to target expression", () => {
+  80 |     expect({ height: 14 }).type.toBe(getSize());
+     |                                      ~~~~~~~~~
+  81 |   });
+  82 | 
+  83 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:77:38 ❭ source expression ❭ identical to target expression
+       at ./__typetests__/toBe.tst.ts:80:38 ❭ source expression ❭ identical to target expression
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
-  81 |     expect({ height: 14 }).type.not.toBe(getSize());
-  82 | 
-  83 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+  84 |     expect({ height: 14 }).type.not.toBe(getSize());
+  85 | 
+  86 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
      |                                                     ~~~~~~~~~
-  84 |   });
-  85 | });
-  86 | 
+  87 |   });
+  88 | });
+  89 | 
 
-       at ./__typetests__/toBe.tst.ts:83:53 ❭ source expression ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:86:53 ❭ source expression ❭ is NOT identical to target expression
 

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -17,7 +17,7 @@ fail ./__typetests__/toBe.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      10 failed, 10 total
-Assertions: 13 failed, 15 passed, 28 total
+Assertions: 14 failed, 16 passed, 30 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -17,7 +17,7 @@ fail ./__typetests__/toBe.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      10 failed, 10 total
-Assertions: 14 failed, 16 passed, 30 total
+Assertions: 16 failed, 18 passed, 34 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -1,7 +1,7 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBe.tst.ts
-  + edge cases
+  × edge cases
   × exact optional property types
   source type
     × is identical to target type
@@ -16,8 +16,8 @@ fail ./__typetests__/toBe.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      9 failed, 1 passed, 10 total
-Assertions: 12 failed, 14 passed, 26 total
+Tests:      10 failed, 10 total
+Assertions: 13 failed, 15 passed, 28 total
 Duration:   <<timestamp>>
 
 Ran all test files.


### PR DESCRIPTION
Similar to what was mentioned in https://github.com/tsdjs/tsd/issues/223

An intersection like `{ a: string } & { a: string }` can be treated as identical to `{ a: string }`.
Or a union like `{ a: string } | { a: string }` can be treated as identical to `{ a: string }`.

EDIT: It would be nice to treat nested properties similarly as well. Leaving that for the bright future (;
