### PR TITLE
feat: make code frame output configurable

### DIFF
--- a/source/output/diagnosticText.tsx
+++ b/source/output/diagnosticText.tsx
@@ -1,12 +1,14 @@
 import { type Diagnostic, DiagnosticCategory } from "#diagnostic";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
-import { CodeSpanText } from "./CodeSpanText.js";
+import { CodeFrameText } from "./CodeFrameText.js";
+import type { CodeFrameOptions } from "./types.js";
 
 interface DiagnosticTextProps {
+  codeFrameOptions?: CodeFrameOptions;
   diagnostic: Diagnostic;
 }
 
-function DiagnosticText({ diagnostic }: DiagnosticTextProps) {
+function DiagnosticText({ codeFrameOptions, diagnostic }: DiagnosticTextProps) {
   const code = diagnostic.code ? <Text color={Color.Gray}> {diagnostic.code}</Text> : undefined;
 
   const text = Array.isArray(diagnostic.text) ? diagnostic.text : [diagnostic.text];
@@ -23,24 +25,28 @@ function DiagnosticText({ diagnostic }: DiagnosticTextProps) {
 
   const related = diagnostic.related?.map((relatedDiagnostic) => <DiagnosticText diagnostic={relatedDiagnostic} />);
 
-  const codeSpan = diagnostic.origin ? (
+  const codeFrame = diagnostic.origin ? (
     <Text>
       <Line />
-      <CodeSpanText diagnosticCategory={diagnostic.category} diagnosticOrigin={diagnostic.origin} />
+      <CodeFrameText
+        diagnosticCategory={diagnostic.category}
+        diagnosticOrigin={diagnostic.origin}
+        options={codeFrameOptions}
+      />
     </Text>
   ) : undefined;
 
   return (
     <Text>
       {message}
-      {codeSpan}
+      {codeFrame}
       <Line />
       <Text indent={2}>{related}</Text>
     </Text>
   );
 }
 
-export function diagnosticText(diagnostic: Diagnostic): ScribblerJsx.Element {
+export function diagnosticText(diagnostic: Diagnostic, codeFrameOptions: CodeFrameOptions = {}): ScribblerJsx.Element {
   let prefix: ScribblerJsx.Element | undefined;
 
   switch (diagnostic.category) {
@@ -56,7 +62,7 @@ export function diagnosticText(diagnostic: Diagnostic): ScribblerJsx.Element {
   return (
     <Text>
       {prefix}
-      <DiagnosticText diagnostic={diagnostic} />
+      <DiagnosticText codeFrameOptions={codeFrameOptions} diagnostic={diagnostic} />
     </Text>
   );
 }

--- a/source/output/index.ts
+++ b/source/output/index.ts
@@ -8,6 +8,7 @@ export { helpText } from "./helpText.js";
 export { OutputService } from "./OutputService.js";
 export { summaryText } from "./summaryText.js";
 export { testNameText } from "./testNameText.js";
+export type { CodeFrameOptions } from "./types.js";
 export { usesCompilerText } from "./usesCompilerText.js";
 export { waitingForFileChangesText } from "./waitingForFileChangesText.js";
 export { watchUsageText } from "./watchUsageText.js";

--- a/source/output/types.ts
+++ b/source/output/types.ts
@@ -1,0 +1,4 @@
+export interface CodeFrameOptions {
+  linesAbove?: number;
+  linesBelow?: number;
+}

--- a/tests/__snapshots__/feature-watch-config-file-has-an-error-stderr.snap.txt
+++ b/tests/__snapshots__/feature-watch-config-file-has-an-error-stderr.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'failFast' requires a value of type boolean.
   3 |   "testFileMatch": [
   4 |     "**/isNumber.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:15
 
@@ -18,7 +17,6 @@ Error: Option 'failFast' requires a value of type boolean.
   3 |   "testFileMatch": [
   4 |     "**/isString.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:15
 
@@ -30,7 +28,6 @@ Error: Option 'failFast' requires a value of type boolean.
   3 |   "testFileMatch": [
   4 |     "**/isString.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:15
 

--- a/tests/__snapshots__/validation-configFile-handles-crlf.snap.txt
+++ b/tests/__snapshots__/validation-configFile-handles-crlf.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'failFast' requires a value of type boolean.
   3 |   "rootPath": true
   4 | }
   5 | 
-  6 | 
 
       at ./tstyche.config.json:2:15
 

--- a/tests/__snapshots__/validation-configFile-syntax-errors-root-brace.snap.txt
+++ b/tests/__snapshots__/validation-configFile-syntax-errors-root-brace.snap.txt
@@ -5,8 +5,6 @@ Error: Expected '{'.
   2 |   {
   3 |     "failFast": true
   4 |   }
-  5 | ]
-  6 | 
 
       at ./tstyche.config.json:1:1
 

--- a/tests/__snapshots__/validation-configFile-syntax-errors-unquoted-values.snap.txt
+++ b/tests/__snapshots__/validation-configFile-syntax-errors-unquoted-values.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'rootPath' requires a value of type string.
   3 |     testFileMatch: [**/*.tst.*]
   4 |   }
   5 | 
-  6 | 
 
       at ./tstyche.config.json:2:15
 

--- a/tests/__snapshots__/validation-configFile-unknown-options.snap.txt
+++ b/tests/__snapshots__/validation-configFile-unknown-options.snap.txt
@@ -6,7 +6,6 @@ Error: Unknown option 'cache'.
   3 |   "cacheTrailing": ["all", "best",],
   4 |   "globals": { delay: 123 },
   5 |   "globalsTrailing": { break: true, delay: 123, },
-  6 |   "mainBroken":,
 
       at ./tstyche.config.json:2:3
 

--- a/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
@@ -9,6 +9,8 @@ Error: 'describe()' cannot be nested within 'expect()'.
   6 |   });
     | ~~~~
   7 | 
+  8 |   it("cannot be nested", () => {
+  9 |     //
 
       at ./__typetests__/handles-nested.tst.ts:4:3
 
@@ -23,6 +25,8 @@ Error: 'it()' cannot be nested within 'expect()'.
   10 |   });
      | ~~~~
   11 | 
+  12 |   test("cannot be nested", () => {
+  13 |     //
 
        at ./__typetests__/handles-nested.tst.ts:8:3
 
@@ -37,6 +41,8 @@ Error: 'test()' cannot be nested within 'expect()'.
   14 |   });
      | ~~~~
   15 | 
+  16 |   // can be nested!
+  17 |   expect<number>().type.toBeString();
 
        at ./__typetests__/handles-nested.tst.ts:12:3
 

--- a/tests/__snapshots__/validation-failFast-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-failFast-wrong-option-value-type-stderr.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'failFast' requires a value of type boolean.
   3 |   "target": [
   4 |     "current"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:15
 

--- a/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
@@ -9,6 +9,8 @@ Error: 'describe()' cannot be nested within 'it()'.
   6 |   });
     | ~~~~
   7 | 
+  8 |   it("nested it is handled?", () => {
+  9 |     expect<never>().type.toBeNever();
 
       at ./__typetests__/handles-nested.tst.ts:4:3
 
@@ -23,6 +25,8 @@ Error: 'it()' cannot be nested within 'it()'.
   10 |   });
      | ~~~~
   11 | 
+  12 |   expect<string>().type.toBeString();
+  13 | });
 
        at ./__typetests__/handles-nested.tst.ts:8:3
 

--- a/tests/__snapshots__/validation-plugins-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-plugins-wrong-option-value-type-stderr.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'plugins' requires a value of type list.
   3 |   "testFileMatch": [
   4 |     "examples/*.test.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:14
 

--- a/tests/__snapshots__/validation-reporters-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-reporters-wrong-option-value-type-stderr.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'reporters' requires a value of type list.
   3 |   "testFileMatch": [
   4 |     "examples/*.test.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:16
 

--- a/tests/__snapshots__/validation-rootPath-path-does-not-exist.snap.txt
+++ b/tests/__snapshots__/validation-rootPath-path-does-not-exist.snap.txt
@@ -6,7 +6,6 @@ Error: The specified path '<<basePath>>/tests/__fixtures__/.generated/validation
   3 |   "testFileMatch": [
   4 |     "examples/*.t*st.*"
   5 |   ]
-  6 | }
 
       at ./config/tstyche.json:2:15
 

--- a/tests/__snapshots__/validation-rootPath-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-rootPath-wrong-option-value-type-stderr.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'rootPath' requires a value of type string.
   3 |   "testFileMatch": [
   4 |     "examples/*.t*st.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:15
 

--- a/tests/__snapshots__/validation-target-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-target-wrong-option-value-type-stderr.snap.txt
@@ -6,7 +6,6 @@ Error: Option 'target' requires a value of type list.
   3 |   "testFileMatch": [
   4 |     "examples/*.test.*"
   5 |   ]
-  6 | }
 
       at ./tstyche.config.json:2:13
 

--- a/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
@@ -9,6 +9,8 @@ Error: 'describe()' cannot be nested within 'test()'.
   6 |   });
     | ~~~~
   7 | 
+  8 |   test("nested test is handled?", () => {
+  9 |     expect<never>().type.toBeNever();
 
       at ./__typetests__/handles-nested.tst.ts:4:3
 
@@ -23,6 +25,8 @@ Error: 'test()' cannot be nested within 'test()'.
   10 |   });
      | ~~~~
   11 | 
+  12 |   expect<string>().type.toBeString();
+  13 | });
 
        at ./__typetests__/handles-nested.tst.ts:8:3
 


### PR DESCRIPTION
Adding `linesAbove` and `linesBelow` configuration options for code frame output. This makes usage of `diagnosticText()` component more flexible for integrations (e.g. custom reporters).