### PR TITLE
refactor!: rename the `--fetch` command line option

### DIFF
--- a/models/CommandLineOptions.ts
+++ b/models/CommandLineOptions.ts
@@ -13,13 +13,13 @@ export interface CommandLineOptions {
      */
     failFast?: boolean;
     /**
+     * Fetch specified versions of the 'typescript' package and exit.
+     */
+    fetch?: boolean;
+    /**
      * Print the list of command line options with brief descriptions and exit.
      */
     help?: boolean;
-    /**
-     * Install specified versions of the 'typescript' package and exit.
-     */
-    install?: boolean;
     /**
      * Print the list of supported versions of the 'typescript' package and exit.
      */

--- a/models/__typetests__/CommandLineOptions.tst.ts
+++ b/models/__typetests__/CommandLineOptions.tst.ts
@@ -6,8 +6,8 @@ describe("CommandLineOptions", () => {
     expect<tstyche.CommandLineOptions>().type.toBeAssignableWith({
       config: "./config/tstyche.json",
       failFast: true,
+      fetch: true,
       help: true,
-      install: true,
       list: true,
       listFiles: true,
       only: "external",
@@ -40,15 +40,15 @@ describe("CommandLineOptions", () => {
     }>();
   });
 
-  test("'help' option", () => {
-    expect<Pick<tstyche.CommandLineOptions, "help">>().type.toBe<{
-      help?: boolean;
+  test("'fetch' option", () => {
+    expect<Pick<tstyche.CommandLineOptions, "fetch">>().type.toBe<{
+      fetch?: boolean;
     }>();
   });
 
-  test("'install' option", () => {
-    expect<Pick<tstyche.CommandLineOptions, "install">>().type.toBe<{
-      install?: boolean;
+  test("'help' option", () => {
+    expect<Pick<tstyche.CommandLineOptions, "help">>().type.toBe<{
+      help?: boolean;
     }>();
   });
 

--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -107,9 +107,9 @@ export class Cli {
         continue;
       }
 
-      if (commandLine.includes("--install")) {
+      if (commandLine.includes("--fetch")) {
         for (const tag of resolvedConfig.target) {
-          await Store.install(tag);
+          await Store.fetch(tag);
         }
         continue;
       }

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -64,16 +64,16 @@ export class Options {
 
     {
       brand: OptionBrand.BareTrue,
-      description: "Print the list of command line options with brief descriptions and exit.",
+      description: "Fetch specified versions of the 'typescript' package and exit.",
       group: OptionGroup.CommandLine,
-      name: "help",
+      name: "fetch",
     },
 
     {
       brand: OptionBrand.BareTrue,
-      description: "Install specified versions of the 'typescript' package and exit.",
+      description: "Print the list of command line options with brief descriptions and exit.",
       group: OptionGroup.CommandLine,
-      name: "install",
+      name: "help",
     },
 
     {

--- a/source/store/PackageService.ts
+++ b/source/store/PackageService.ts
@@ -55,7 +55,7 @@ export class PackageService {
   async ensure(packageVersion: string, manifest?: Manifest): Promise<string | undefined> {
     let packagePath: string | undefined = Path.join(this.#storePath, `typescript@${packageVersion}`);
 
-    const diagnostic = Diagnostic.error(StoreDiagnosticText.failedToInstalTypeScript(packageVersion));
+    const diagnostic = Diagnostic.error(StoreDiagnosticText.failedToFetchPackage(packageVersion));
 
     if (await this.#lockService.isLocked(packagePath, diagnostic)) {
       return;

--- a/source/store/Store.ts
+++ b/source/store/Store.ts
@@ -35,7 +35,7 @@ export class Store {
     Store.#manifestService = new ManifestService(Store.#storePath, Store.#npmRegistry, Store.#fetcher);
   }
 
-  static async install(tag: string): Promise<void> {
+  static async fetch(tag: string): Promise<void> {
     if (tag === "current") {
       return;
     }

--- a/source/store/StoreDiagnosticText.ts
+++ b/source/store/StoreDiagnosticText.ts
@@ -7,8 +7,8 @@ export class StoreDiagnosticText {
     return `Failed to fetch metadata of the 'typescript' package from '${registry}'.`;
   }
 
-  static failedToInstalTypeScript(version: string): string {
-    return `Failed to install 'typescript@${version}'.`;
+  static failedToFetchPackage(version: string): string {
+    return `Failed to fetch the 'typescript@${version}' package.`;
   }
 
   static failedToUpdateMetadata(registry: string): string {

--- a/tests/__snapshots__/config-help-stdout.snap.txt
+++ b/tests/__snapshots__/config-help-stdout.snap.txt
@@ -18,11 +18,11 @@ Command Line Options
   --failFast  boolean
   Stop running tests after the first failed assertion.
 
+  --fetch
+  Fetch specified versions of the 'typescript' package and exit.
+
   --help
   Print the list of command line options with brief descriptions and exit.
-
-  --install
-  Install specified versions of the 'typescript' package and exit.
 
   --list
   Print the list of supported versions of the 'typescript' package and exit.

--- a/tests/config-fetch.test.js
+++ b/tests/config-fetch.test.js
@@ -18,26 +18,26 @@ const tsconfig = {
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
-await test("'--install' command line option", async (t) => {
+await test("'--fetch' command line option", async (t) => {
   t.afterEach(async () => {
     await clearFixture(fixtureUrl);
   });
 
   const testCases = [
     {
-      args: ["--install", "--target", "4.9"],
+      args: ["--fetch", "--target", "4.9"],
       testCase: "when '--target' command line option is specified",
     },
     {
-      args: ["--install", "false", "--target", "4.9"],
+      args: ["--fetch", "false", "--target", "4.9"],
       testCase: "does not take arguments",
     },
     {
-      args: ["feature", "--install", "--target", "4.9"],
+      args: ["feature", "--fetch", "--target", "4.9"],
       testCase: "ignores search string specified before the option",
     },
     {
-      args: ["--install", "feature", "--target", "4.9"],
+      args: ["--fetch", "feature", "--target", "4.9"],
       testCase: "ignores search string specified after the option",
     },
   ];
@@ -57,7 +57,7 @@ await test("'--install' command line option", async (t) => {
       assert.equal(
         normalizeOutput(stdout),
         [
-          "adds TypeScript 4.9.5 to <<basePath>>/tests/__fixtures__/.generated/config-install/.store/typescript@4.9.5",
+          "adds TypeScript 4.9.5 to <<basePath>>/tests/__fixtures__/.generated/config-fetch/.store/typescript@4.9.5",
           "",
         ].join("\n"),
       );
@@ -76,13 +76,13 @@ await test("'--install' command line option", async (t) => {
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--install"]);
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--fetch"]);
 
     assert.equal(
       normalizeOutput(stdout),
       [
-        "adds TypeScript 4.8.4 to <<basePath>>/tests/__fixtures__/.generated/config-install/.store/typescript@4.8.4",
-        "adds TypeScript 5.0.4 to <<basePath>>/tests/__fixtures__/.generated/config-install/.store/typescript@5.0.4",
+        "adds TypeScript 4.8.4 to <<basePath>>/tests/__fixtures__/.generated/config-fetch/.store/typescript@4.8.4",
+        "adds TypeScript 5.0.4 to <<basePath>>/tests/__fixtures__/.generated/config-fetch/.store/typescript@5.0.4",
         "",
       ].join("\n"),
     );
@@ -100,7 +100,7 @@ await test("'--install' command line option", async (t) => {
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--install"]);
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--fetch"]);
 
     assert.equal(stdout, "");
     assert.equal(stderr, "");
@@ -116,7 +116,7 @@ await test("'--install' command line option", async (t) => {
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--install", "--target", "current"]);
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--fetch", "--target", "current"]);
 
     assert.equal(stdout, "");
     assert.equal(stderr, "");

--- a/tests/config-storePath.test.js
+++ b/tests/config-storePath.test.js
@@ -129,7 +129,7 @@ await test("'TSTYCHE_STORE_PATH' environment variable", async (t) => {
 
     assert.pathDoesNotExist(storeUrl);
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--install", "--target", "5.2.2"], {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--fetch", "--target", "5.2.2"], {
       env: {
         ["TSTYCHE_STORE_PATH"]: "./dummy-store",
       },

--- a/tests/config-typescriptModule.test.js
+++ b/tests/config-typescriptModule.test.js
@@ -36,7 +36,7 @@ await test("'TSTYCHE_TYPESCRIPT_MODULE' environment variable", async (t) => {
       ["__typetests__/dummy.test.ts"]: isStringTestText,
     });
 
-    await spawnTyche(fixtureUrl, ["--install", "--target", "5.2.2"]);
+    await spawnTyche(fixtureUrl, ["--fetch", "--target", "5.2.2"]);
 
     const typescriptModule = new URL("./.store/typescript@5.2.2/lib/typescript.js", fixtureUrl).toString();
 

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -130,7 +130,7 @@ await test("TypeScript 4.x", async (t) => {
 
   for (const version of testCases) {
     await t.test(`uses TypeScript ${version} as current target`, async () => {
-      await spawnTyche(fixtureUrl, ["--install", "--target", version]);
+      await spawnTyche(fixtureUrl, ["--fetch", "--target", version]);
 
       const typescriptModule = new URL(`./typescript@${version}/lib/typescript.js`, storeUrl).toString();
 
@@ -174,7 +174,7 @@ await test("TypeScript 5.x", async (t) => {
 
   for (const version of testCases) {
     await t.test(`uses TypeScript ${version} as current target`, async () => {
-      await spawnTyche(fixtureUrl, ["--install", "--target", version]);
+      await spawnTyche(fixtureUrl, ["--fetch", "--target", version]);
 
       const typescriptModule = new URL(`./typescript@${version}/lib/typescript.js`, storeUrl).toString();
 

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -100,7 +100,7 @@ await test("store", async (t) => {
     });
 
     const expected = [
-      "Error: Failed to install 'typescript@5.1.6'.",
+      "Error: Failed to fetch the 'typescript@5.1.6' package.",
       "",
       "The request timeout of 0.001s was exceeded.",
       "",
@@ -124,7 +124,7 @@ await test("store", async (t) => {
     });
 
     const expected = [
-      "Error: Failed to install 'typescript@5.4.5'.",
+      "Error: Failed to fetch the 'typescript@5.4.5' package.",
       "",
       "Lock wait timeout of 1.5s was exceeded.",
       "",


### PR DESCRIPTION
Closes #374

Renaming the `--fetch` command line option.