### PR TITLE
chore!: drop support for Node.js 18

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.12', '20.x', '22.x', '23.x']
+        node-version: ['20.9', '20.x', '22.x', '23.x']
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.9', '20.x', '22.x', '23.x']
+        node-version: ['20.12', '20.x', '22.x', '23.x']
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18.19', '18.x', '20.x', '22.x', '23.x']
+        node-version: ['20.9', '20.x', '22.x', '23.x']
     runs-on: ubuntu-latest
 
     steps:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,10 +2,10 @@
 
 For the smoothest development experience in this codebase, you'll need:
 
-- [Node.js] — You'll need at least v18, but would be better served with v22.
-- [nvm] — Optional, but helpful.
-- [yarn] — Not just npm.
-- [hyperfine] — Optional for many basic tasks, but required for performance metrics.
+- [Node.js] — Install the latest Long Term Support (LTS) release.
+  - Recommended: use [n] or similar tool for managing Node.js versions.
+- [Yarn] — Not just npm.
+- [Hyperfine] — Optional for many basic tasks, but required for performance metrics.
 
 You'll do a typical setup sequence from there.
 
@@ -27,7 +27,7 @@ Run tests:
 yarn test
 ```
 
-You can then see everything as a user would, by running tstyche against some example tests:
+You can then see everything as a user would, by running TSTyche against some example tests:
 
 ```shell
 yarn test:examples
@@ -39,13 +39,13 @@ Which is just an alias for:
 tstyche ./examples
 ```
 
-## Install notes for macos
+## Install notes for macOS
 
 - You can't just `brew install yarn`.
   It will install an ancient version, and won't work.
-  Instead, see the [yarn setup instructions].
+  Instead, see the [Yarn setup instructions].
 
-- For hyperfine, the version from brew works well enough: `brew install hyperfine`.
+- For Hyperfine, the version from Brew works well enough: `brew install hyperfine`.
 
 ## Before you commit
 
@@ -59,7 +59,7 @@ yarn test
 ```
 
 [Node.js]: https://nodejs.org
-[nvm]: https://github.com/nvm-sh/nvm
-[yarn]: https://yarnpkg.com/getting-started/install
-[hyperfine]: https://github.com/sharkdp/hyperfine
-[yarn setup instructions]: https://yarnpkg.com/getting-started/install
+[n]: https://github.com/tj/n
+[Yarn]: https://yarnpkg.com/getting-started/install
+[Hyperfine]: https://github.com/sharkdp/hyperfine
+[Yarn setup instructions]: https://yarnpkg.com/getting-started/install

--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "engines": {
-    "node": ">=20.9"
+    "node": ">=20.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "engines": {
-    "node": ">=18.19"
+    "node": ">=20.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "engines": {
-    "node": ">=20.12"
+    "node": ">=20.9"
   }
 }

--- a/tests/feature-watch.test.js
+++ b/tests/feature-watch.test.js
@@ -45,23 +45,6 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 await test("watch", async (t) => {
-  let isRecursiveWatchAvailable;
-
-  try {
-    const watcher = fs.watch(process.cwd(), { persistent: false, recursive: true });
-    watcher.close();
-
-    isRecursiveWatchAvailable = true;
-  } catch {
-    isRecursiveWatchAvailable = false;
-  }
-
-  if (!isRecursiveWatchAvailable) {
-    t.skip();
-
-    return;
-  }
-
   await t.test("interactive input", async (t) => {
     t.afterEach(async () => {
       await clearFixture(fixtureUrl);

--- a/tests/feature-watch.test.js
+++ b/tests/feature-watch.test.js
@@ -45,6 +45,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
 await test("watch", async (t) => {
+  // TODO remove this check after dropping support for Node.js 20
+  if (process.versions.node.startsWith("20.9") && process.platform === "linux") {
+    t.skip();
+
+    return;
+  }
+
   await t.test("interactive input", async (t) => {
     t.afterEach(async () => {
       await clearFixture(fixtureUrl);


### PR DESCRIPTION
Dropping support for Node.js 18. (The plan is to release TSTyche 4 after Node.js 18 will be end-of-life.)