### PR TITLE
refactor!: enable the `checkSourceFiles` option by default

### DIFF
--- a/models/config-schema.json
+++ b/models/config-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "checkSourceFiles": {
-      "default": false,
+      "default": true,
       "description": "Enable type error reporting for source files.",
       "type": "boolean"
     },

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -3,7 +3,7 @@ import { Path } from "#path";
 import type { ConfigFileOptions } from "./types.js";
 
 export const defaultOptions: Required<ConfigFileOptions> = {
-  checkSourceFiles: false,
+  checkSourceFiles: true,
   failFast: false,
   plugins: [],
   rejectAnyType: false,


### PR DESCRIPTION
Closes #389

Enabling the `checkSourceFiles` option by default.