### PR TITLE
feat!: make default compiler options strict

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -16,5 +16,5 @@
   "ignorePaths": ["**/__snapshots__/**/*"],
   "language": "en-US",
   "useGitignore": true,
-  "words": ["codacy", "findup", "identicality", "jsxs", "monocart", "tsserverlibrary", "typetests"]
+  "words": ["codacy", "findup", "identicality", "jsxs", "monocart", "nodenext", "tsserverlibrary", "typetests"]
 }

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -3,7 +3,6 @@ import type { ResolvedConfig } from "#config";
 import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
 import { Select } from "#select";
-import { Version } from "#version";
 
 export class ProjectService {
   #compiler: typeof ts;
@@ -80,19 +79,16 @@ export class ProjectService {
       allowImportingTsExtensions: true,
       allowJs: true,
       checkJs: true,
-      esModuleInterop: true,
+      exactOptionalPropertyTypes: true,
       jsx: "preserve" as ts.server.protocol.JsxEmit,
-      module: "esnext" as ts.server.protocol.ModuleKind,
-      moduleResolution: "bundler" as ts.server.protocol.ModuleResolutionKind,
+      module: "nodenext" as ts.server.protocol.ModuleKind,
+      moduleResolution: "nodenext" as ts.server.protocol.ModuleResolutionKind,
+      noUncheckedIndexedAccess: true,
       resolveJsonModule: true,
-      strictFunctionTypes: true,
-      strictNullChecks: true,
+      strict: true,
       target: "esnext" as ts.server.protocol.ScriptTarget,
+      verbatimModuleSyntax: true,
     };
-
-    if (Version.isSatisfiedWith(this.#compiler.version, "5.4")) {
-      defaultCompilerOptions.module = "preserve" as ts.server.protocol.ModuleKind;
-    }
 
     return defaultCompilerOptions;
   }

--- a/tests/project-tsconfig.test.js
+++ b/tests/project-tsconfig.test.js
@@ -35,7 +35,7 @@ test("'useUnknownInCatchVariables': false", () => {
   try {
     //
   } catch (error) {
-    expect(error).type.toBeAny();
+    expect(error).type.toBe<unknown>();
   }
 });
 `;


### PR DESCRIPTION
Closes #381

Making default compiler options more strict:

```json
{
  "allowImportingTsExtensions": true,
  "allowJs": true,
  "checkJs": true,
  "exactOptionalPropertyTypes": true,
  "jsx": "preserve",
  "module": "nodenext",
  "moduleResolution": "nodenext",
  "noUncheckedIndexedAccess": true,
  "resolveJsonModule": true,
  "strict": true,
  "target": "esnext",
  "verbatimModuleSyntax": true
}
```