### PR TITLE
refactor!: rename `AssertionNode` and  `TestTreeNode` classes

### DIFF
--- a/source/collect/AssertionNode.ts
+++ b/source/collect/AssertionNode.ts
@@ -1,14 +1,14 @@
 import type ts from "typescript";
-import { TestMember } from "./TestMember.js";
-import type { TestMemberBrand } from "./TestMemberBrand.enum.js";
-import type { TestMemberFlags } from "./TestMemberFlags.enum.js";
 import type { TestTree } from "./TestTree.js";
+import { TestTreeNode } from "./TestTreeNode.js";
+import type { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
+import type { TestTreeNodeFlags } from "./TestTreeNodeFlags.enum.js";
 
 export interface MatcherNode extends ts.CallExpression {
   expression: ts.PropertyAccessExpression;
 }
 
-export class Assertion extends TestMember {
+export class AssertionNode extends TestTreeNode {
   isNot: boolean;
   matcherName: ts.MemberName;
   matcherNode: MatcherNode;
@@ -19,10 +19,10 @@ export class Assertion extends TestMember {
 
   constructor(
     compiler: typeof ts,
-    brand: TestMemberBrand,
+    brand: TestTreeNodeBrand,
     node: ts.CallExpression,
-    parent: TestTree | TestMember,
-    flags: TestMemberFlags,
+    parent: TestTree | TestTreeNode,
+    flags: TestTreeNodeFlags,
     matcherNode: MatcherNode,
     modifierNode: ts.PropertyAccessExpression,
     notNode?: ts.PropertyAccessExpression,

--- a/source/collect/IdentifierLookup.ts
+++ b/source/collect/IdentifierLookup.ts
@@ -1,6 +1,6 @@
 import type ts from "typescript";
-import { TestMemberBrand } from "./TestMemberBrand.enum.js";
-import { TestMemberFlags } from "./TestMemberFlags.enum.js";
+import { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
+import { TestTreeNodeFlags } from "./TestTreeNodeFlags.enum.js";
 
 export interface Identifiers {
   namedImports: Record<string, string | undefined>;
@@ -59,8 +59,8 @@ export class IdentifierLookup {
     }
   }
 
-  resolveTestMemberMeta(node: ts.CallExpression): { brand: TestMemberBrand; flags: TestMemberFlags } | undefined {
-    let flags = TestMemberFlags.None;
+  resolveTestMemberMeta(node: ts.CallExpression): { brand: TestTreeNodeBrand; flags: TestTreeNodeFlags } | undefined {
+    let flags = TestTreeNodeFlags.None;
     let expression = node.expression;
 
     while (this.#compiler.isPropertyAccessExpression(expression)) {
@@ -70,19 +70,19 @@ export class IdentifierLookup {
 
       switch (expression.name.getText()) {
         case "fail":
-          flags |= TestMemberFlags.Fail;
+          flags |= TestTreeNodeFlags.Fail;
           break;
 
         case "only":
-          flags |= TestMemberFlags.Only;
+          flags |= TestTreeNodeFlags.Only;
           break;
 
         case "skip":
-          flags |= TestMemberFlags.Skip;
+          flags |= TestTreeNodeFlags.Skip;
           break;
 
         case "todo":
-          flags |= TestMemberFlags.Todo;
+          flags |= TestTreeNodeFlags.Todo;
           break;
       }
 
@@ -108,14 +108,14 @@ export class IdentifierLookup {
 
     switch (identifierName) {
       case "describe":
-        return { brand: TestMemberBrand.Describe, flags };
+        return { brand: TestTreeNodeBrand.Describe, flags };
 
       case "it":
       case "test":
-        return { brand: TestMemberBrand.Test, flags };
+        return { brand: TestTreeNodeBrand.Test, flags };
 
       case "expect":
-        return { brand: TestMemberBrand.Expect, flags };
+        return { brand: TestTreeNodeBrand.Expect, flags };
     }
 
     return;

--- a/source/collect/TestTree.ts
+++ b/source/collect/TestTree.ts
@@ -1,12 +1,11 @@
 import type ts from "typescript";
-import type { Assertion } from "./Assertion.js";
-import type { TestMember } from "./TestMember.js";
+import type { AssertionNode } from "./AssertionNode.js";
+import type { TestTreeNode } from "./TestTreeNode.js";
 
 export class TestTree {
+  children: Array<TestTreeNode | AssertionNode> = [];
   diagnostics: Set<ts.Diagnostic>;
   hasOnly = false;
-  // TODO rename to 'children' in TStyche 4
-  members: Array<TestMember | Assertion> = [];
   sourceFile: ts.SourceFile;
 
   constructor(diagnostics: Set<ts.Diagnostic>, sourceFile: ts.SourceFile) {

--- a/source/collect/TestTreeNodeBrand.enum.ts
+++ b/source/collect/TestTreeNodeBrand.enum.ts
@@ -1,4 +1,4 @@
-export const enum TestMemberBrand {
+export const enum TestTreeNodeBrand {
   Describe = "describe",
   Test = "test",
   Expect = "expect",

--- a/source/collect/TestTreeNodeFlags.enum.ts
+++ b/source/collect/TestTreeNodeFlags.enum.ts
@@ -1,4 +1,4 @@
-export const enum TestMemberFlags {
+export const enum TestTreeNodeFlags {
   None = 0,
   Fail = 1 << 0,
   Only = 1 << 1,

--- a/source/collect/index.ts
+++ b/source/collect/index.ts
@@ -1,6 +1,6 @@
-export { Assertion } from "./Assertion.js";
+export { AssertionNode } from "./AssertionNode.js";
 export { CollectService } from "./CollectService.js";
-export { TestMember } from "./TestMember.js";
-export { TestMemberBrand } from "./TestMemberBrand.enum.js";
-export { TestMemberFlags } from "./TestMemberFlags.enum.js";
 export { TestTree } from "./TestTree.js";
+export { TestTreeNode } from "./TestTreeNode.js";
+export { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
+export { TestTreeNodeFlags } from "./TestTreeNodeFlags.enum.js";

--- a/source/diagnostic/DiagnosticOrigin.ts
+++ b/source/diagnostic/DiagnosticOrigin.ts
@@ -1,27 +1,27 @@
 import type ts from "typescript";
-import type { Assertion } from "#collect";
+import type { AssertionNode } from "#collect";
 import type { SourceFile } from "./SourceFile.js";
 
 export class DiagnosticOrigin {
-  assertion: Assertion | undefined;
+  assertion: AssertionNode | undefined;
   end: number;
   sourceFile: SourceFile | ts.SourceFile;
   start: number;
 
-  constructor(start: number, end: number, sourceFile: SourceFile | ts.SourceFile, assertion?: Assertion) {
+  constructor(start: number, end: number, sourceFile: SourceFile | ts.SourceFile, assertion?: AssertionNode) {
     this.start = start;
     this.end = end;
     this.sourceFile = sourceFile;
     this.assertion = assertion;
   }
 
-  static fromAssertion(assertion: Assertion): DiagnosticOrigin {
+  static fromAssertion(assertion: AssertionNode): DiagnosticOrigin {
     const node = assertion.matcherName;
 
     return new DiagnosticOrigin(node.getStart(), node.getEnd(), node.getSourceFile(), assertion);
   }
 
-  static fromNode(node: ts.Node, assertion?: Assertion): DiagnosticOrigin {
+  static fromNode(node: ts.Node, assertion?: AssertionNode): DiagnosticOrigin {
     return new DiagnosticOrigin(node.getStart(), node.getEnd(), node.getSourceFile(), assertion);
   }
 }

--- a/source/events/types.ts
+++ b/source/events/types.ts
@@ -1,4 +1,4 @@
-import type { Assertion, TestMember, TestTree } from "#collect";
+import type { AssertionNode, TestTree, TestTreeNode } from "#collect";
 import type { Diagnostic } from "#diagnostic";
 import type { DescribeResult, ExpectResult, Result, TargetResult, TaskResult, TestResult } from "#result";
 
@@ -21,7 +21,7 @@ export type Event =
   | ["task:error", { diagnostics: Array<Diagnostic>; result: TaskResult }]
   | ["task:end", { result: TaskResult }]
   | ["collect:start", { testTree: TestTree }]
-  | ["collect:node", { testNode: TestMember | Assertion }]
+  | ["collect:node", { testNode: TestTreeNode | AssertionNode }]
   | ["collect:end", { testTree: TestTree }]
   | ["describe:start", { result: DescribeResult }]
   | ["describe:end", { result: DescribeResult }]

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -1,5 +1,5 @@
 import type ts from "typescript";
-import type { Assertion } from "#collect";
+import type { AssertionNode } from "#collect";
 import type { ResolvedConfig } from "#config";
 import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
@@ -71,7 +71,7 @@ export class ExpectService {
   }
 
   match(
-    assertion: Assertion,
+    assertion: AssertionNode,
     onDiagnostics: DiagnosticsHandler<Diagnostic | Array<Diagnostic>>,
   ): MatchResult | undefined {
     const matcherNameText = assertion.matcherName.getText();
@@ -138,28 +138,32 @@ export class ExpectService {
     return;
   }
 
-  #onMatcherIsNotSupported(matcherNameText: string, assertion: Assertion, onDiagnostics: DiagnosticsHandler) {
+  #onMatcherIsNotSupported(matcherNameText: string, assertion: AssertionNode, onDiagnostics: DiagnosticsHandler) {
     const text = ExpectDiagnosticText.matcherIsNotSupported(matcherNameText);
     const origin = DiagnosticOrigin.fromNode(assertion.matcherName);
 
     onDiagnostics(Diagnostic.error(text, origin));
   }
 
-  #onSourceArgumentOrTypeArgumentMustBeProvided(assertion: Assertion, onDiagnostics: DiagnosticsHandler) {
+  #onSourceArgumentOrTypeArgumentMustBeProvided(assertion: AssertionNode, onDiagnostics: DiagnosticsHandler) {
     const text = ExpectDiagnosticText.argumentOrTypeArgumentMustBeProvided("source", "Source");
     const origin = DiagnosticOrigin.fromNode(assertion.node.expression);
 
     onDiagnostics(Diagnostic.error(text, origin));
   }
 
-  #onTargetArgumentMustBeProvided(argumentNameText: string, assertion: Assertion, onDiagnostics: DiagnosticsHandler) {
+  #onTargetArgumentMustBeProvided(
+    argumentNameText: string,
+    assertion: AssertionNode,
+    onDiagnostics: DiagnosticsHandler,
+  ) {
     const text = ExpectDiagnosticText.argumentMustBeProvided(argumentNameText);
     const origin = DiagnosticOrigin.fromNode(assertion.matcherName);
 
     onDiagnostics(Diagnostic.error(text, origin));
   }
 
-  #onTargetArgumentOrTypeArgumentMustBeProvided(assertion: Assertion, onDiagnostics: DiagnosticsHandler) {
+  #onTargetArgumentOrTypeArgumentMustBeProvided(assertion: AssertionNode, onDiagnostics: DiagnosticsHandler) {
     const text = ExpectDiagnosticText.argumentOrTypeArgumentMustBeProvided("target", "Target");
     const origin = DiagnosticOrigin.fromNode(assertion.matcherName);
 

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -1,17 +1,17 @@
 import type ts from "typescript";
-import type { Assertion } from "#collect";
+import type { AssertionNode } from "#collect";
 import { DiagnosticOrigin } from "#diagnostic";
 import { Version } from "#version";
 import type { Relation, TypeChecker } from "./types.js";
 
 export class MatchWorker {
-  assertion: Assertion;
+  assertion: AssertionNode;
   #compiler: typeof ts;
   #signatureCache = new Map<ts.Node, Array<ts.Signature>>();
   #typeCache = new Map<ts.Node, ts.Type>();
   #typeChecker: TypeChecker;
 
-  constructor(compiler: typeof ts, typeChecker: TypeChecker, assertion: Assertion) {
+  constructor(compiler: typeof ts, typeChecker: TypeChecker, assertion: AssertionNode) {
     this.#compiler = compiler;
     this.#typeChecker = typeChecker;
     this.assertion = assertion;

--- a/source/handlers/TestTreeHandler.ts
+++ b/source/handlers/TestTreeHandler.ts
@@ -1,4 +1,4 @@
-import { TestMemberFlags, type TestTree } from "#collect";
+import { type TestTree, TestTreeNodeFlags } from "#collect";
 import type { Event, EventHandler } from "#events";
 
 export class TestTreeHandler implements EventHandler {
@@ -15,7 +15,7 @@ export class TestTreeHandler implements EventHandler {
         break;
 
       case "collect:node":
-        if (payload.testNode.flags & TestMemberFlags.Only) {
+        if (payload.testNode.flags & TestTreeNodeFlags.Only) {
           this.testTree!.hasOnly = true;
         }
         break;

--- a/source/output/CodeFrameText.tsx
+++ b/source/output/CodeFrameText.tsx
@@ -1,11 +1,11 @@
-import type { TestMember, TestTree } from "#collect";
+import type { TestTree, TestTreeNode } from "#collect";
 import { DiagnosticCategory, type DiagnosticOrigin } from "#diagnostic";
 import { Path } from "#path";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 import type { CodeFrameOptions } from "./types.js";
 
 interface BreadcrumbsTextProps {
-  ancestor: TestMember | TestTree;
+  ancestor: TestTreeNode | TestTree;
 }
 
 function BreadcrumbsText({ ancestor }: BreadcrumbsTextProps) {

--- a/source/result/DescribeResult.ts
+++ b/source/result/DescribeResult.ts
@@ -1,14 +1,14 @@
-import type { TestMember } from "#collect";
+import type { TestTreeNode } from "#collect";
 import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
 export class DescribeResult {
-  describe: TestMember;
+  describe: TestTreeNode;
   parent: DescribeResult | undefined;
   results: Array<DescribeResult | TestResult> = [];
   timing = new ResultTiming();
 
-  constructor(describe: TestMember, parent?: DescribeResult) {
+  constructor(describe: TestTreeNode, parent?: DescribeResult) {
     this.describe = describe;
     this.parent = parent;
   }

--- a/source/result/ExpectResult.ts
+++ b/source/result/ExpectResult.ts
@@ -1,17 +1,17 @@
-import type { Assertion } from "#collect";
+import type { AssertionNode } from "#collect";
 import type { Diagnostic } from "#diagnostic";
 import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
 export class ExpectResult {
-  assertion: Assertion;
+  assertion: AssertionNode;
   diagnostics: Array<Diagnostic> = [];
   parent: TestResult | undefined;
   status: ResultStatus = ResultStatus.Runs;
   timing = new ResultTiming();
 
-  constructor(assertion: Assertion, parent?: TestResult) {
+  constructor(assertion: AssertionNode, parent?: TestResult) {
     this.assertion = assertion;
     this.parent = parent;
   }

--- a/source/result/TestResult.ts
+++ b/source/result/TestResult.ts
@@ -1,4 +1,4 @@
-import type { TestMember } from "#collect";
+import type { TestTreeNode } from "#collect";
 import type { Diagnostic } from "#diagnostic";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
@@ -12,10 +12,10 @@ export class TestResult {
   parent: DescribeResult | undefined;
   results: Array<ExpectResult> = [];
   status: ResultStatus = ResultStatus.Runs;
-  test: TestMember;
+  test: TestTreeNode;
   timing = new ResultTiming();
 
-  constructor(test: TestMember, parent?: DescribeResult) {
+  constructor(test: TestTreeNode, parent?: DescribeResult) {
     this.test = test;
     this.parent = parent;
   }

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -107,6 +107,6 @@ export class TaskRunner {
       position: task.position,
     });
 
-    testTreeWalker.visit(testTree.members, RunMode.Normal, /* parentResult */ undefined);
+    testTreeWalker.visit(testTree.children, RunMode.Normal, /* parentResult */ undefined);
   }
 }


### PR DESCRIPTION
Renaming `AssertionNode` and  `TestTreeNode` classes as well as `TestTreeNodeBrand` and `TestTreeNodeFlags` enums.