### PR TITLE
feat: as-mocha module for IDE unit test runner support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 coverage
 node_modules
 *.log
+.idea
+*.iml

--- a/as-mocha/AssertionError.ts
+++ b/as-mocha/AssertionError.ts
@@ -1,0 +1,42 @@
+import type { Diagnostic } from "../source/diagnostic/index.js";
+
+/**
+ * An Error subclass with the added extras a Mocha reporter can use
+ * to enhance the developer experience.
+ * @remarks
+ * The IJ Mocha reporter looks for:
+ * - `actual` and `expected`, which don't need to be strings, as
+ *    the reporter will call `.toString()` on them either way.
+ * - `stack` will be trimmed to eliminate the line with the
+ *   `message`, and will try to find the first "(file.js:line:char)"
+ *   to turn into a clickable source ref.
+ * - `showDiff`, a Boolean not used here, can disable the diff UI.
+ * - `expectedFilePath` and `actualFilePath`, if present, will cause
+ *   the UI to display a diff of those files, not the `actual` and
+ *   `expected` values.
+ */
+export class AssertionError extends Error {
+  public override readonly stack: string;
+  public readonly actual: string;
+  public readonly matcher: string
+  public readonly expected: string;
+  public readonly diagnostics: ReadonlyArray<Diagnostic>;
+  public readonly sourceLocation: string;
+
+  constructor(
+    message: string,
+    actual: string,
+    matcher: string,
+    expected: string,
+    diagnostics: ReadonlyArray<Diagnostic>,
+    sourceLocation: string,
+  ) {
+    super(message);
+    this.actual = actual;
+    this.matcher = matcher;
+    this.expected = expected;
+    this.diagnostics = diagnostics;
+    this.sourceLocation = sourceLocation;
+    this.stack = `AssertionError: ${message}\n    at ${matcher} (${sourceLocation})\n`;
+  }
+}

--- a/as-mocha/MochaReporter.ts
+++ b/as-mocha/MochaReporter.ts
@@ -1,0 +1,488 @@
+// biome-ignore lint/correctness/noUndeclaredDependencies : biome can't see mocha in this module's package.json?
+import * as M from "mocha";
+import * as path from "node:path";
+import * as process from "node:process";
+import type { Assertion, TestMember } from "../source/collect/index.js";
+import type { ResolvedConfig } from "../source/config/index.js";
+import { type Diagnostic, DiagnosticCategory } from "../source/diagnostic/index.js";
+import { BaseReporter } from "../source/reporters/index.js";
+import type { ReporterEvent } from "../source/reporters/index.js";
+import { ResultStatus } from "../source/result/index.js";
+import {
+  DescribeResult,
+  type ExpectResult,
+  type ProjectResult,
+  type Result,
+  type TargetResult,
+  type TaskResult,
+  TestResult,
+} from "../source/result/index.js";
+import { Runner } from "../source/runner/index.js";
+import { AssertionError } from "./AssertionError.js";
+
+// ----------------------------------------------------------------------
+// as-mocha reporter shim
+// ----------------------
+//
+// tl;dr: Act as a go-between for a tstyche Runner and a mocha Reporter.
+//
+// Details:
+//
+// Both sides use generally-compatible paradigms.  The tstyche side has
+// a bit more nuance, which we throw right out the window because mocha
+// reporters don't care.
+//
+// Basically, we flatten tstyche's "Result" chain down to mocha's
+// Suites and Tests.  When the tstyche Runner sends an event, we pull
+// whatever Result seems the most relevant, and pass it along as a
+// mocha Suite.  Yes, even the tstyche TestResult becomes a mocha Suite.
+//
+// This is because a mocha Test cannot contain other Tests, so Tests are
+// always leaf nodes.  The equivalents on the tstyche side are the
+// Assertions and TestMembers.  While those do have a TaskResult, which
+// is used as a fallback, if the event sends something closer (like a
+// DescribeResult) its corresponding Suite is used instead.  The hope
+// is that this psuedo-structure will be close enough to the dev's mental
+// model of the test hierarchy.
+//
+// We could make it so `it` or `test` blocks are leaf nodes, and just
+// collapse the Assertions to the first failure.  But that's throwing
+// away perfectly good info ... and tstyche doesn't actually require you
+// to use `it` or `test` ... so, meh?
+//
+// The rest ... is pretty much just boring plumbing.
+// ----------------------------------------------------------------------
+
+type SuiteCacheKey = TaskResult | TestResult | TargetResult | DescribeResult | ProjectResult | Result;
+type TestCacheKey = TestMember;
+
+/**
+ * Pretend to be a tstchye Reporter which translates and funnels events
+ * and results along to a faux mocha Runner, which is then passing along
+ * events to some third-party mocha Reporter on the other side.  Likely
+ * an IDE.
+ */
+export class MochaReporter extends BaseReporter {
+  /**
+   * Map from tstyche status to mocha status (state).
+   */
+  public static readonly testStatusFromResultStatus: Readonly<Partial<Record<ResultStatus, M.Runnable["state"]>>> =
+    Object.freeze({
+      [ResultStatus.Failed]: "failed",
+      [ResultStatus.Passed]: "passed",
+      [ResultStatus.Skipped]: "pending",
+      [ResultStatus.Todo]: "pending",
+    });
+  readonly #mRunner: M.Runner;
+  readonly #onRunner: (mRunner: M.Runner) => void;
+  readonly #rootSuite: M.Suite;
+  readonly #suites = new Map<SuiteCacheKey, M.Suite>();
+  readonly #tests = new Map<TestCacheKey, M.Test>();
+
+  constructor(
+    resolvedConfig: ResolvedConfig,
+    onRunner: (mRunner: M.Runner) => void,
+  ) {
+    super(resolvedConfig);
+    this.#rootSuite = new M.Suite(`tstyche ${ Runner.version }`);
+    this.#rootSuite.root = true;
+    this.#mRunner = new M.Runner(this.#rootSuite);
+    this.#onRunner = onRunner;
+  }
+
+  /**
+   * If an Error instance is attached to a failed test, the mocha
+   * reporter will pick it apart for info it can turn into UI/UX.
+   * The mildly-heavy-handed wall of code here is to get as much
+   * info into the Error as we can, and as succinctly as possible.
+   */
+  public static errorFromAssertion(assertion: Assertion, diagnostics: Array<Diagnostic>): AssertionError {
+    // The left hand side of the type comparison.
+    const actual = assertion.source.map((s) => s.getText()).join("");
+    // Right hand side.
+    let expected = assertion.target.map((t) => t.getText()).join("");
+    // We have limited space for nuance (basically just a single line
+    // of a stack trace) to be able to convey what is wrong.  This
+    // matcher is an abbreviated version of the middle of the assertion
+    // chain.  We work from right to left, so this is often "toBe".
+    let matcher = assertion.matcherName.getText();
+    if (assertion.isNot) {
+      expected = "(not) ".concat(expected);
+      matcher = "not.".concat(matcher);
+    }
+    // This is likely "type".
+    matcher = assertion.modifierNode.name.getText().concat(".", matcher);
+    const maybeExpect = assertion.modifierNode.expression.getFirstToken();
+    if (maybeExpect != null) {
+      // This is likely "expect".
+      matcher = maybeExpect.getText().concat(".", matcher);
+    }
+    // Generally, the reporters don't care about warnings.
+    const errors = diagnostics.filter((d) => d.category === DiagnosticCategory.Error);
+    const texts = errors.flatMap((e) => e.text).join("\n");
+    const message = texts === "" ? `Assertion failed: ${ matcher }` : texts;
+    // Try to grab at least a line of context, so we can add it to the stack trace.
+    const origin = errors.find((d) => d.origin != null)?.origin;
+    let sourceLocation = path.relative(process.cwd(), origin?.sourceFile.fileName ?? assertion.parent.task.filePath);
+    if (origin != null) {
+      const { start } = origin;
+      if (start != null) {
+        const { line, character } = origin.sourceFile.getLineAndCharacterOfPosition(origin.start);
+        sourceLocation = sourceLocation.concat(":", String(line + 1), ":", String(character + 1));
+      }
+    }
+    return new AssertionError(message, actual, matcher, expected, errors, sourceLocation);
+  }
+
+  /**
+   * Assertion instances all have empty `name` fields, so we make up
+   * something a bit easier to read.  Note that this is slightly different
+   * from what we encode in an Error, as the Error has its `actual` and
+   * `expected` fields for additional context.
+   * @example
+   * Omit<Fruit, "color"> toBe { name: string }
+   * Omit<Fruit, "color"> not toBe { color: string; name: string }
+   */
+  public static nameForAssertion(assertion: Assertion): string {
+    const source = assertion.source
+      .map((s) => s.getText())
+      .join("")
+      .replace(/\n\s+/g, " ");
+    const matcher = assertion.matcherName.getText();
+    const not = assertion.isNot ? "not " : "";
+    const target = assertion.target
+      .map((s) => s.getText())
+      .join("")
+      .replace(/\n\s+/g, " ");
+    return `${ source } ${ not }${ matcher } ${ target }`;
+  }
+
+  /**
+   * Figure out which mocha Suite belongs to this tstyche object, or build
+   * one if we don't have one yet.  And as mocha reporters expect the
+   * Suites and Tests to be hierarchical, spend extra attention on parent
+   * child relationships.
+   * Also, why doesn't Map have a `.getOrCompute` method?  Is this 1996?
+   */
+  protected getOrComputeSuite<Key extends SuiteCacheKey>(
+    key: Key,
+    title: string,
+    parentKey: SuiteCacheKey | undefined,
+    parentSuite: M.Suite | undefined = this.getParentSuite(parentKey),
+  ): M.Suite {
+    let suite = this.#suites.get(key);
+    if (suite == null) {
+      suite = new M.Suite(title);
+      this.#suites.set(key, suite);
+    }
+    if (parentSuite != null && suite.parent == null) {
+      suite.parent = parentSuite;
+      parentSuite.addSuite(suite);
+    }
+    return suite;
+  }
+
+  /**
+   * Same as {@link getOrComputeSuite}, but for mocha Tests.
+   */
+  protected getOrComputeTest<Key extends TestCacheKey>(
+    key: Key,
+    title: string,
+    parentKey: SuiteCacheKey,
+    parentSuite: M.Suite | undefined = this.getParentSuite(parentKey),
+  ): M.Test {
+    let test = this.#tests.get(key);
+    if (test == null) {
+      test = new M.Test(title);
+      this.#tests.set(key, test);
+    }
+    if (parentSuite != null && test.parent == null) {
+      test.parent = parentSuite;
+      parentSuite.addTest(test);
+    }
+    return test;
+  }
+
+  /**
+   * Since it's possible to just have a bare assertion without
+   * any `describe`, `test`, or `it`, blocks, this walks up the
+   * Result chain until we find the closest Result already associated
+   * with a Suite.  (So, it's the parent of the Suite, but possibly
+   * an ancestor of the Result.)
+   */
+  protected getParentSuite(key: SuiteCacheKey | undefined): M.Suite | undefined {
+    let k = key;
+    while (k != null) {
+      const maybe = this.#suites.get(k);
+      if (maybe != null) {
+        return maybe;
+      }
+      k = k.parent;
+    }
+    // We really shouldn't ever get this far.
+    return this.#rootSuite;
+  }
+
+  /**
+   * Handler for events from the tstyche Runner.  Mostly just plumbing
+   * following the same pattern:
+   * 1. Got an event!
+   * 2. Extract the tstyche Result (and Diagnostics).
+   * 3. Map the Result to a mocha Suite or Test.
+   * 4. Update the Suite or Test instance with the new state.
+   * 5. Pass along the equivalent event to the mocha Runner/Reporter.
+   */
+  public override on([ type, payload ]: ReporterEvent): void {
+    switch (type) {
+      case "describe:end": {
+        const suite = this.suiteFromDescribeResult(payload.result);
+        this.#mRunner.emit("suite end", suite);
+        break;
+      }
+      case "describe:start": {
+        const suite = this.suiteFromDescribeResult(payload.result);
+        this.#mRunner.emit("suite", suite);
+        break;
+      }
+      case "expect:error":
+      case "expect:fail":
+      case "expect:pass":
+      case "expect:skip": {
+        const parent = this.getParentSuite(payload.result.parent);
+        const diagnostics = type === "expect:fail" || type === "expect:error" ? payload.diagnostics : [];
+        const test = this.testFromExpectResult(payload.result, parent, diagnostics);
+        test.file = payload.result.assertion.parent.task.filePath;
+        if (type === "expect:pass") {
+          this.#mRunner.emit("pass", test);
+        } else if (type === "expect:fail") {
+          this.#mRunner.emit("fail", test, test.err);
+        } else if (type === "expect:skip") {
+          this.#mRunner.emit("pending", test);
+        } else {
+          test.emit("error", payload.diagnostics);
+        }
+        // Not sure when/if this is needed?
+        // this.#mRunner.emit("test end", test);
+        break;
+      }
+      case "expect:start": {
+        const parent = this.getParentSuite(payload.result.parent);
+        const test = this.testFromExpectResult(payload.result, parent, payload.result.diagnostics);
+        this.#mRunner.emit("test", test);
+        break;
+      }
+      case "task:error":
+      case "task:end": {
+        const parent: SuiteCacheKey | undefined =
+          payload.parentResult instanceof TestResult ? undefined : payload.parentResult;
+        const suite = this.suiteFromTaskResult(payload.result, this.getParentSuite(parent));
+        const { total } = payload.result.expectCount;
+        if (total === 0) {
+          this.sendFillerTest(suite, payload.result.status);
+        }
+        this.#mRunner.emit("suite end", suite);
+        break;
+      }
+      case "task:start": {
+        const parent: SuiteCacheKey | undefined =
+          payload.parentResult instanceof TestResult ? undefined : payload.parentResult;
+        const suite = this.suiteFromTaskResult(payload.result, this.getParentSuite(parent));
+        this.#mRunner.emit("suite", suite);
+        break;
+      }
+      case "test:error":
+      case "test:fail":
+      case "test:todo":
+      case "test:skip":
+      case "test:pass": {
+        const parent = this.getParentSuite(payload.result.parent);
+        const suite = this.suiteFromTestResult(payload.result, parent);
+        const { total } = payload.result.expectCount;
+        if (total === 0) {
+          this.sendFillerTest(suite, payload.result.status);
+        }
+        this.#mRunner.emit("suite end", suite);
+        break;
+      }
+      case "test:start": {
+        const suite = this.suiteFromTestResult(payload.result);
+        this.#mRunner.emit("suite", suite);
+        break;
+      }
+      case "run:end": {
+        const { total } = payload.result.expectCount;
+        if (total === 0) {
+          this.sendFillerTest(this.#rootSuite, ResultStatus.Skipped);
+        }
+        this.#mRunner.emit("end");
+        break;
+      }
+      case "run:start": {
+        // Now that we have the Result, we can put the root suite
+        // in the cache so Task suites can find it.
+        this.#suites.set(payload.result, this.#rootSuite);
+        // We delay hooking this up in case of config issues.
+        // It makes for less noise if the reporter function isn't
+        // spewing errors at the same time.
+        this.#onRunner(this.#mRunner);
+        this.#mRunner.emit("start");
+        break;
+      }
+      case "target:end": {
+        const suite = this.suiteFromTargetResult(payload.result);
+        this.#mRunner.emit("suite end", suite);
+        break;
+      }
+      case "target:start": {
+        const suite = this.suiteFromTargetResult(payload.result);
+        this.#mRunner.emit("suite", suite);
+        break;
+      }
+      case "store:error":
+      case "store:adds":
+      case "project:uses":
+      case "project:error":
+      case "watch:error":
+      case "deprecation:info": {
+        // Do nothing
+        break;
+      }
+      default: {
+        process.stdout.write(`Unhandled event from tstyche: ${ type }\n`, "utf-8");
+      }
+    }
+  }
+
+  /**
+   * The IJ mocha Reporter doesn't like it when a Suite ends without any
+   * Tests associated with it.  Maybe you have an empty test file.  Or
+   * maybe you thought you were running tests but aren't.  Whatever the
+   * reason, we cobble together a fake filler Test and send it before
+   * the Suite end event is sent.
+   * The logic here is that we assume if you skipped the entire Suite
+   * (tstyche Describe, `it`, or `test`) then we mark the faux Test
+   * as skipped ("pending" in mocha terms).  But if you passed the
+   * tstyche Result without any Assertions, then that seems more like
+   * it wasn't intentional, so we inject a failing mocha Test to catch
+   * your attention.  We could probably add a config option for this.
+   */
+  protected sendFillerTest(suite: M.Suite, resultStatus: ResultStatus): void {
+    const test = new M.Test("(no assertions found)");
+    suite.addTest(test);
+    this.#mRunner.emit("test", test);
+    test.duration = 0;
+    if (resultStatus === ResultStatus.Skipped) {
+      test.pending = true;
+      test.state = "pending";
+    } else if (resultStatus === ResultStatus.Passed) {
+      test.state = "failed";
+      test.err = new Error("(no assertions found)");
+    } else {
+      // Seems impossible to get here ... but yolo?
+      test.state = "failed";
+      test.err = new Error("(suite failed)");
+    }
+    if (test.state === "failed") {
+      this.#mRunner.emit("fail", test, test.err);
+    } else if (test.state === "pending") {
+      this.#mRunner.emit("pending", test);
+    } else {
+      // :shrug:
+      this.#mRunner.emit("test end", test);
+    }
+  }
+
+  /**
+   * Find or build a Suite for this Describe block, and wire up all
+   * its child results.
+   */
+  protected suiteFromDescribeResult(describeResult: DescribeResult, parentSuite?: M.Suite): M.Suite {
+    const suite = this.getOrComputeSuite(
+      describeResult,
+      describeResult.describe.name,
+      describeResult.parent,
+      parentSuite,
+    );
+    for (const result of describeResult.results) {
+      if (result instanceof TestResult) {
+        this.suiteFromTestResult(result, suite);
+      } else {
+        this.suiteFromDescribeResult(result, suite);
+      }
+    }
+    return suite;
+  }
+
+  /**
+   * Find or build a Suite for a ProjectResult.
+   */
+  protected suiteFromProjectResult(
+    projectResult: ProjectResult,
+    _key: string | undefined,
+    parentSuite?: M.Suite,
+  ): M.Suite {
+    return this.getOrComputeSuite(projectResult, projectResult.compilerVersion, projectResult.parent, parentSuite);
+  }
+
+  /**
+   * Find or build a Suite for a TargetResult, and wire up its child Results.
+   */
+  protected suiteFromTargetResult(targetResult: TargetResult, parentSuite?: M.Suite): M.Suite {
+    const suite = this.getOrComputeSuite(targetResult, targetResult.target, targetResult.parent, parentSuite);
+    for (const [ key, result ] of targetResult.results) {
+      this.suiteFromProjectResult(result, key, suite);
+    }
+    return suite;
+  }
+
+  /**
+   * Find or build a Suite for a TaskResult, and wire up all its child Results.
+   */
+  protected suiteFromTaskResult(taskResult: TaskResult, parentSuite: M.Suite | undefined): M.Suite {
+    const name = path.relative(process.cwd(), taskResult.task.filePath);
+    const suite = this.getOrComputeSuite(taskResult, name, taskResult.parent, parentSuite);
+    suite.file ??= taskResult.task.filePath;
+    for (const result of taskResult.results) {
+      if (result instanceof DescribeResult) {
+        this.suiteFromDescribeResult(result, suite);
+      } else if (result instanceof TestResult) {
+        this.suiteFromTestResult(result, suite);
+      } else {
+        this.testFromExpectResult(result, suite, taskResult.diagnostics);
+      }
+    }
+    return suite;
+  }
+
+  /**
+   * Find or build a Suite for a TestResult, and wire up its child ExpectResults.
+   */
+  protected suiteFromTestResult(testResult: TestResult, parentSuite = this.getParentSuite(testResult.parent)): M.Suite {
+    const suite = this.getOrComputeSuite(testResult, testResult.test.name, testResult.parent, parentSuite);
+    for (const expectResult of testResult.results) {
+      this.testFromExpectResult(expectResult, suite, testResult.diagnostics);
+    }
+    return suite;
+  }
+
+  /**
+   * Find or build a mocha Test for the tstyche Assertion inside an
+   * ExpectResult.  Also update its state before passing it back to
+   * the caller.
+   */
+  protected testFromExpectResult(
+    expectResult: ExpectResult,
+    parentSuite: M.Suite | undefined,
+    diagnostics: Array<Diagnostic>,
+  ): M.Test {
+    const name = MochaReporter.nameForAssertion(expectResult.assertion);
+    const test = this.getOrComputeTest(expectResult.assertion, name, expectResult.assertion.parent, parentSuite);
+    test.state = MochaReporter.testStatusFromResultStatus[expectResult.status];
+    test.pending = expectResult.status === ResultStatus.Skipped;
+    test.duration = expectResult.timing.duration;
+    if (test.state === "failed" && test.err == null) {
+      test.err = MochaReporter.errorFromAssertion(expectResult.assertion, diagnostics);
+    }
+    return test;
+  }
+}

--- a/as-mocha/README.md
+++ b/as-mocha/README.md
@@ -1,0 +1,49 @@
+# tstyche-as-mocha
+
+This is a lightweight shim between a tstyche Runner and a mocha Reporter.
+
+## Installation
+
+Typical npm/yarn/pnpm stuff:
+
+```shell
+npm install --save-dev tstyche-as-mocha
+```
+
+Note that you will need `tstyche` and `mocha` as peer dependencies.
+
+## Usage
+
+For your type unit tests' Run Configuration, set your IDE's unit test runner to point its "mocha installation" at this package folder instead.
+
+In JetBrains products (IntelliJ, WebStorm, etc.), create a new Run Configuration, select Mocha as the type, and use its folder picker to find `tstyche-as-mocha` in your project's `node_modules` directory.
+
+If your `tstyche.config.json` isn't proximal to your test files, edit the Run Configuration to add to the mocha CLI options:
+
+```
+--config path/to/tstyche.config.json
+```
+
+Run the configuration just as you would a normal mocha suite.
+Your IDE should pass its own `--reporter` option to this shim, which will then handle running tstyche and brokering the interchange.
+
+## Development
+
+If you want to step through this shim script with a debugger, you can also set up the same Run Configuration to use `tsx` instead of node.
+You'll then need to edit this module's `package.json` to swap out the `bin`:
+
+```json
+{
+  "bin": "./mocha.ts"
+}
+```
+
+## Manifest
+
+- `mocha.ts` is the CLI script which pretends to be the mocha CLI.
+
+- `MochaReporter.ts` is the tstyche Reporter plugin, when then also pretends to be a mocha Runner.
+
+- `AssertionError.ts` is a really simple Error class which can be inspected by the IDE mocha Reporters for UI/UX details.
+
+- `lib/*` contains shims which make this module look more mocha-like to Reporters which load it.

--- a/as-mocha/lib/reporters/base.ts
+++ b/as-mocha/lib/reporters/base.ts
@@ -1,0 +1,21 @@
+// biome-ignore lint/correctness/noUndeclaredDependencies : biome can't see mocha in this module's package.json?
+import { reporters } from "mocha";
+
+// The JetBrains/TeamCity/mocha reporter looks specifically for a
+// loadable import/require from "./lib/reporters/base.js".  In mocha,
+// this module exports the Base Reporter class which all Reporter
+// classes are supposed to inherit from.
+//
+// Instead of locking their reporter to a specific version of mocha,
+// and risk it running into conflict with the installed and running
+// version, they try to load and use this Base.
+// We don't want to run into the same problem, so we just re-export
+// the peer-mocha's Base from the same import/require location.
+//
+// But ... at least for JetBrains, they also rely on some old
+// CommonJS features like `require.main`, so we need to signal to
+// the loader (likely node, but maybe tsx or something else) that
+// it needs to provide a CJS context for this module.  That's
+// done by the `{ type: "commonjs" }` package.json two directories up.
+
+export default reporters.Base;

--- a/as-mocha/mocha.ts
+++ b/as-mocha/mocha.ts
@@ -1,0 +1,131 @@
+// biome-ignore lint/correctness/noUndeclaredDependencies : biome can't see mocha in this module's package.json?
+import type * as M from "mocha";
+import * as path from "node:path";
+import * as process from "node:process";
+import * as util from "node:util";
+import type { CommandLineOptions } from "../source/config/index.js";
+import { Config } from "../source/config/index.js";
+import { Runner } from "../source/runner/index.js";
+import { Select } from "../source/select/index.js";
+import { MochaReporter } from "./MochaReporter.js";
+
+const {
+  values: { config: configArg, grep, help, reporter: reporterArg },
+  positionals,
+} = util.parseArgs({
+  allowPositionals: true,
+  options: {
+    /**
+     * This is from mocha.  Matching in tstyche doesn't use patterns,
+     * it's just strings, but it will work for very simple "run this
+     * describe block" use-cases.
+     */
+    grep: {
+      type: "string",
+    },
+    /**
+     * This is neither mocha, tstyche, nor IJ.  It's just trying to be helpful.
+     */
+    help: {
+      type: "boolean",
+      short: "h",
+    },
+    /**
+     * This is for tstyche.  (Though it is also a standard mocha option.)
+     */
+    config: {
+      type: "string",
+    },
+    /**
+     * This is from mocha, but tstyche has no equivalent.
+     */
+    recursive: {
+      type: "boolean",
+    },
+    /**
+     * This is standard for mocha.
+     * See {@link https://mochajs.org/#command-line-usage | mochajs.org}.
+     */
+    reporter: {
+      short: "R",
+      type: "string",
+    },
+    /**
+     * This is standard for mocha.
+     * See {@link https://mochajs.org/#command-line-usage | mochajs.org}.
+     */
+    timeout: {
+      short: "t",
+      type: "string",
+    },
+    /**
+     * This is standard for mocha.
+     * See {@link https://mochajs.org/#command-line-usage | mochajs.org}.
+     */
+    ui: {
+      default: "bdd",
+      type: "string",
+    },
+  },
+});
+
+if (help) {
+  process.stdout.write(
+    `
+This shim uses only a small subset of mocha CLI options.
+Params:
+  --reporter path    Path to the reporter JS used by the IDE.
+  --config path      Path to tstyche.config.json (not mocha!)
+  `.trim(),
+    "utf-8",
+  );
+  process.exit(1);
+}
+
+if (reporterArg == null) {
+  process.stdout.write("--reporter|-R (path/to/js) is required\n", "utf-8");
+  process.exit(1);
+}
+
+const run = async () => {
+  const reporterModule = (await import(reporterArg)).default as unknown;
+  if (typeof reporterModule !== "function") {
+    throw new Error(`Imported reporter does not have a default export: ${reporterArg}`);
+  }
+  const fn = reporterModule as (runner: M.Runner) => void;
+  const configOptions = await Config.parseConfigFile(configArg);
+  const commandLineOptions: CommandLineOptions = {};
+  if (grep != null && grep !== "") {
+    // tstyche doesn't support patterns, which IJ tries to add by default.
+    // Strip it down to support just a substring match.  Won't handle multiple
+    // values!
+    commandLineOptions.only = grep.replace(/^\^|\$$/g, "");
+  }
+  let pathMatch: Array<string> | undefined ;
+  if (positionals != null && positionals.length > 0) {
+    const cwd = process.cwd();
+    // tystche matchers don't expand relative paths to absolute,
+    // so we need to match.
+    pathMatch = positionals.map((p) => path.relative(cwd, p));
+  }
+  const resolvedConfig = Config.resolve({
+    ...configOptions,
+    commandLineOptions,
+    ...(pathMatch == null ? {} : { pathMatch }),
+  });
+  // Clear out the default Line and Summary reporters.
+  resolvedConfig.reporters = [];
+  const testFiles = await Select.selectFiles(resolvedConfig);
+  const runner = new Runner(resolvedConfig);
+  // Add in the shim.
+  const reporter = new MochaReporter(resolvedConfig, fn);
+  runner.addReporter(reporter);
+  // Ready?  Goooooo!!!!
+  await runner.run(testFiles);
+};
+
+run().catch((err: unknown) => {
+  // biome-ignore lint/suspicious/noConsole : It's an error logger.  Why reinvent that?
+  console.error(err);
+  process.exit(1);
+});

--- a/as-mocha/package.json
+++ b/as-mocha/package.json
@@ -1,0 +1,13 @@
+{
+  "devDependencies": {
+    "@types/mocha": ">=10.0.10"
+  },
+  "peerDependencies": {
+    "mocha": ">=11",
+    "tstyche": ">=3.3.1"
+  },
+  "name": "tstyche-as-mocha",
+  "bin": "./build/mocha.js",
+  "bin-tsx": "./mocha.ts",
+  "type": "module"
+}

--- a/as-mocha/tsconfig.json
+++ b/as-mocha/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
+    "paths": {
+      "#scribbler/jsx-runtime": ["../source/scribbler/jsxRuntime.js"],
+      "#*": ["../source/*/index.js"]
+    },
+
+    "verbatimModuleSyntax": true,
+
+    "jsx": "react-jsx",
+    "jsxImportSource": "#scribbler",
+    "target": "es2023",
+
+    "skipLibCheck": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": [
+    "**/__tests__/**/*",
+    "**/build/**"
+  ]
+}

--- a/source/collect/Assertion.ts
+++ b/source/collect/Assertion.ts
@@ -1,4 +1,5 @@
 import type ts from "typescript";
+import type { TaskResult } from "../result/index.js";
 import { TestMember } from "./TestMember.js";
 import type { TestMemberBrand } from "./TestMemberBrand.enum.js";
 import type { TestMemberFlags } from "./TestMemberFlags.enum.js";
@@ -25,9 +26,10 @@ export class Assertion extends TestMember {
     flags: TestMemberFlags,
     matcherNode: MatcherNode,
     modifierNode: ts.PropertyAccessExpression,
-    notNode?: ts.PropertyAccessExpression,
+    notNode: ts.PropertyAccessExpression | undefined,
+    parentResult: TaskResult,
   ) {
-    super(compiler, brand, node, parent, flags);
+    super(compiler, brand, node, parent, flags, parentResult);
 
     this.isNot = notNode != null;
     this.matcherName = matcherNode.expression.name;

--- a/source/collect/TestTree.ts
+++ b/source/collect/TestTree.ts
@@ -1,4 +1,5 @@
 import type ts from "typescript";
+import type { TaskResult } from "../result/index.js";
 import type { Assertion } from "./Assertion.js";
 import type { TestMember } from "./TestMember.js";
 import { TestMemberFlags } from "./TestMemberFlags.enum.js";
@@ -6,11 +7,13 @@ import { TestMemberFlags } from "./TestMemberFlags.enum.js";
 export class TestTree {
   diagnostics: Set<ts.Diagnostic>;
   members: Array<TestMember | Assertion> = [];
+  parent: TaskResult;
   sourceFile: ts.SourceFile;
 
-  constructor(diagnostics: Set<ts.Diagnostic>, sourceFile: ts.SourceFile) {
+  constructor(diagnostics: Set<ts.Diagnostic>, sourceFile: ts.SourceFile, parent: TaskResult) {
     this.diagnostics = diagnostics;
     this.sourceFile = sourceFile;
+    this.parent = parent;
   }
 
   get hasOnly(): boolean {

--- a/source/events/types.ts
+++ b/source/events/types.ts
@@ -17,9 +17,12 @@ export type Event =
   | ["target:end", { result: TargetResult }]
   | ["project:uses", { compilerVersion: string; projectConfigFilePath: string | undefined }]
   | ["project:error", { diagnostics: Array<Diagnostic> }]
-  | ["task:start", { result: TaskResult }]
-  | ["task:error", { diagnostics: Array<Diagnostic>; result: TaskResult }]
-  | ["task:end", { result: TaskResult }]
+  | ["task:start", { result: TaskResult; parentResult: DescribeResult | TestResult | TaskResult | TargetResult }]
+  | [
+      "task:error",
+      { diagnostics: Array<Diagnostic>; parentResult: DescribeResult | TestResult | TaskResult; result: TaskResult },
+    ]
+  | ["task:end", { result: TaskResult; parentResult: DescribeResult | TestResult | TaskResult | TargetResult }]
   | ["describe:start", { result: DescribeResult }]
   | ["describe:end", { result: DescribeResult }]
   | ["test:start", { result: TestResult }]

--- a/source/handlers/ResultHandler.ts
+++ b/source/handlers/ResultHandler.ts
@@ -1,7 +1,7 @@
 import { DiagnosticCategory } from "#diagnostic";
 import type { Event, EventHandler } from "#events";
 import {
-  type DescribeResult,
+  DescribeResult,
   type ExpectResult,
   ProjectResult,
   type Result,
@@ -62,7 +62,11 @@ export class ResultHandler implements EventHandler {
         let projectResult = this.#targetResult!.results.get(payload.projectConfigFilePath);
 
         if (!projectResult) {
-          projectResult = new ProjectResult(payload.compilerVersion, payload.projectConfigFilePath);
+          projectResult = new ProjectResult(
+            payload.compilerVersion,
+            payload.projectConfigFilePath,
+            this.#targetResult!,
+          );
           this.#targetResult!.results.set(payload.projectConfigFilePath, projectResult);
         }
 
@@ -119,7 +123,13 @@ export class ResultHandler implements EventHandler {
 
       case "describe:end":
         this.#describeResult!.timing.end = Date.now();
-        this.#describeResult = this.#describeResult!.parent;
+        if (this.#describeResult != null) {
+          if (this.#describeResult.parent instanceof DescribeResult) {
+            this.#describeResult = this.#describeResult.parent;
+          } else {
+            this.#taskResult ??= this.#describeResult.parent;
+          }
+        }
         break;
 
       case "test:start":

--- a/source/output/CodeSpanText.tsx
+++ b/source/output/CodeSpanText.tsx
@@ -12,7 +12,7 @@ function BreadcrumbsText({ ancestor }: BreadcrumbsTextProps) {
 
   while ("name" in ancestor) {
     text.push(ancestor.name);
-    ancestor = ancestor.parent;
+    ancestor = ancestor.parentTreeMember;
   }
 
   text.push("");
@@ -140,7 +140,7 @@ export function CodeSpanText({ diagnosticCategory, diagnosticOrigin }: CodeSpanT
       <Text color={Color.Gray}>{" at "}</Text>
       <Text color={Color.Cyan}>{Path.relative("", diagnosticOrigin.sourceFile.fileName)}</Text>
       <Text color={Color.Gray}>{`:${firstMarkedLine + 1}:${firstMarkedLineCharacter + 1}`}</Text>
-      {diagnosticOrigin.assertion && <BreadcrumbsText ancestor={diagnosticOrigin.assertion.parent} />}
+      {diagnosticOrigin.assertion && <BreadcrumbsText ancestor={diagnosticOrigin.assertion.parentTreeMember} />}
     </Line>
   );
 

--- a/source/result/DescribeResult.ts
+++ b/source/result/DescribeResult.ts
@@ -1,14 +1,15 @@
 import type { TestMember } from "#collect";
 import { ResultTiming } from "./ResultTiming.js";
+import type { TaskResult } from "./TaskResult.js";
 import type { TestResult } from "./TestResult.js";
 
 export class DescribeResult {
   describe: TestMember;
-  parent: DescribeResult | undefined;
+  parent: DescribeResult | TaskResult;
   results: Array<DescribeResult | TestResult> = [];
   timing = new ResultTiming();
 
-  constructor(describe: TestMember, parent?: DescribeResult) {
+  constructor(describe: TestMember, parent: DescribeResult | TaskResult) {
     this.describe = describe;
     this.parent = parent;
   }

--- a/source/result/ProjectResult.ts
+++ b/source/result/ProjectResult.ts
@@ -1,14 +1,17 @@
 import type { Diagnostic } from "#diagnostic";
+import type { TargetResult } from "./TargetResult.js";
 import type { TaskResult } from "./TaskResult.js";
 
 export class ProjectResult {
   compilerVersion: string;
   diagnostics: Array<Diagnostic> = [];
+  parent: TargetResult;
   projectConfigFilePath: string | undefined;
   results: Array<TaskResult> = [];
 
-  constructor(compilerVersion: string, projectConfigFilePath: string | undefined) {
+  constructor(compilerVersion: string, projectConfigFilePath: string | undefined, parent: TargetResult) {
     this.compilerVersion = compilerVersion;
+    this.parent = parent;
     this.projectConfigFilePath = projectConfigFilePath;
   }
 }

--- a/source/result/Result.ts
+++ b/source/result/Result.ts
@@ -7,6 +7,7 @@ import type { TargetResult } from "./TargetResult.js";
 export class Result {
   expectCount = new ResultCount();
   fileCount = new ResultCount();
+  parent: undefined;
   resolvedConfig: ResolvedConfig;
   results: Array<TargetResult> = [];
   targetCount = new ResultCount();

--- a/source/result/TargetResult.ts
+++ b/source/result/TargetResult.ts
@@ -1,19 +1,22 @@
 import type { Task } from "#task";
 import type { ProjectResult } from "./ProjectResult.js";
+import type { Result } from "./Result.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 
 export type TargetResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
 
 export class TargetResult {
+  parent: Result;
   results = new Map<string | undefined, ProjectResult>();
   status: TargetResultStatus = ResultStatus.Runs;
   target: string;
   tasks: Array<Task>;
   timing = new ResultTiming();
 
-  constructor(target: string, tasks: Array<Task>) {
+  constructor(target: string, tasks: Array<Task>, parent: Result) {
     this.target = target;
     this.tasks = tasks;
+    this.parent = parent;
   }
 }

--- a/source/result/TaskResult.ts
+++ b/source/result/TaskResult.ts
@@ -5,6 +5,7 @@ import type { ExpectResult } from "./ExpectResult.js";
 import { ResultCount } from "./ResultCount.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
+import type { TargetResult } from "./TargetResult.js";
 import type { TestResult } from "./TestResult.js";
 
 export type TaskResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
@@ -12,13 +13,15 @@ export type TaskResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultS
 export class TaskResult {
   diagnostics: Array<Diagnostic> = [];
   expectCount = new ResultCount();
+  parent: TargetResult;
   results: Array<DescribeResult | TestResult | ExpectResult> = [];
   status: TaskResultStatus = ResultStatus.Runs;
   task: Task;
   testCount = new ResultCount();
   timing = new ResultTiming();
 
-  constructor(task: Task) {
+  constructor(task: Task, parent: TargetResult) {
     this.task = task;
+    this.parent = parent;
   }
 }

--- a/source/result/TestResult.ts
+++ b/source/result/TestResult.ts
@@ -5,17 +5,18 @@ import type { ExpectResult } from "./ExpectResult.js";
 import { ResultCount } from "./ResultCount.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
+import type { TaskResult } from "./TaskResult.js";
 
 export class TestResult {
   diagnostics: Array<Diagnostic> = [];
   expectCount = new ResultCount();
-  parent: DescribeResult | undefined;
+  parent: DescribeResult | TaskResult;
   results: Array<ExpectResult> = [];
   status: ResultStatus = ResultStatus.Runs;
   test: TestMember;
   timing = new ResultTiming();
 
-  constructor(test: TestMember, parent?: DescribeResult) {
+  constructor(test: TestMember, parent: DescribeResult | TaskResult) {
     this.test = test;
     this.parent = parent;
   }

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -49,6 +49,10 @@ export class Runner {
     }
   }
 
+  public addReporter(reporter: Reporter): void {
+    this.#eventEmitter.addReporter(reporter);
+  }
+
   async run(testFiles: Array<string | URL | Task>, cancellationToken = new CancellationToken()): Promise<void> {
     const tasks = testFiles.map((testFile) => (testFile instanceof Task ? testFile : new Task(testFile)));
 
@@ -78,7 +82,7 @@ export class Runner {
     EventEmitter.dispatch(["run:start", { result }]);
 
     for (const target of this.#resolvedConfig.target) {
-      const targetResult = new TargetResult(target, tasks);
+      const targetResult = new TargetResult(target, tasks, result);
 
       EventEmitter.dispatch(["target:start", { result: targetResult }]);
 
@@ -89,7 +93,7 @@ export class Runner {
         const taskRunner = new TaskRunner(this.#resolvedConfig, compiler);
 
         for (const task of tasks) {
-          taskRunner.run(task, cancellationToken);
+          taskRunner.run(task, cancellationToken, targetResult);
         }
       }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "target": "es2022"
   },
   "exclude": [
-    "build/**/*",
+    "**/build/**/*",
     "coverage/**/*",
     "examples/**/*",
     "models/**/*",


### PR DESCRIPTION
This adds a new `as-mocha` module and build steps.  When built, it looks and acts enough like the mocha CLI to allow IDE-based unit test runners to run it, which in turn runs tstyche and acts as a Reporter, to present the tstyche test results in the IDE UI.

(For now, this has only been tested with JetBrains/IntelliJ/WebStorm.)

To support this, several of the core `*Result` types got minor refactors to give them all a concept of parent/child hierarchy.