### PR TITLE
feat: add validation of the source node passed to `.toBeCallableWith()`

### DIFF
--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -77,8 +77,51 @@ export class ToBeCallableWith {
     matchWorker: MatchWorker,
     sourceNode: ArgumentNode,
     targetNodes: ts.NodeArray<ArgumentNode>,
-    _onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>, // not used here
+    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
   ): MatchResult | undefined {
+    let isValid: boolean | undefined;
+    let type: ts.Type | undefined;
+
+    if (this.#compiler.isArrowFunction(sourceNode)) {
+      isValid = false;
+    }
+
+    if (this.#compiler.isCallExpression(sourceNode)) {
+      const signature = matchWorker.typeChecker.getResolvedSignature(sourceNode);
+
+      if (signature != null) {
+        type = matchWorker.typeChecker.getTypeOfSymbol(signature.getReturnType().symbol);
+      } else {
+        isValid = false;
+      }
+    }
+
+    if (
+      this.#compiler.isIdentifier(sourceNode) ||
+      // instantiation expressions are allowed
+      this.#compiler.isExpressionWithTypeArguments(sourceNode)
+    ) {
+      type = matchWorker.getType(sourceNode);
+    }
+
+    if (type != null) {
+      isValid = type.getCallSignatures().length > 0;
+    }
+
+    if (!isValid) {
+      const text = this.#compiler.isTypeNode(sourceNode)
+        ? ExpectDiagnosticText.typeArgumentMustBe("Source", "an identifier of a callable type")
+        : ExpectDiagnosticText.argumentMustBe("source", "an identifier of a callable expression");
+
+      const origin = DiagnosticOrigin.fromNode(sourceNode);
+
+      // TODO when source is a class, suggest using the '.toBeConstructable()' matcher
+
+      onDiagnostics([Diagnostic.error(text, origin)]);
+
+      return;
+    }
+
     return {
       explain: () => this.#explain(matchWorker, sourceNode, targetNodes),
       isMatch: !matchWorker.assertion.abilityDiagnostics,

--- a/tests/__fixtures__/validation-toBeCallableWith/__typetests__/toBeCallableWith.tst.ts
+++ b/tests/__fixtures__/validation-toBeCallableWith/__typetests__/toBeCallableWith.tst.ts
@@ -1,15 +1,48 @@
 import { describe, expect, test } from "tstyche";
 
+class Person {
+  _name: string;
+
+  constructor(name: string) {
+    this._name = name;
+  }
+}
+
+function getPerson(name: string) {
+  return new Person(name);
+}
+
+function getPersonGetter() {
+  return getPerson;
+}
+
 describe("argument for 'source'", () => {
   test("must be provided", () => {
     expect().type.toBeCallableWith(false);
   });
 
-  test("must be of a function type", () => {
-    expect("sample").type.toBeCallableWith(false);
+  test("must be an identifier of a callable expression", () => {
+    expect("abc").type.toBeCallableWith();
+    expect(123).type.toBeCallableWith();
+    expect(false).type.toBeCallableWith();
+    expect(undefined).type.toBeCallableWith();
+    expect(null).type.toBeCallableWith();
+
+    expect(() => undefined).type.toBeCallableWith();
+    expect(() => {}).type.toBeCallableWith();
+    expect(() => () => false).type.toBeCallableWith();
+
+    expect(getPerson).type.toBeCallableWith("abc"); // allowed
+    expect(getPerson("abc")).type.toBeCallableWith("abc");
+
+    expect(getPersonGetter).type.toBeCallableWith(); // allowed
+    expect(getPersonGetter()).type.toBeCallableWith("abc"); // allowed
+
+    expect(Person).type.toBeCallableWith("abc");
   });
 
-  test("must be an identifier or instantiation expression", () => {
-    expect(() => "sample").type.toBeCallableWith(false);
+  test("is rejected type?", () => {
+    expect("abc" as any).type.toBeCallableWith();
+    expect("abc" as never).type.toBeCallableWith();
   });
 });

--- a/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
@@ -1,42 +1,162 @@
 Error: An argument for 'source' or type argument for 'Source' must be provided.
 
-  3 | describe("argument for 'source'", () => {
-  4 |   test("must be provided", () => {
-  5 |     expect().type.toBeCallableWith(false);
-    |     ~~~~~~
-  6 |   });
-  7 | 
-  8 |   test("must be of a function type", () => {
+  19 | describe("argument for 'source'", () => {
+  20 |   test("must be provided", () => {
+  21 |     expect().type.toBeCallableWith(false);
+     |     ~~~~~~
+  22 |   });
+  23 | 
+  24 |   test("must be an identifier of a callable expression", () => {
 
-      at ./__typetests__/toBeCallableWith.tst.ts:5:5
+       at ./__typetests__/toBeCallableWith.tst.ts:21:5
 
-Error: Expression cannot be called with the given argument.
+Error: An argument for 'source' must be an identifier of a callable expression.
 
-This expression is not callable.
-Type 'String' has no call signatures.
+  23 | 
+  24 |   test("must be an identifier of a callable expression", () => {
+  25 |     expect("abc").type.toBeCallableWith();
+     |            ~~~~~
+  26 |     expect(123).type.toBeCallableWith();
+  27 |     expect(false).type.toBeCallableWith();
+  28 |     expect(undefined).type.toBeCallableWith();
 
-   7 | 
-   8 |   test("must be of a function type", () => {
-   9 |     expect("sample").type.toBeCallableWith(false);
-     |                                            ~~~~~
-  10 |   });
-  11 | 
-  12 |   test("must be an identifier or instantiation expression", () => {
+       at ./__typetests__/toBeCallableWith.tst.ts:25:12
 
-       at ./__typetests__/toBeCallableWith.tst.ts:9:44
+Error: An argument for 'source' must be an identifier of a callable expression.
 
-Error: Expression cannot be called with the given argument.
+  24 |   test("must be an identifier of a callable expression", () => {
+  25 |     expect("abc").type.toBeCallableWith();
+  26 |     expect(123).type.toBeCallableWith();
+     |            ~~~
+  27 |     expect(false).type.toBeCallableWith();
+  28 |     expect(undefined).type.toBeCallableWith();
+  29 |     expect(null).type.toBeCallableWith();
 
-This expression is not callable.
-Type 'String' has no call signatures.
+       at ./__typetests__/toBeCallableWith.tst.ts:26:12
 
-  11 | 
-  12 |   test("must be an identifier or instantiation expression", () => {
-  13 |     expect(() => "sample").type.toBeCallableWith(false);
-     |                                                  ~~~~~
-  14 |   });
-  15 | });
-  16 | 
+Error: An argument for 'source' must be an identifier of a callable expression.
 
-       at ./__typetests__/toBeCallableWith.tst.ts:13:50
+  25 |     expect("abc").type.toBeCallableWith();
+  26 |     expect(123).type.toBeCallableWith();
+  27 |     expect(false).type.toBeCallableWith();
+     |            ~~~~~
+  28 |     expect(undefined).type.toBeCallableWith();
+  29 |     expect(null).type.toBeCallableWith();
+  30 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:27:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  26 |     expect(123).type.toBeCallableWith();
+  27 |     expect(false).type.toBeCallableWith();
+  28 |     expect(undefined).type.toBeCallableWith();
+     |            ~~~~~~~~~
+  29 |     expect(null).type.toBeCallableWith();
+  30 | 
+  31 |     expect(() => undefined).type.toBeCallableWith();
+
+       at ./__typetests__/toBeCallableWith.tst.ts:28:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  27 |     expect(false).type.toBeCallableWith();
+  28 |     expect(undefined).type.toBeCallableWith();
+  29 |     expect(null).type.toBeCallableWith();
+     |            ~~~~
+  30 | 
+  31 |     expect(() => undefined).type.toBeCallableWith();
+  32 |     expect(() => {}).type.toBeCallableWith();
+
+       at ./__typetests__/toBeCallableWith.tst.ts:29:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  29 |     expect(null).type.toBeCallableWith();
+  30 | 
+  31 |     expect(() => undefined).type.toBeCallableWith();
+     |            ~~~~~~~~~~~~~~~
+  32 |     expect(() => {}).type.toBeCallableWith();
+  33 |     expect(() => () => false).type.toBeCallableWith();
+  34 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:31:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  30 | 
+  31 |     expect(() => undefined).type.toBeCallableWith();
+  32 |     expect(() => {}).type.toBeCallableWith();
+     |            ~~~~~~~~
+  33 |     expect(() => () => false).type.toBeCallableWith();
+  34 | 
+  35 |     expect(getPerson).type.toBeCallableWith("abc"); // allowed
+
+       at ./__typetests__/toBeCallableWith.tst.ts:32:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  31 |     expect(() => undefined).type.toBeCallableWith();
+  32 |     expect(() => {}).type.toBeCallableWith();
+  33 |     expect(() => () => false).type.toBeCallableWith();
+     |            ~~~~~~~~~~~~~~~~~
+  34 | 
+  35 |     expect(getPerson).type.toBeCallableWith("abc"); // allowed
+  36 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
+
+       at ./__typetests__/toBeCallableWith.tst.ts:33:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  34 | 
+  35 |     expect(getPerson).type.toBeCallableWith("abc"); // allowed
+  36 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
+     |            ~~~~~~~~~~~~~~~~
+  37 | 
+  38 |     expect(getPersonGetter).type.toBeCallableWith(); // allowed
+  39 |     expect(getPersonGetter()).type.toBeCallableWith("abc"); // allowed
+
+       at ./__typetests__/toBeCallableWith.tst.ts:36:12
+
+Error: An argument for 'source' must be an identifier of a callable expression.
+
+  39 |     expect(getPersonGetter()).type.toBeCallableWith("abc"); // allowed
+  40 | 
+  41 |     expect(Person).type.toBeCallableWith("abc");
+     |            ~~~~~~
+  42 |   });
+  43 | 
+  44 |   test("is rejected type?", () => {
+
+       at ./__typetests__/toBeCallableWith.tst.ts:41:12
+
+Error: An argument for 'source' cannot be of the 'any' type.
+
+The 'any' type was rejected because the 'rejectAnyType' option is enabled.
+If this check is necessary, pass 'any' as the type argument explicitly.
+
+  43 | 
+  44 |   test("is rejected type?", () => {
+  45 |     expect("abc" as any).type.toBeCallableWith();
+     |            ~~~~~~~~~~~~
+  46 |     expect("abc" as never).type.toBeCallableWith();
+  47 |   });
+  48 | });
+
+       at ./__typetests__/toBeCallableWith.tst.ts:45:12
+
+Error: An argument for 'source' cannot be of the 'never' type.
+
+The 'never' type was rejected because the 'rejectNeverType' option is enabled.
+If this check is necessary, pass 'never' as the type argument explicitly.
+
+  44 |   test("is rejected type?", () => {
+  45 |     expect("abc" as any).type.toBeCallableWith();
+  46 |     expect("abc" as never).type.toBeCallableWith();
+     |            ~~~~~~~~~~~~~~
+  47 |   });
+  48 | });
+  49 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:46:12
 

--- a/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
@@ -3,13 +3,13 @@ uses TypeScript <<version>> with ./tsconfig.json
 fail ./__typetests__/toBeCallableWith.tst.ts
   argument for 'source'
     × must be provided
-    × must be of a function type
-    × must be an identifier or instantiation expression
+    × must be an identifier of a callable expression
+    × is rejected type?
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      3 failed, 3 total
-Assertions: 3 failed, 3 total
+Assertions: 13 failed, 3 passed, 16 total
 Duration:   <<timestamp>>
 
 Ran all test files.


### PR DESCRIPTION
Adding validation of the source node passed to the `.toBeCallableWith()` matcher.