### PR TITLE
fix: relax validation of the target of `.toBeCallableWith()` matcher

### DIFF
--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -83,36 +83,8 @@ export class ToBeCallableWith {
     matchWorker: MatchWorker,
     sourceNode: ArgumentNode,
     targetNodes: ts.NodeArray<ArgumentNode>,
-    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
+    _onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>, // not used here
   ): MatchResult | undefined {
-    let mustBeText: string | undefined;
-
-    if (
-      !(
-        sourceNode.kind === this.#compiler.SyntaxKind.Identifier ||
-        // instantiation expressions are allowed
-        sourceNode.kind === this.#compiler.SyntaxKind.ExpressionWithTypeArguments
-      )
-    ) {
-      mustBeText = "an identifier or instantiation expression";
-    }
-
-    if (matchWorker.getType(sourceNode).getCallSignatures().length === 0) {
-      mustBeText = "of a function type";
-    }
-
-    if (mustBeText != null) {
-      const text = this.#compiler.isTypeNode(sourceNode)
-        ? ExpectDiagnosticText.typeArgumentMustBe("Source", mustBeText)
-        : ExpectDiagnosticText.argumentMustBe("source", mustBeText);
-
-      const origin = DiagnosticOrigin.fromNode(sourceNode);
-
-      onDiagnostics([Diagnostic.error(text, origin)]);
-
-      return;
-    }
-
     return {
       explain: () => this.#explain(matchWorker, sourceNode, targetNodes),
       isMatch: !matchWorker.assertion.abilityDiagnostics,

--- a/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
@@ -10,27 +10,33 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 
       at ./__typetests__/toBeCallableWith.tst.ts:5:5
 
-Error: An argument for 'source' must be of a function type.
+Error: Expression cannot be called with the given argument.
+
+This expression is not callable.
+Type 'String' has no call signatures.
 
    7 | 
    8 |   test("must be of a function type", () => {
    9 |     expect("sample").type.toBeCallableWith(false);
-     |            ~~~~~~~~
+     |                                            ~~~~~
   10 |   });
   11 | 
   12 |   test("must be an identifier or instantiation expression", () => {
 
-       at ./__typetests__/toBeCallableWith.tst.ts:9:12
+       at ./__typetests__/toBeCallableWith.tst.ts:9:44
 
-Error: An argument for 'source' must be an identifier or instantiation expression.
+Error: Expression cannot be called with the given argument.
+
+This expression is not callable.
+Type 'String' has no call signatures.
 
   11 | 
   12 |   test("must be an identifier or instantiation expression", () => {
   13 |     expect(() => "sample").type.toBeCallableWith(false);
-     |            ~~~~~~~~~~~~~~
+     |                                                  ~~~~~
   14 |   });
   15 | });
   16 | 
 
-       at ./__typetests__/toBeCallableWith.tst.ts:13:12
+       at ./__typetests__/toBeCallableWith.tst.ts:13:50
 


### PR DESCRIPTION
Relaxing validation of the target of `.toBeCallableWith()` matcher. It seems that current validation logic is too strict in the real world usage.