### PR TITLE
fix: simplify complex unions and intersections for identicality checks

### DIFF
--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -28,6 +28,12 @@ test("edge cases", () => {
   expect<{ a: string } & { b: string }>().type.not.toBe<{ a: string }>();
   expect<{ a: string } & { b: string }>().type.toBe<{ a: string }>();
 
+  expect<(({ a: string } & { a: string }) | { a: string }) & { a: string }>().type.toBe<{ a: string }>();
+  expect<(({ a: string } & { a: string }) | { a: string }) & { a: string }>().type.not.toBe<{ a: string }>();
+
+  expect<(({ a: string } & { a: string }) | { a: string }) & { b: string }>().type.not.toBe<{ a: string }>();
+  expect<(({ a: string } & { a: string }) | { a: string }) & { b: string }>().type.toBe<{ a: string }>();
+
   expect<{ a: string }>().type.toBe<{ a: string } | { a: string }>();
   expect<{ a: string }>().type.not.toBe<{ a: string } | { a: string }>();
 
@@ -39,6 +45,12 @@ test("edge cases", () => {
 
   expect<{ a: string }>().type.not.toBe<{ a: string } & { b: string }>();
   expect<{ a: string }>().type.toBe<{ a: string } & { b: string }>();
+
+  expect<{ a: string }>().type.toBe<(({ a: string } & { a: string }) | { a: string }) & { a: string }>();
+  expect<{ a: string }>().type.not.toBe<(({ a: string } & { a: string }) | { a: string }) & { a: string }>();
+
+  expect<{ a: string }>().type.not.toBe<(({ a: string } & { a: string }) | { a: string }) & { b: string }>();
+  expect<{ a: string }>().type.toBe<(({ a: string } & { a: string }) | { a: string }) & { b: string }>();
 
   expect(Date).type.toBe<typeof Date>();
 });

--- a/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
@@ -17,7 +17,7 @@ pass ./__typetests__/toBe.tst.ts
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
 Tests:      9 skipped, 1 passed, 10 total
-Assertions: 38 skipped, 4 passed, 42 total
+Assertions: 46 skipped, 4 passed, 50 total
 Duration:   <<timestamp>>
 
 Ran tests matching 'exact' in all test files.

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -41,200 +41,248 @@ Error: Type '{ a: string; } & { b: string; }' is not identical to type '{ a: str
   29 |   expect<{ a: string } & { b: string }>().type.toBe<{ a: string }>();
      |                                                     ~~~~~~~~~~~~~
   30 | 
-  31 |   expect<{ a: string }>().type.toBe<{ a: string } | { a: string }>();
-  32 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { a: string }>();
+  31 |   expect<(({ a: string } & { a: string }) | { a: string }) & { a: string }>().type.toBe<{ a: string }>();
+  32 |   expect<(({ a: string } & { a: string }) | { a: string }) & { a: string }>().type.not.toBe<{ a: string }>();
 
        at ./__typetests__/toBe.tst.ts:29:53 ❭ edge cases
 
-Error: Type '{ a: string; }' is identical to type '{ a: string; } | { a: string; }'.
+Error: Type '(({ a: string; } & { a: string; }) | { a: string; }) & { a: string; }' is identical to type '{ a: string; }'.
 
   30 | 
-  31 |   expect<{ a: string }>().type.toBe<{ a: string } | { a: string }>();
-  32 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { a: string }>();
-     |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  31 |   expect<(({ a: string } & { a: string }) | { a: string }) & { a: string }>().type.toBe<{ a: string }>();
+  32 |   expect<(({ a: string } & { a: string }) | { a: string }) & { a: string }>().type.not.toBe<{ a: string }>();
+     |                                                                                             ~~~~~~~~~~~~~
   33 | 
-  34 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { b: string }>();
-  35 |   expect<{ a: string }>().type.toBe<{ a: string } | { b: string }>();
+  34 |   expect<(({ a: string } & { a: string }) | { a: string }) & { b: string }>().type.not.toBe<{ a: string }>();
+  35 |   expect<(({ a: string } & { a: string }) | { a: string }) & { b: string }>().type.toBe<{ a: string }>();
 
-       at ./__typetests__/toBe.tst.ts:32:41 ❭ edge cases
+       at ./__typetests__/toBe.tst.ts:32:93 ❭ edge cases
 
-Error: Type '{ a: string; }' is not identical to type '{ a: string; } | { b: string; }'.
+Error: Type '(({ a: string; } & { a: string; }) | { a: string; }) & { b: string; }' is not identical to type '{ a: string; }'.
 
   33 | 
-  34 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { b: string }>();
-  35 |   expect<{ a: string }>().type.toBe<{ a: string } | { b: string }>();
-     |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  34 |   expect<(({ a: string } & { a: string }) | { a: string }) & { b: string }>().type.not.toBe<{ a: string }>();
+  35 |   expect<(({ a: string } & { a: string }) | { a: string }) & { b: string }>().type.toBe<{ a: string }>();
+     |                                                                                         ~~~~~~~~~~~~~
   36 | 
-  37 |   expect<{ a: string }>().type.toBe<{ a: string } & { a: string }>();
-  38 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { a: string }>();
+  37 |   expect<{ a: string }>().type.toBe<{ a: string } | { a: string }>();
+  38 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { a: string }>();
 
-       at ./__typetests__/toBe.tst.ts:35:37 ❭ edge cases
+       at ./__typetests__/toBe.tst.ts:35:89 ❭ edge cases
 
-Error: Type '{ a: string; }' is identical to type '{ a: string; } & { a: string; }'.
+Error: Type '{ a: string; }' is identical to type '{ a: string; } | { a: string; }'.
 
   36 | 
-  37 |   expect<{ a: string }>().type.toBe<{ a: string } & { a: string }>();
-  38 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { a: string }>();
+  37 |   expect<{ a: string }>().type.toBe<{ a: string } | { a: string }>();
+  38 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { a: string }>();
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 | 
-  40 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { b: string }>();
-  41 |   expect<{ a: string }>().type.toBe<{ a: string } & { b: string }>();
+  40 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { b: string }>();
+  41 |   expect<{ a: string }>().type.toBe<{ a: string } | { b: string }>();
 
        at ./__typetests__/toBe.tst.ts:38:41 ❭ edge cases
 
-Error: Type '{ a: string; }' is not identical to type '{ a: string; } & { b: string; }'.
+Error: Type '{ a: string; }' is not identical to type '{ a: string; } | { b: string; }'.
 
   39 | 
-  40 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { b: string }>();
-  41 |   expect<{ a: string }>().type.toBe<{ a: string } & { b: string }>();
+  40 |   expect<{ a: string }>().type.not.toBe<{ a: string } | { b: string }>();
+  41 |   expect<{ a: string }>().type.toBe<{ a: string } | { b: string }>();
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   42 | 
-  43 |   expect(Date).type.toBe<typeof Date>();
-  44 | });
+  43 |   expect<{ a: string }>().type.toBe<{ a: string } & { a: string }>();
+  44 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { a: string }>();
 
        at ./__typetests__/toBe.tst.ts:41:37 ❭ edge cases
 
+Error: Type '{ a: string; }' is identical to type '{ a: string; } & { a: string; }'.
+
+  42 | 
+  43 |   expect<{ a: string }>().type.toBe<{ a: string } & { a: string }>();
+  44 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { a: string }>();
+     |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  45 | 
+  46 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { b: string }>();
+  47 |   expect<{ a: string }>().type.toBe<{ a: string } & { b: string }>();
+
+       at ./__typetests__/toBe.tst.ts:44:41 ❭ edge cases
+
+Error: Type '{ a: string; }' is not identical to type '{ a: string; } & { b: string; }'.
+
+  45 | 
+  46 |   expect<{ a: string }>().type.not.toBe<{ a: string } & { b: string }>();
+  47 |   expect<{ a: string }>().type.toBe<{ a: string } & { b: string }>();
+     |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  48 | 
+  49 |   expect<{ a: string }>().type.toBe<(({ a: string } & { a: string }) | { a: string }) & { a: string }>();
+  50 |   expect<{ a: string }>().type.not.toBe<(({ a: string } & { a: string }) | { a: string }) & { a: string }>();
+
+       at ./__typetests__/toBe.tst.ts:47:37 ❭ edge cases
+
+Error: Type '{ a: string; }' is identical to type '(({ a: string; } & { a: string; }) | { a: string; }) & { a: string; }'.
+
+  48 | 
+  49 |   expect<{ a: string }>().type.toBe<(({ a: string } & { a: string }) | { a: string }) & { a: string }>();
+  50 |   expect<{ a: string }>().type.not.toBe<(({ a: string } & { a: string }) | { a: string }) & { a: string }>();
+     |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  51 | 
+  52 |   expect<{ a: string }>().type.not.toBe<(({ a: string } & { a: string }) | { a: string }) & { b: string }>();
+  53 |   expect<{ a: string }>().type.toBe<(({ a: string } & { a: string }) | { a: string }) & { b: string }>();
+
+       at ./__typetests__/toBe.tst.ts:50:41 ❭ edge cases
+
+Error: Type '{ a: string; }' is not identical to type '(({ a: string; } & { a: string; }) | { a: string; }) & { b: string; }'.
+
+  51 | 
+  52 |   expect<{ a: string }>().type.not.toBe<(({ a: string } & { a: string }) | { a: string }) & { b: string }>();
+  53 |   expect<{ a: string }>().type.toBe<(({ a: string } & { a: string }) | { a: string }) & { b: string }>();
+     |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  54 | 
+  55 |   expect(Date).type.toBe<typeof Date>();
+  56 | });
+
+       at ./__typetests__/toBe.tst.ts:53:37 ❭ edge cases
+
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  47 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
-  48 | 
-  49 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  59 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  60 | 
+  61 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  50 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  51 | 
-  52 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  62 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  63 | 
+  64 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
 
-       at ./__typetests__/toBe.tst.ts:49:42 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:61:42 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is identical to type '{ a?: number | undefined; }'.
 
-  48 | 
-  49 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
-  50 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  60 | 
+  61 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
+  62 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
      |                                                      ~~~~~~~~~~~~~~
-  51 | 
-  52 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  53 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  63 | 
+  64 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  65 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
 
-       at ./__typetests__/toBe.tst.ts:50:54 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:62:54 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable with type '{ a?: number | undefined; }'.
 
-  50 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
-  51 | 
-  52 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  62 |   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();
+  63 | 
+  64 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  53 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
-  54 | });
-  55 | 
+  65 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  66 | });
+  67 | 
 
-       at ./__typetests__/toBe.tst.ts:52:56 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:64:56 ❭ exact optional property types
 
 Error: Type '{ a?: number | undefined; }' is assignable to type '{ a?: number | undefined; }'.
 
-  51 | 
-  52 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
-  53 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
+  63 | 
+  64 |   expect<{ a?: number }>().type.not.toBeAssignableWith<{ a?: number | undefined }>();
+  65 |   expect<{ a?: number | undefined }>().type.not.toBeAssignableTo<{ a?: number }>();
      |                                                                  ~~~~~~~~~~~~~~
-  54 | });
-  55 | 
-  56 | describe("source type", () => {
+  66 | });
+  67 | 
+  68 | describe("source type", () => {
 
-       at ./__typetests__/toBe.tst.ts:53:66 ❭ exact optional property types
+       at ./__typetests__/toBe.tst.ts:65:66 ❭ exact optional property types
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  59 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
-  60 | 
-  61 |     expect<Names>().type.toBe<{ first: string; last: string }>();
+  71 |     expect<Names>().type.toBe<{ first: string; last?: string }>();
+  72 | 
+  73 |     expect<Names>().type.toBe<{ first: string; last: string }>();
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  62 |   });
-  63 | 
-  64 |   test("is NOT identical to target type", () => {
+  74 |   });
+  75 | 
+  76 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:61:31 ❭ source type ❭ is identical to target type
+       at ./__typetests__/toBe.tst.ts:73:31 ❭ source type ❭ is identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  65 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
-  66 | 
-  67 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
+  77 |     expect<Names>().type.not.toBe<{ first: string; last: string }>();
+  78 | 
+  79 |     expect<Names>().type.not.toBe<{ first: string; last?: string }>();
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  68 |   });
-  69 | 
-  70 |   test("is identical to target expression", () => {
+  80 |   });
+  81 | 
+  82 |   test("is identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:67:35 ❭ source type ❭ is NOT identical to target type
+       at ./__typetests__/toBe.tst.ts:79:35 ❭ source type ❭ is NOT identical to target type
 
 Error: Type '{ first: string; last: string; }' is not identical to type 'Names'.
 
-  72 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
-  73 | 
-  74 |     expect<{ first: string; last: string }>().type.toBe(getNames());
+  84 |     expect<{ first: string; last?: string }>().type.toBe(getNames());
+  85 | 
+  86 |     expect<{ first: string; last: string }>().type.toBe(getNames());
      |                                                         ~~~~~~~~~~
-  75 |   });
-  76 | 
-  77 |   test("is NOT identical to target expression", () => {
+  87 |   });
+  88 | 
+  89 |   test("is NOT identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:74:57 ❭ source type ❭ is identical to target expression
+       at ./__typetests__/toBe.tst.ts:86:57 ❭ source type ❭ is identical to target expression
 
 Error: Type '{ first: string; last?: string | undefined; }' is identical to type 'Names'.
 
-  78 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
-  79 | 
-  80 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
+  90 |     expect<{ first: string; last: string }>().type.not.toBe(getNames());
+  91 | 
+  92 |     expect<{ first: string; last?: string }>().type.not.toBe(getNames());
      |                                                              ~~~~~~~~~~
-  81 |   });
-  82 | });
-  83 | 
+  93 |   });
+  94 | });
+  95 | 
 
-       at ./__typetests__/toBe.tst.ts:80:62 ❭ source type ❭ is NOT identical to target expression
+       at ./__typetests__/toBe.tst.ts:92:62 ❭ source type ❭ is NOT identical to target expression
 
 Error: Type 'Names' is not identical to type '{ first: string; last: string; }'.
 
-  87 |     expect(getNames()).type.toBe<Names>();
-  88 | 
-  89 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
-     |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  90 |   });
-  91 | 
-  92 |   test("is NOT identical to target type", () => {
+   99 |     expect(getNames()).type.toBe<Names>();
+  100 | 
+  101 |     expect(getNames()).type.toBe<{ first: string; last: string }>();
+      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  102 |   });
+  103 | 
+  104 |   test("is NOT identical to target type", () => {
 
-       at ./__typetests__/toBe.tst.ts:89:34 ❭ source expression ❭ identical to target type
+        at ./__typetests__/toBe.tst.ts:101:34 ❭ source expression ❭ identical to target type
 
 Error: Type 'Names' is identical to type '{ first: string; last?: string | undefined; }'.
 
-  93 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
-  94 | 
-  95 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
-     |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  96 |   });
-  97 | 
-  98 |   test("identical to target expression", () => {
+  105 |     expect(getNames()).type.not.toBe<{ first: string; last: string }>();
+  106 | 
+  107 |     expect(getNames()).type.not.toBe<{ first: string; last?: string }>();
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  108 |   });
+  109 | 
+  110 |   test("identical to target expression", () => {
 
-       at ./__typetests__/toBe.tst.ts:95:38 ❭ source expression ❭ is NOT identical to target type
+        at ./__typetests__/toBe.tst.ts:107:38 ❭ source expression ❭ is NOT identical to target type
 
 Error: Type '{ height: number; }' is not identical to type 'Size'.
 
-   99 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
-  100 | 
-  101 |     expect({ height: 14 }).type.toBe(getSize());
+  111 |     expect({ height: 14, width: 25 }).type.toBe(getSize());
+  112 | 
+  113 |     expect({ height: 14 }).type.toBe(getSize());
       |                                      ~~~~~~~~~
-  102 |   });
-  103 | 
-  104 |   test("is NOT identical to target expression", () => {
+  114 |   });
+  115 | 
+  116 |   test("is NOT identical to target expression", () => {
 
-        at ./__typetests__/toBe.tst.ts:101:38 ❭ source expression ❭ identical to target expression
+        at ./__typetests__/toBe.tst.ts:113:38 ❭ source expression ❭ identical to target expression
 
 Error: Type '{ height: number; width: number; }' is identical to type 'Size'.
 
-  105 |     expect({ height: 14 }).type.not.toBe(getSize());
-  106 | 
-  107 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
+  117 |     expect({ height: 14 }).type.not.toBe(getSize());
+  118 | 
+  119 |     expect({ height: 14, width: 25 }).type.not.toBe(getSize());
       |                                                     ~~~~~~~~~
-  108 |   });
-  109 | });
-  110 | 
+  120 |   });
+  121 | });
+  122 | 
 
-        at ./__typetests__/toBe.tst.ts:107:53 ❭ source expression ❭ is NOT identical to target expression
+        at ./__typetests__/toBe.tst.ts:119:53 ❭ source expression ❭ is NOT identical to target expression
 

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -17,7 +17,7 @@ fail ./__typetests__/toBe.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      10 failed, 10 total
-Assertions: 20 failed, 22 passed, 42 total
+Assertions: 24 failed, 26 passed, 50 total
 Duration:   <<timestamp>>
 
 Ran all test files.


### PR DESCRIPTION
Following up #392 and #393.

Complex unions and intersections like `(({ a: string } & { a: string }) | { a: string }) & { a: string }` can be simplify to `{ a: string }`  for identicality checks.