### PR TITLE
fix: exclude whitespace when comparing diagnostic messages

### DIFF
--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -56,18 +56,18 @@ export class Diagnostic {
       const text =
         typeof diagnostic.messageText === "string"
           ? diagnostic.messageText
-          : Diagnostic.#toMessageText(diagnostic.messageText);
+          : Diagnostic.toMessageText(diagnostic.messageText);
 
       return new Diagnostic(text, DiagnosticCategory.Error, origin).add({ code, related });
     });
   }
 
-  static #toMessageText(chain: ts.DiagnosticMessageChain): Array<string> {
+  static toMessageText(chain: ts.DiagnosticMessageChain): Array<string> {
     const result = [chain.messageText];
 
     if (chain.next != null) {
       for (const nextChain of chain.next) {
-        result.push(...Diagnostic.#toMessageText(nextChain));
+        result.push(...Diagnostic.toMessageText(nextChain));
       }
     }
 


### PR DESCRIPTION
Whitespace should be ignored when comparing TypeScript’s diagnostic messages.