### PR TITLE
feat: add the `.toBeInstantiableWith()` matcher

### DIFF
--- a/examples/Matchers.tst.ts
+++ b/examples/Matchers.tst.ts
@@ -1,22 +1,10 @@
-import { expect } from "tstyche";
+import { type _, expect } from "tstyche";
 
 interface Matchers<R, T = unknown> {
   [key: string]: (expected: T) => R;
 }
 
-expect<Matchers<void, string>>().type.not.toRaiseError();
+expect<Matchers<_>>().type.toBeInstantiableWith<[void]>();
+expect<Matchers<_>>().type.toBeInstantiableWith<[void, string]>();
 
-expect<Matchers<void>>().type.not.toRaiseError();
-
-// Substring of the error message
-expect<Matchers>().type.toRaiseError("requires between 1 and 2 type arguments");
-
-// The error code
-expect<Matchers>().type.toRaiseError(2707);
-
-// Pattern matching the error message
-expect<Matchers>().type.toRaiseError(/between \d and \d type arguments/);
-expect<Matchers>().type.toRaiseError(/generic .+ requires .+ type arguments/i);
-
-// The exact error message
-expect<Matchers>().type.toRaiseError(/^Generic type 'Matchers<R, T>' requires between 1 and 2 type arguments.$/);
+expect<Matchers<_>>().type.not.toBeInstantiableWith<[]>();

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -11,6 +11,7 @@ import { ToAcceptProps } from "./ToAcceptProps.js";
 import { ToBe } from "./ToBe.js";
 import { ToBeAssignableTo } from "./ToBeAssignableTo.js";
 import { ToBeAssignableWith } from "./ToBeAssignableWith.js";
+import { ToBeInstantiableWith } from "./ToBeInstantiableWith.js";
 import { ToHaveProperty } from "./ToHaveProperty.js";
 import { ToMatch } from "./ToMatch.js";
 import { ToRaiseError } from "./ToRaiseError.js";
@@ -28,6 +29,7 @@ export class ExpectService {
   private toBeAssignableWith: ToBeAssignableWith;
   private toBeBigInt: PrimitiveTypeMatcher;
   private toBeBoolean: PrimitiveTypeMatcher;
+  private toBeInstantiableWith: ToBeInstantiableWith;
   private toBeNever: PrimitiveTypeMatcher;
   private toBeNull: PrimitiveTypeMatcher;
   private toBeNumber: PrimitiveTypeMatcher;
@@ -60,6 +62,7 @@ export class ExpectService {
     this.toBeAssignableWith = new ToBeAssignableWith();
     this.toBeBigInt = new PrimitiveTypeMatcher(compiler.TypeFlags.BigInt);
     this.toBeBoolean = new PrimitiveTypeMatcher(compiler.TypeFlags.Boolean);
+    this.toBeInstantiableWith = new ToBeInstantiableWith(compiler, typeChecker);
     this.toBeNever = new PrimitiveTypeMatcher(compiler.TypeFlags.Never);
     this.toBeNull = new PrimitiveTypeMatcher(compiler.TypeFlags.Null);
     this.toBeNumber = new PrimitiveTypeMatcher(compiler.TypeFlags.Number);
@@ -127,6 +130,12 @@ export class ExpectService {
       case "toBeUnknown":
       case "toBeVoid":
         return this[matcherNameText].match(matchWorker, assertion.source[0]);
+
+      case "toBeInstantiableWith": {
+        // TODO this.#onTargetTypeArgumentMustBeProvided()
+
+        return this.toBeInstantiableWith.match(matchWorker, assertion.source[0], assertion.target[0] as ts.TypeNode);
+      }
 
       case "toHaveProperty":
         if (!assertion.target[0]) {

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -123,15 +123,15 @@ export class MatchWorker {
     return signatures;
   }
 
-  getTypeText(node: ArgumentNode): string {
+  getTypeText(node: ts.Node): string {
     const type = this.getType(node);
 
     // TODO consider passing 'enclosingDeclaration' as well
     return this.#typeChecker.typeToString(type);
   }
 
-  getType(node: ArgumentNode): ts.Type {
-    return this.#compiler.isExpression(node) ? this.#getTypeOfNode(node) : this.#getTypeOfTypeNode(node);
+  getType(node: ts.Node): ts.Type {
+    return this.#compiler.isExpression(node) ? this.#getTypeOfNode(node) : this.#getTypeOfTypeNode(node as ts.TypeNode);
   }
 
   #getTypeOfNode(node: ts.Node) {

--- a/source/expect/ToBeInstantiableWith.ts
+++ b/source/expect/ToBeInstantiableWith.ts
@@ -1,0 +1,231 @@
+import type ts from "typescript";
+import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
+import type { MatchWorker } from "./MatchWorker.js";
+import type { ArgumentNode, MatchResult, TypeChecker } from "./types.js";
+
+export class ToBeInstantiableWith {
+  #compiler: typeof ts;
+  #typeChecker: TypeChecker;
+
+  constructor(compiler: typeof ts, typeChecker: TypeChecker) {
+    this.#compiler = compiler;
+    this.#typeChecker = typeChecker;
+  }
+
+  #explain(
+    matchWorker: MatchWorker,
+    identifier: ts.EntityName,
+    typeParameters: ReadonlyArray<ts.TypeParameterDeclaration>,
+    targetNode: ArgumentNode,
+    typeArguments: Array<ts.TypeNode>,
+    typeParameterCount: { max: number; min: number },
+    typeArgumentCount: number,
+  ) {
+    const sourceTypeText = matchWorker.getTypeText(identifier);
+
+    if (matchWorker.assertion.isNot) {
+      const text =
+        typeParameterCount.max === 0
+          ? "without type arguments"
+          : `with given type argument${typeParameterCount.max === 1 ? "" : "s"}`;
+
+      const origin = DiagnosticOrigin.fromNode(targetNode);
+
+      return [Diagnostic.error(`Generic type '${sourceTypeText}' can be instantiated ${text}.`, origin)];
+    }
+
+    const diagnostics: Array<Diagnostic> = [];
+
+    for (let index = 0; index < typeArgumentCount; index++) {
+      // biome-ignore lint/style/noNonNullAssertion: fine like this, because length matches
+      const typeParameter = typeParameters[index]!;
+      const constraint = this.#compiler.getEffectiveConstraintOfTypeParameter(typeParameter);
+
+      // biome-ignore lint/style/noNonNullAssertion: fine like this, because length matches
+      const argument = typeArguments[index]!;
+
+      if (constraint != null) {
+        const constraintType = matchWorker.getType(constraint);
+        const argumentType = matchWorker.getType(argument);
+
+        if (!this.#typeChecker.isTypeAssignableTo(constraintType, argumentType)) {
+          const constraintTypeText = matchWorker.getTypeText(constraint);
+          const argumentTypeText = matchWorker.getTypeText(argument);
+
+          const text = `The constraint '${constraintTypeText}' is not satisfied with type '${argumentTypeText}'.`;
+          const origin = DiagnosticOrigin.fromNode(argument);
+
+          diagnostics.push(Diagnostic.error(text, origin));
+        }
+      }
+    }
+
+    return diagnostics;
+  }
+
+  #explainArgumentCountMismatch(
+    matchWorker: MatchWorker,
+    identifier: ts.EntityName,
+    targetNode: ArgumentNode,
+    typeParameterCount: { max: number; min: number },
+    typeArgumentCount: number,
+  ) {
+    const sourceTypeText = matchWorker.getTypeText(identifier);
+
+    let parameterCountText: string;
+
+    if (typeParameterCount.max === 0) {
+      parameterCountText = "does not take type arguments";
+    } else if (typeArgumentCount > typeParameterCount.max) {
+      parameterCountText = `takes ${
+        typeParameterCount.max > typeParameterCount.min ? "at most " : "only "
+      }${typeParameterCount.max} type argument${typeParameterCount.max === 1 ? "" : "s"}`;
+    } else {
+      parameterCountText = `requires ${
+        typeParameterCount.min < typeParameterCount.max ? "at least " : ""
+      }${typeParameterCount.min} type argument${typeParameterCount.min === 1 ? "" : "s"}`;
+    }
+
+    const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertion);
+
+    return [Diagnostic.error(`Generic type '${sourceTypeText}' ${parameterCountText}.`, origin)];
+  }
+
+  #getEffectiveTypeParameters(identifier: ts.EntityName) {
+    let typeParameters: ReadonlyArray<ts.TypeParameterDeclaration> = [];
+
+    // TODO what happens with overloads?
+    const symbol = this.#typeChecker.getSymbolAtLocation(identifier);
+
+    for (const declaration of symbol?.declarations ?? []) {
+      if (
+        this.#compiler.isTypeAliasDeclaration(declaration) ||
+        this.#compiler.isInterfaceDeclaration(declaration) ||
+        this.#compiler.isFunctionDeclaration(declaration) ||
+        this.#compiler.isClassDeclaration(declaration)
+      ) {
+        typeParameters = this.#compiler.getEffectiveTypeParameterDeclarations(declaration);
+
+        // interface declaration are allowed to be merged with more constrained declarations
+        if (typeParameters.some((typeParameter) => typeParameter.constraint != null)) {
+          break;
+        }
+      }
+    }
+
+    return typeParameters;
+  }
+
+  #getParameterCount(typeParameters: ReadonlyArray<ts.TypeParameterDeclaration>) {
+    const defaultIndex = typeParameters.findIndex((typeParameter) => typeParameter.default != null);
+
+    return { max: typeParameters.length, min: defaultIndex === -1 ? typeParameters.length : defaultIndex };
+  }
+
+  match(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNode: ArgumentNode): MatchResult | undefined {
+    const identifier = this.#compiler.isIdentifier(sourceNode)
+      ? sourceNode
+      : this.#compiler.isTypeReferenceNode(sourceNode)
+        ? sourceNode.typeName
+        : undefined;
+
+    if (!identifier) {
+      // TODO error: Must be an identifier or a type reference.
+      return;
+    }
+
+    // TODO eliminate not generic types, probably those that do not take type arguments?
+
+    if (!this.#compiler.isTypeNode(targetNode)) {
+      // TODO error: Must be type argument.
+      return;
+    }
+
+    let symbol: ts.Symbol | undefined;
+
+    if (this.#compiler.isTypeReferenceNode(targetNode)) {
+      symbol = this.#typeChecker.getSymbolAtLocation(targetNode.typeName);
+    }
+
+    if (symbol?.declarations?.[0] != null && this.#compiler.isTypeAliasDeclaration(symbol.declarations[0])) {
+      targetNode = symbol.declarations[0].type;
+    }
+
+    if (!this.#compiler.isTupleTypeNode(targetNode)) {
+      // TODO error: "A type argument for 'Target' must be of tuple type."
+      return;
+    }
+
+    const diagnostics: Array<string> = [];
+    const typeArguments: Array<ts.TypeNode> = [];
+
+    for (const element of targetNode.elements) {
+      if (this.#compiler.isNamedTupleMember(element)) {
+        diagnostics.push("Named element is not allowed in the 'Target' type.");
+      }
+
+      if (this.#compiler.isRestTypeNode(element)) {
+        diagnostics.push("Rest element is not allowed in the 'Target' type.");
+      }
+
+      typeArguments.push(element);
+    }
+
+    if (diagnostics.length > 0) {
+      // TODO Emit diagnostics
+      return;
+    }
+
+    const typeParameters = this.#getEffectiveTypeParameters(identifier);
+    const typeParameterCount = this.#getParameterCount(typeParameters);
+
+    const typeArgumentCount = typeArguments.length;
+
+    let isMatch = typeArgumentCount >= typeParameterCount.min && typeArgumentCount <= typeParameterCount.max;
+
+    if (!isMatch) {
+      return {
+        explain: () =>
+          this.#explainArgumentCountMismatch(
+            matchWorker,
+            identifier,
+            targetNode,
+            typeParameterCount,
+            typeArgumentCount,
+          ),
+        isMatch,
+      };
+    }
+
+    for (let index = 0; index < typeArgumentCount; index++) {
+      // biome-ignore lint/style/noNonNullAssertion: fine like this, because length matches
+      const constraint = this.#compiler.getEffectiveConstraintOfTypeParameter(typeParameters[index]!);
+      // biome-ignore lint/style/noNonNullAssertion: fine like this, because length matches
+      const argument = typeArguments[index]!;
+
+      if (constraint != null) {
+        const constraintType = matchWorker.getType(constraint);
+        const argumentType = matchWorker.getType(argument);
+
+        if (!this.#typeChecker.isTypeAssignableTo(constraintType, argumentType)) {
+          isMatch = false;
+          break;
+        }
+      }
+    }
+
+    return {
+      explain: () =>
+        this.#explain(
+          matchWorker,
+          identifier,
+          typeParameters,
+          targetNode,
+          typeArguments,
+          typeParameterCount,
+          typeArgumentCount,
+        ),
+      isMatch,
+    };
+  }
+}

--- a/source/types.ts
+++ b/source/types.ts
@@ -126,6 +126,10 @@ interface Matchers {
     (target: unknown): void;
   };
   /**
+   * Checks if the generic type can be instantiated with the given type arguments.
+   */
+  toBeInstantiableWith: <Target extends [...args: Array<unknown>]>() => void;
+  /**
    * Checks if a property key exists on the source type.
    */
   toHaveProperty: (key: string | number | symbol) => void;
@@ -307,6 +311,11 @@ interface Expect {
     };
   };
 }
+
+/**
+ * The fill-in type. Useful to fill in the required type arguments of generic types.
+ */
+export type _ = never;
 
 /**
  * Builds an assertion.


### PR DESCRIPTION
Adding the `.toBeInstantiableWith()` matcher, which will be able to check if the generic type can be instantiated with the given type arguments.

```ts
import { type _, expect } from "tstyche";

interface Matchers<R, T = unknown> {
  [key: string]: (expected: T) => R;
}

expect<Matchers<_>>().type.toBeInstantiableWith<[void, string]>();
expect<Matchers<_>>().type.toBeInstantiableWith<[void]>();

expect<Matchers<_>>().type.not.toBeInstantiableWith<[]>();
```

Also the `_` type is added which is useful to fill in the required type arguments of generic types.

The matcher handles generic type aliases, interfaces, functions and classes.

---

Implementing `.toBeInstantiableWith()` is similar to adding `.toBeCallableWith()` matcher, but with there is less complexity. This work helps me to understand the needs of `.toBeCallableWith()`. For example, errors will be rather similar:

<img width="685" alt="Screenshot 2025-01-04 at 11 22 35" src="https://github.com/user-attachments/assets/93f7d5a0-b0eb-4e1f-a29a-6fea5fa5ba3b" />
