### PR TITLE
feat: add the `.toBeConstructableWith()` matcher

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -134,6 +134,10 @@ interface Matchers {
    */
   toBeCallableWith: (...target: Array<unknown>) => void;
   /**
+   * Checks if the source type can be constructed with the given arguments.
+   */
+  toBeConstructableWith: (...target: Array<unknown>) => void;
+  /**
    * Checks if a property key exists on the source type.
    */
   toHaveProperty: (key: string | number | symbol) => void;


### PR DESCRIPTION
Adding the `.toBeConstructableWith()` matcher that will check, if an expression can be constructed with the given arguments.

Implementation, tests and examples will follow.

---

TypeScript code base use term *constructable* and not *constructible*. Hence I prefer to call the matcher `.toBeConstructableWith()`. 