### PR TITLE
refactor!: always take `compiler` as the first constructor argument

### DIFF
--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -11,9 +11,9 @@ export class ProjectService {
   #seenPrograms = new WeakSet<ts.Program>();
   #service: ts.server.ProjectService;
 
-  constructor(resolvedConfig: ResolvedConfig, compiler: typeof ts) {
-    this.#resolvedConfig = resolvedConfig;
+  constructor(compiler: typeof ts, resolvedConfig: ResolvedConfig) {
     this.#compiler = compiler;
+    this.#resolvedConfig = resolvedConfig;
 
     const noop = () => undefined;
 

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -93,7 +93,7 @@ export class Runner {
 
       if (compiler) {
         // TODO to improve performance, task runners (or even test projects) could be cached in the future
-        const taskRunner = new TaskRunner(this.#resolvedConfig, compiler);
+        const taskRunner = new TaskRunner(compiler, this.#resolvedConfig);
 
         for (const task of tasks) {
           taskRunner.run(task, cancellationToken);

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -13,16 +13,16 @@ import { RunMode } from "./RunMode.enum.js";
 import { TestTreeWalker } from "./TestTreeWalker.js";
 
 export class TaskRunner {
-  #compiler: typeof ts;
   #collectService: CollectService;
+  #compiler: typeof ts;
   #resolvedConfig: ResolvedConfig;
   #projectService: ProjectService;
 
-  constructor(resolvedConfig: ResolvedConfig, compiler: typeof ts) {
-    this.#resolvedConfig = resolvedConfig;
+  constructor(compiler: typeof ts, resolvedConfig: ResolvedConfig) {
     this.#compiler = compiler;
+    this.#resolvedConfig = resolvedConfig;
 
-    this.#projectService = new ProjectService(this.#resolvedConfig, compiler);
+    this.#projectService = new ProjectService(compiler, this.#resolvedConfig);
     this.#collectService = new CollectService(compiler, this.#projectService, this.#resolvedConfig);
   }
 
@@ -100,7 +100,7 @@ export class TaskRunner {
 
     const typeChecker = program.getTypeChecker() as TypeChecker;
 
-    const testTreeWalker = new TestTreeWalker(this.#resolvedConfig, this.#compiler, typeChecker, {
+    const testTreeWalker = new TestTreeWalker(this.#compiler, typeChecker, this.#resolvedConfig, {
       cancellationToken,
       taskResult,
       hasOnly: testTree.hasOnly,

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -24,9 +24,9 @@ export class TestTreeWalker {
   #taskResult: TaskResult;
 
   constructor(
-    resolvedConfig: ResolvedConfig,
     compiler: typeof ts,
     typeChecker: TypeChecker,
+    resolvedConfig: ResolvedConfig,
     options: TestTreeWalkerOptions,
   ) {
     this.#resolvedConfig = resolvedConfig;


### PR DESCRIPTION
Cleaning up. The `compiler` argument must be always the first one in constructors.