### PR TITLE
feat: add the `skipIf()` run mode flag

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -1,3 +1,10 @@
+interface SkipConditions {
+  /**
+   * The range of TypeScript versions.
+   */
+  target?: string;
+}
+
 interface Describe {
   /**
    * Defines a group of tests.
@@ -20,6 +27,13 @@ interface Describe {
    * @param callback - The function to create a scope for a group of tests.
    */
   skip: (name: string, callback: () => void | Promise<void>) => void;
+  /**
+   * If any of the given conditions are met, marks a group of tests as skipped.
+   *
+   * @param name - The name of the group.
+   * @param callback - The function to create a scope for a group of tests.
+   */
+  skipIf: (conditions: SkipConditions) => (name: string, callback: () => void | Promise<void>) => void;
   /**
    * Marks a group of tests as yet to be implemented.
    *
@@ -51,6 +65,13 @@ interface Test {
    * @param callback - The function with a code snippet and assertions.
    */
   skip: (name: string, callback: () => void | Promise<void>) => void;
+  /**
+   * If any of the given conditions are met, a test as skipped.
+   *
+   * @param name - The name of the test.
+   * @param callback - The function with a code snippet and assertions.
+   */
+  skipIf: (conditions: SkipConditions) => (name: string, callback: () => void | Promise<void>) => void;
   /**
    * Marks a test as yet to be implemented.
    *
@@ -260,6 +281,37 @@ interface Expect {
    * Marks an assertion as skipped.
    */
   skip: {
+    /**
+     * Marks an assertion as skipped.
+     *
+     * @template Source - The type against which the assertion is made.
+     */
+    <Source>(): Modifier;
+    /**
+     * Marks an assertion as skipped.
+     *
+     * @param source - The expression against which type the assertion is made.
+     */
+    (source: unknown): Modifier;
+    fail: {
+      /**
+       * Marks an assertion as supposed to fail.
+       *
+       * @template Source - The type against which the assertion is made.
+       */
+      <Source>(): Modifier;
+      /**
+       * Marks an assertion as supposed to fail.
+       *
+       * @param source - The expression against which type the assertion is made.
+       */
+      (source: unknown): Modifier;
+    };
+  };
+  /**
+   * If any of the given conditions are met, an assertion as skipped.
+   */
+  skipIf(conditions: SkipConditions): {
     /**
      * Marks an assertion as skipped.
      *

--- a/tests/__snapshots__/validation-omit-stderr.snap.txt
+++ b/tests/__snapshots__/validation-omit-stderr.snap.txt
@@ -12,15 +12,15 @@ Error: Expected at least 2 arguments, but got 0. ts(2555)
 
     An argument for 'object' was not provided. ts(6210)
 
-      291 |  * Reshapes type of the given object by removing the specified keys.
-      292 |  */
-      293 | declare function omit<T, K extends PropertyKey>(object: T, ...keys: [K, ...Array<K>]): Omit<T, K>;
+      342 |  * Reshapes type of the given object by removing the specified keys.
+      343 |  */
+      344 | declare function omit<T, K extends PropertyKey>(object: T, ...keys: [K, ...Array<K>]): Omit<T, K>;
           |                                                 ~~~~~~~~~
-      294 | /**
-      295 |  * Reshapes type of the given object by keeping only the specified keys.
-      296 |  */
+      345 | /**
+      346 |  * Reshapes type of the given object by keeping only the specified keys.
+      347 |  */
 
-            at ../../../build/index.d.ts:293:49
+            at ../../../build/index.d.ts:344:49
 
 Error: Expected at least 2 arguments, but got 1. ts(2555)
 
@@ -36,13 +36,13 @@ Error: Expected at least 2 arguments, but got 1. ts(2555)
 
     Arguments for the rest parameter 'keys' were not provided. ts(6236)
 
-      291 |  * Reshapes type of the given object by removing the specified keys.
-      292 |  */
-      293 | declare function omit<T, K extends PropertyKey>(object: T, ...keys: [K, ...Array<K>]): Omit<T, K>;
+      342 |  * Reshapes type of the given object by removing the specified keys.
+      343 |  */
+      344 | declare function omit<T, K extends PropertyKey>(object: T, ...keys: [K, ...Array<K>]): Omit<T, K>;
           |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~
-      294 | /**
-      295 |  * Reshapes type of the given object by keeping only the specified keys.
-      296 |  */
+      345 | /**
+      346 |  * Reshapes type of the given object by keeping only the specified keys.
+      347 |  */
 
-            at ../../../build/index.d.ts:293:60
+            at ../../../build/index.d.ts:344:60
 

--- a/tests/__snapshots__/validation-pick-stderr.snap.txt
+++ b/tests/__snapshots__/validation-pick-stderr.snap.txt
@@ -12,15 +12,15 @@ Error: Expected at least 2 arguments, but got 0. ts(2555)
 
     An argument for 'object' was not provided. ts(6210)
 
-      295 |  * Reshapes type of the given object by keeping only the specified keys.
-      296 |  */
-      297 | declare function pick<T, K extends keyof T>(object: T, ...keys: [K, ...Array<K>]): Pick<T, K>;
+      346 |  * Reshapes type of the given object by keeping only the specified keys.
+      347 |  */
+      348 | declare function pick<T, K extends keyof T>(object: T, ...keys: [K, ...Array<K>]): Pick<T, K>;
           |                                             ~~~~~~~~~
-      298 | /**
-      299 |  * Defines a test group.
-      300 |  */
+      349 | /**
+      350 |  * Defines a test group.
+      351 |  */
 
-            at ../../../build/index.d.ts:297:45
+            at ../../../build/index.d.ts:348:45
 
 Error: Expected at least 2 arguments, but got 1. ts(2555)
 
@@ -36,15 +36,15 @@ Error: Expected at least 2 arguments, but got 1. ts(2555)
 
     Arguments for the rest parameter 'keys' were not provided. ts(6236)
 
-      295 |  * Reshapes type of the given object by keeping only the specified keys.
-      296 |  */
-      297 | declare function pick<T, K extends keyof T>(object: T, ...keys: [K, ...Array<K>]): Pick<T, K>;
+      346 |  * Reshapes type of the given object by keeping only the specified keys.
+      347 |  */
+      348 | declare function pick<T, K extends keyof T>(object: T, ...keys: [K, ...Array<K>]): Pick<T, K>;
           |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~
-      298 | /**
-      299 |  * Defines a test group.
-      300 |  */
+      349 | /**
+      350 |  * Defines a test group.
+      351 |  */
 
-            at ../../../build/index.d.ts:297:56
+            at ../../../build/index.d.ts:348:56
 
 Error: Argument of type '"b"' is not assignable to parameter of type '"a"'. ts(2345)
 

--- a/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-describe-level-errors-stderr.snap.txt
@@ -12,13 +12,13 @@ Error: Expected 2 arguments, but got 1. ts(2554)
 
     An argument for 'callback' was not provided. ts(6210)
 
-      36 |      * @param callback - The function with a code snippet and assertions.
-      37 |      */
-      38 |     (name: string, callback: () => void | Promise<void>): void;
+      49 |      * @param callback - The function with a code snippet and assertions.
+      50 |      */
+      51 |     (name: string, callback: () => void | Promise<void>): void;
          |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      39 |     /**
-      40 |      * Marks a test as focused.
-      41 |      *
+      52 |     /**
+      53 |      * Marks a test as focused.
+      54 |      *
 
-           at ../../../build/index.d.ts:38:20
+           at ../../../build/index.d.ts:51:20
 


### PR DESCRIPTION
Closes #429

Adding the `skipIf()` run mode flag which will allow skipping tests conditionally (e.g. on specified TypeScript versions).