### PR TITLE
feat: allow using `.toBeCallableWith()` with more callable expressions

### DIFF
--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -84,34 +84,20 @@ export class AbilityLayer {
   }
 
   handleNode(assertionNode: AssertionNode): void {
+    const expectStart = assertionNode.node.pos;
+    const expectExpressionEnd = assertionNode.node.expression.end;
+    const expectEnd = assertionNode.node.end;
+    const matcherNameEnd = assertionNode.matcherNameNode.end;
+
     switch (assertionNode.matcherNameNode.name.text) {
-      case "toBeApplicable": {
-        const expectStart = assertionNode.node.pos;
-        const expectExpressionEnd = assertionNode.node.expression.end;
-        const expectEnd = assertionNode.node.end;
-        const matcherNameEnd = assertionNode.matcherNameNode.end;
-
+      case "toBeApplicable":
+      case "toBeCallableWith":
         this.#addRanges(assertionNode, [
-          { end: expectExpressionEnd + 1, start: expectStart },
-          { end: matcherNameEnd, start: expectEnd - 1 },
+          { end: expectExpressionEnd, start: expectStart },
+          { end: matcherNameEnd, start: expectEnd },
         ]);
 
         break;
-      }
-
-      case "toBeCallableWith": {
-        const expectStart = assertionNode.node.pos;
-        const expectExpressionEnd = assertionNode.node.expression.end;
-        const expectEnd = assertionNode.node.end;
-        const matcherNameEnd = assertionNode.matcherNameNode.end;
-
-        this.#addRanges(assertionNode, [
-          { end: expectExpressionEnd + 1, start: expectStart },
-          { end: matcherNameEnd, start: expectEnd - 1 },
-        ]);
-
-        break;
-      }
     }
   }
 

--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -106,7 +106,7 @@ export class ToBeCallableWith {
       }
 
       if (type != null && type.getConstructSignatures().length > 0) {
-        text.push("Did you mean to use the '.toBeConstructable()' matcher?");
+        text.push("Did you mean to use the '.toBeConstructableWith()' matcher?");
       }
 
       const origin = DiagnosticOrigin.fromNode(sourceNode);

--- a/tests/__fixtures__/validation-toBeCallableWith/__typetests__/toBeCallableWith.tst.ts
+++ b/tests/__fixtures__/validation-toBeCallableWith/__typetests__/toBeCallableWith.tst.ts
@@ -21,7 +21,7 @@ describe("argument for 'source'", () => {
     expect().type.toBeCallableWith(false);
   });
 
-  test("must be an identifier of a callable expression", () => {
+  test("must be a callable expression", () => {
     expect("abc").type.toBeCallableWith();
     expect(123).type.toBeCallableWith();
     expect(false).type.toBeCallableWith();
@@ -32,13 +32,33 @@ describe("argument for 'source'", () => {
     expect(() => {}).type.toBeCallableWith();
     expect(() => () => false).type.toBeCallableWith();
 
-    expect(getPerson).type.toBeCallableWith("abc"); // allowed
     expect(getPerson("abc")).type.toBeCallableWith("abc");
 
-    expect(getPersonGetter).type.toBeCallableWith(); // allowed
-    expect(getPersonGetter()).type.toBeCallableWith("abc"); // allowed
-
     expect(Person).type.toBeCallableWith("abc");
+  });
+
+  test("allowed expressions", () => {
+    expect(getPerson).type.toBeCallableWith("abc");
+
+    expect(getPersonGetter).type.toBeCallableWith();
+    expect(getPersonGetter()).type.toBeCallableWith("abc");
+
+    expect((a?: string) => a).type.toBeCallableWith("true");
+    expect((a?: string) => a).type.toBeCallableWith();
+
+    expect(function (a?: string) {
+      return a;
+    }).type.toBeCallableWith("true");
+    expect(function (a?: string) {
+      return a;
+    }).type.toBeCallableWith();
+
+    expect(function quick(a?: string) {
+      return a;
+    }).type.toBeCallableWith("true");
+    expect(function quick(a?: string) {
+      return a;
+    }).type.toBeCallableWith();
   });
 
   test("is rejected type?", () => {

--- a/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
@@ -6,14 +6,14 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
      |     ~~~~~~
   22 |   });
   23 | 
-  24 |   test("must be an identifier of a callable expression", () => {
+  24 |   test("must be a callable expression", () => {
 
        at ./__typetests__/toBeCallableWith.tst.ts:21:5
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
   23 | 
-  24 |   test("must be an identifier of a callable expression", () => {
+  24 |   test("must be a callable expression", () => {
   25 |     expect("abc").type.toBeCallableWith();
      |            ~~~~~
   26 |     expect(123).type.toBeCallableWith();
@@ -22,9 +22,9 @@ Error: An argument for 'source' must be an identifier of a callable expression.
 
        at ./__typetests__/toBeCallableWith.tst.ts:25:12
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
-  24 |   test("must be an identifier of a callable expression", () => {
+  24 |   test("must be a callable expression", () => {
   25 |     expect("abc").type.toBeCallableWith();
   26 |     expect(123).type.toBeCallableWith();
      |            ~~~
@@ -34,7 +34,7 @@ Error: An argument for 'source' must be an identifier of a callable expression.
 
        at ./__typetests__/toBeCallableWith.tst.ts:26:12
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
   25 |     expect("abc").type.toBeCallableWith();
   26 |     expect(123).type.toBeCallableWith();
@@ -46,7 +46,7 @@ Error: An argument for 'source' must be an identifier of a callable expression.
 
        at ./__typetests__/toBeCallableWith.tst.ts:27:12
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
   26 |     expect(123).type.toBeCallableWith();
   27 |     expect(false).type.toBeCallableWith();
@@ -58,7 +58,7 @@ Error: An argument for 'source' must be an identifier of a callable expression.
 
        at ./__typetests__/toBeCallableWith.tst.ts:28:12
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
   27 |     expect(false).type.toBeCallableWith();
   28 |     expect(undefined).type.toBeCallableWith();
@@ -70,93 +70,59 @@ Error: An argument for 'source' must be an identifier of a callable expression.
 
        at ./__typetests__/toBeCallableWith.tst.ts:29:12
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
-  29 |     expect(null).type.toBeCallableWith();
-  30 | 
-  31 |     expect(() => undefined).type.toBeCallableWith();
-     |            ~~~~~~~~~~~~~~~
-  32 |     expect(() => {}).type.toBeCallableWith();
   33 |     expect(() => () => false).type.toBeCallableWith();
   34 | 
-
-       at ./__typetests__/toBeCallableWith.tst.ts:31:12
-
-Error: An argument for 'source' must be an identifier of a callable expression.
-
-  30 | 
-  31 |     expect(() => undefined).type.toBeCallableWith();
-  32 |     expect(() => {}).type.toBeCallableWith();
-     |            ~~~~~~~~
-  33 |     expect(() => () => false).type.toBeCallableWith();
-  34 | 
-  35 |     expect(getPerson).type.toBeCallableWith("abc"); // allowed
-
-       at ./__typetests__/toBeCallableWith.tst.ts:32:12
-
-Error: An argument for 'source' must be an identifier of a callable expression.
-
-  31 |     expect(() => undefined).type.toBeCallableWith();
-  32 |     expect(() => {}).type.toBeCallableWith();
-  33 |     expect(() => () => false).type.toBeCallableWith();
-     |            ~~~~~~~~~~~~~~~~~
-  34 | 
-  35 |     expect(getPerson).type.toBeCallableWith("abc"); // allowed
-  36 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
-
-       at ./__typetests__/toBeCallableWith.tst.ts:33:12
-
-Error: An argument for 'source' must be an identifier of a callable expression.
-
-  34 | 
-  35 |     expect(getPerson).type.toBeCallableWith("abc"); // allowed
-  36 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
+  35 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
      |            ~~~~~~~~~~~~~~~~
-  37 | 
-  38 |     expect(getPersonGetter).type.toBeCallableWith(); // allowed
-  39 |     expect(getPersonGetter()).type.toBeCallableWith("abc"); // allowed
+  36 | 
+  37 |     expect(Person).type.toBeCallableWith("abc");
+  38 |   });
 
-       at ./__typetests__/toBeCallableWith.tst.ts:36:12
+       at ./__typetests__/toBeCallableWith.tst.ts:35:12
 
-Error: An argument for 'source' must be an identifier of a callable expression.
+Error: An argument for 'source' must be a callable expression.
 
-  39 |     expect(getPersonGetter()).type.toBeCallableWith("abc"); // allowed
-  40 | 
-  41 |     expect(Person).type.toBeCallableWith("abc");
+Did you mean to use the '.toBeConstructable()' matcher?
+
+  35 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
+  36 | 
+  37 |     expect(Person).type.toBeCallableWith("abc");
      |            ~~~~~~
-  42 |   });
-  43 | 
-  44 |   test("is rejected type?", () => {
+  38 |   });
+  39 | 
+  40 |   test("allowed expressions", () => {
 
-       at ./__typetests__/toBeCallableWith.tst.ts:41:12
+       at ./__typetests__/toBeCallableWith.tst.ts:37:12
 
 Error: An argument for 'source' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
-  43 | 
-  44 |   test("is rejected type?", () => {
-  45 |     expect("abc" as any).type.toBeCallableWith();
+  63 | 
+  64 |   test("is rejected type?", () => {
+  65 |     expect("abc" as any).type.toBeCallableWith();
      |            ~~~~~~~~~~~~
-  46 |     expect("abc" as never).type.toBeCallableWith();
-  47 |   });
-  48 | });
+  66 |     expect("abc" as never).type.toBeCallableWith();
+  67 |   });
+  68 | });
 
-       at ./__typetests__/toBeCallableWith.tst.ts:45:12
+       at ./__typetests__/toBeCallableWith.tst.ts:65:12
 
 Error: An argument for 'source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, pass 'never' as the type argument explicitly.
 
-  44 |   test("is rejected type?", () => {
-  45 |     expect("abc" as any).type.toBeCallableWith();
-  46 |     expect("abc" as never).type.toBeCallableWith();
+  64 |   test("is rejected type?", () => {
+  65 |     expect("abc" as any).type.toBeCallableWith();
+  66 |     expect("abc" as never).type.toBeCallableWith();
      |            ~~~~~~~~~~~~~~
-  47 |   });
-  48 | });
-  49 | 
+  67 |   });
+  68 | });
+  69 | 
 
-       at ./__typetests__/toBeCallableWith.tst.ts:46:12
+       at ./__typetests__/toBeCallableWith.tst.ts:66:12
 

--- a/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
@@ -84,7 +84,7 @@ Error: An argument for 'source' must be a callable expression.
 
 Error: An argument for 'source' must be a callable expression.
 
-Did you mean to use the '.toBeConstructable()' matcher?
+Did you mean to use the '.toBeConstructableWith()' matcher?
 
   35 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
   36 | 

--- a/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
@@ -3,13 +3,14 @@ uses TypeScript <<version>> with ./tsconfig.json
 fail ./__typetests__/toBeCallableWith.tst.ts
   argument for 'source'
     × must be provided
-    × must be an identifier of a callable expression
+    × must be a callable expression
+    + allowed expressions
     × is rejected type?
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      3 failed, 3 total
-Assertions: 13 failed, 3 passed, 16 total
+Tests:      3 failed, 1 passed, 4 total
+Assertions: 10 failed, 12 passed, 22 total
 Duration:   <<timestamp>>
 
 Ran all test files.


### PR DESCRIPTION
This change allows using `.toBeCallableWith()` with: arrow functions, function declarations and function expressions.