### PR TITLE
fix: insert missing semicolons in the ability layer text

### DIFF
--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -95,7 +95,6 @@ export class AbilityLayer {
 
     switch (assertionNode.matcherNameNode.name.text) {
       case "toBeApplicable":
-      case "toBeCallableWith":
         this.#addRanges(assertionNode, [
           { end: expectExpressionEnd, start: expectStart },
           { end: matcherNameEnd, start: expectEnd },
@@ -103,9 +102,17 @@ export class AbilityLayer {
 
         break;
 
+      case "toBeCallableWith":
+        this.#addRanges(assertionNode, [
+          { end: expectExpressionEnd, start: expectStart, replacement: ";" },
+          { end: matcherNameEnd, start: expectEnd },
+        ]);
+
+        break;
+
       case "toBeConstructableWith":
         this.#addRanges(assertionNode, [
-          { end: expectExpressionEnd, start: expectStart, replacement: "new" },
+          { end: expectExpressionEnd, start: expectStart, replacement: "; new" },
           { end: matcherNameEnd, start: expectEnd },
         ]);
 

--- a/tests/__snapshots__/api-toBeCallableWith-stdout-missing-semicolons.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-stdout-missing-semicolons.snap.txt
@@ -1,0 +1,12 @@
+uses TypeScript <<version>>
+
+pass ./__typetests__/toBeCallableWith.tst.ts
+  + pickLonger()
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 5 passed, 5 total
+Duration:   <<timestamp>>
+
+Ran all test files.

--- a/tests/__snapshots__/api-toBeConstructableWith-stdout-missing-semicolons.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-stdout-missing-semicolons.snap.txt
@@ -1,0 +1,12 @@
+uses TypeScript <<version>>
+
+pass ./__typetests__/toBeConstructableWith.tst.ts
+  + Pair
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 6 passed, 6 total
+Duration:   <<timestamp>>
+
+Ran all test files.


### PR DESCRIPTION
The ability layer must handle missing semicolons by inserting them.