### PR TITLE
refactor!: remove `Store.getSupportedTags()` method

### DIFF
--- a/source/store/Store.ts
+++ b/source/store/Store.ts
@@ -35,13 +35,6 @@ export class Store {
     Store.#manifestService = new ManifestService(Store.#storePath, Store.#npmRegistry, Store.#fetcher);
   }
 
-  /** @deprecated Use 'Store.manifest' directly. */
-  static async getSupportedTags(): Promise<Array<string> | undefined> {
-    await Store.open();
-
-    return Store.#supportedTags;
-  }
-
   static async install(tag: string): Promise<void> {
     if (tag === "current") {
       return;


### PR DESCRIPTION
Removing the deprecated `Store.getSupportedTags()` method.