### PR TITLE
feat: add the `.toBeTaggableWith()` matcher

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -134,6 +134,10 @@ interface Matchers {
    */
   toBeCallableWith: (...target: Array<unknown>) => void;
   /**
+   * Checks if the source type can be tagged with the target template string.
+   */
+  toBeTaggableWith: (target: string) => void;
+  /**
    * Checks if a property key exists on the source type.
    */
   toHaveProperty: (key: string | number | symbol) => void;


### PR DESCRIPTION
Instead of calling a function, the `.toBeTaggableWith()` matcher could check, if it can be tagged with the given template string.

Might be useful in some edge cases.

The idea was inspired by this test: https://github.com/KhraksMamtsov/effect/blob/main/packages/platform/dtslint/HttpApiEndpoint.ts