### PR TITLE
fix: allow passing property access expressions to the callability matchers

### DIFF
--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -86,9 +86,10 @@ export class ToBeCallableWith {
       this.#compiler.isArrowFunction(sourceNode) ||
       this.#compiler.isFunctionDeclaration(sourceNode) ||
       this.#compiler.isFunctionExpression(sourceNode) ||
-      // instantiation expressions are allowed
+      // allows instantiation expressions
       this.#compiler.isExpressionWithTypeArguments(sourceNode) ||
-      this.#compiler.isIdentifier(sourceNode)
+      this.#compiler.isIdentifier(sourceNode) ||
+      this.#compiler.isPropertyAccessExpression(sourceNode)
     ) {
       type = matchWorker.getType(sourceNode);
     }

--- a/source/expect/ToBeConstructableWith.ts
+++ b/source/expect/ToBeConstructableWith.ts
@@ -86,9 +86,10 @@ export class ToBeConstructableWith {
     }
 
     if (
-      // instantiation expressions are allowed
+      // allows instantiation expressions
       this.#compiler.isExpressionWithTypeArguments(sourceNode) ||
-      this.#compiler.isIdentifier(sourceNode)
+      this.#compiler.isIdentifier(sourceNode) ||
+      this.#compiler.isPropertyAccessExpression(sourceNode)
     ) {
       type = matchWorker.getType(sourceNode);
     }

--- a/tests/__fixtures__/validation-toBeCallableWith/__typetests__/toBeCallableWith.tst.ts
+++ b/tests/__fixtures__/validation-toBeCallableWith/__typetests__/toBeCallableWith.tst.ts
@@ -16,6 +16,10 @@ function getPersonGetter() {
   return getPerson;
 }
 
+const obj = {
+  person: () => new Person("sample"),
+};
+
 describe("argument for 'source'", () => {
   test("must be provided", () => {
     expect().type.toBeCallableWith(false);
@@ -42,6 +46,8 @@ describe("argument for 'source'", () => {
 
     expect(getPersonGetter).type.toBeCallableWith();
     expect(getPersonGetter()).type.toBeCallableWith("abc");
+
+    expect(obj.person).type.toBeCallableWith();
 
     expect((a?: string) => a).type.toBeCallableWith("true");
     expect((a?: string) => a).type.toBeCallableWith();

--- a/tests/__fixtures__/validation-toBeConstructableWith/__typetests__/toBeConstructableWith.tst.ts
+++ b/tests/__fixtures__/validation-toBeConstructableWith/__typetests__/toBeConstructableWith.tst.ts
@@ -20,6 +20,10 @@ function getPersonGetter() {
   return getPerson;
 }
 
+const obj = {
+  Person,
+};
+
 describe("argument for 'source'", () => {
   test("must be provided", () => {
     expect().type.toBeConstructableWith(false);
@@ -47,6 +51,7 @@ describe("argument for 'source'", () => {
   test("allowed expressions", () => {
     expect(getPersonConstructor()).type.toBeConstructableWith("abc");
     expect(Person).type.toBeConstructableWith("abc");
+    expect(obj.Person).type.toBeConstructableWith("abc");
   });
 
   test("is rejected type?", () => {

--- a/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stderr.snap.txt
@@ -1,128 +1,128 @@
 Error: An argument for 'source' or type argument for 'Source' must be provided.
 
-  19 | describe("argument for 'source'", () => {
-  20 |   test("must be provided", () => {
-  21 |     expect().type.toBeCallableWith(false);
+  23 | describe("argument for 'source'", () => {
+  24 |   test("must be provided", () => {
+  25 |     expect().type.toBeCallableWith(false);
      |     ~~~~~~
-  22 |   });
-  23 | 
-  24 |   test("must be a callable expression", () => {
+  26 |   });
+  27 | 
+  28 |   test("must be a callable expression", () => {
 
-       at ./__typetests__/toBeCallableWith.tst.ts:21:5
+       at ./__typetests__/toBeCallableWith.tst.ts:25:5
 
 Error: An argument for 'source' must be a callable expression.
 
-  23 | 
-  24 |   test("must be a callable expression", () => {
-  25 |     expect("abc").type.toBeCallableWith();
+  27 | 
+  28 |   test("must be a callable expression", () => {
+  29 |     expect("abc").type.toBeCallableWith();
      |            ~~~~~
-  26 |     expect(123).type.toBeCallableWith();
-  27 |     expect(false).type.toBeCallableWith();
-  28 |     expect(undefined).type.toBeCallableWith();
-
-       at ./__typetests__/toBeCallableWith.tst.ts:25:12
-
-Error: An argument for 'source' must be a callable expression.
-
-  24 |   test("must be a callable expression", () => {
-  25 |     expect("abc").type.toBeCallableWith();
-  26 |     expect(123).type.toBeCallableWith();
-     |            ~~~
-  27 |     expect(false).type.toBeCallableWith();
-  28 |     expect(undefined).type.toBeCallableWith();
-  29 |     expect(null).type.toBeCallableWith();
-
-       at ./__typetests__/toBeCallableWith.tst.ts:26:12
-
-Error: An argument for 'source' must be a callable expression.
-
-  25 |     expect("abc").type.toBeCallableWith();
-  26 |     expect(123).type.toBeCallableWith();
-  27 |     expect(false).type.toBeCallableWith();
-     |            ~~~~~
-  28 |     expect(undefined).type.toBeCallableWith();
-  29 |     expect(null).type.toBeCallableWith();
-  30 | 
-
-       at ./__typetests__/toBeCallableWith.tst.ts:27:12
-
-Error: An argument for 'source' must be a callable expression.
-
-  26 |     expect(123).type.toBeCallableWith();
-  27 |     expect(false).type.toBeCallableWith();
-  28 |     expect(undefined).type.toBeCallableWith();
-     |            ~~~~~~~~~
-  29 |     expect(null).type.toBeCallableWith();
-  30 | 
-  31 |     expect(() => undefined).type.toBeCallableWith();
-
-       at ./__typetests__/toBeCallableWith.tst.ts:28:12
-
-Error: An argument for 'source' must be a callable expression.
-
-  27 |     expect(false).type.toBeCallableWith();
-  28 |     expect(undefined).type.toBeCallableWith();
-  29 |     expect(null).type.toBeCallableWith();
-     |            ~~~~
-  30 | 
-  31 |     expect(() => undefined).type.toBeCallableWith();
-  32 |     expect(() => {}).type.toBeCallableWith();
+  30 |     expect(123).type.toBeCallableWith();
+  31 |     expect(false).type.toBeCallableWith();
+  32 |     expect(undefined).type.toBeCallableWith();
 
        at ./__typetests__/toBeCallableWith.tst.ts:29:12
 
 Error: An argument for 'source' must be a callable expression.
 
-  33 |     expect(() => () => false).type.toBeCallableWith();
-  34 | 
-  35 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
-     |            ~~~~~~~~~~~~~~~~
-  36 | 
-  37 |     expect(Person).type.toBeCallableWith("abc");
-  38 |   });
+  28 |   test("must be a callable expression", () => {
+  29 |     expect("abc").type.toBeCallableWith();
+  30 |     expect(123).type.toBeCallableWith();
+     |            ~~~
+  31 |     expect(false).type.toBeCallableWith();
+  32 |     expect(undefined).type.toBeCallableWith();
+  33 |     expect(null).type.toBeCallableWith();
 
-       at ./__typetests__/toBeCallableWith.tst.ts:35:12
+       at ./__typetests__/toBeCallableWith.tst.ts:30:12
+
+Error: An argument for 'source' must be a callable expression.
+
+  29 |     expect("abc").type.toBeCallableWith();
+  30 |     expect(123).type.toBeCallableWith();
+  31 |     expect(false).type.toBeCallableWith();
+     |            ~~~~~
+  32 |     expect(undefined).type.toBeCallableWith();
+  33 |     expect(null).type.toBeCallableWith();
+  34 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:31:12
+
+Error: An argument for 'source' must be a callable expression.
+
+  30 |     expect(123).type.toBeCallableWith();
+  31 |     expect(false).type.toBeCallableWith();
+  32 |     expect(undefined).type.toBeCallableWith();
+     |            ~~~~~~~~~
+  33 |     expect(null).type.toBeCallableWith();
+  34 | 
+  35 |     expect(() => undefined).type.toBeCallableWith();
+
+       at ./__typetests__/toBeCallableWith.tst.ts:32:12
+
+Error: An argument for 'source' must be a callable expression.
+
+  31 |     expect(false).type.toBeCallableWith();
+  32 |     expect(undefined).type.toBeCallableWith();
+  33 |     expect(null).type.toBeCallableWith();
+     |            ~~~~
+  34 | 
+  35 |     expect(() => undefined).type.toBeCallableWith();
+  36 |     expect(() => {}).type.toBeCallableWith();
+
+       at ./__typetests__/toBeCallableWith.tst.ts:33:12
+
+Error: An argument for 'source' must be a callable expression.
+
+  37 |     expect(() => () => false).type.toBeCallableWith();
+  38 | 
+  39 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
+     |            ~~~~~~~~~~~~~~~~
+  40 | 
+  41 |     expect(Person).type.toBeCallableWith("abc");
+  42 |   });
+
+       at ./__typetests__/toBeCallableWith.tst.ts:39:12
 
 Error: An argument for 'source' must be a callable expression.
 
 Did you mean to use the '.toBeConstructableWith()' matcher?
 
-  35 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
-  36 | 
-  37 |     expect(Person).type.toBeCallableWith("abc");
+  39 |     expect(getPerson("abc")).type.toBeCallableWith("abc");
+  40 | 
+  41 |     expect(Person).type.toBeCallableWith("abc");
      |            ~~~~~~
-  38 |   });
-  39 | 
-  40 |   test("allowed expressions", () => {
+  42 |   });
+  43 | 
+  44 |   test("allowed expressions", () => {
 
-       at ./__typetests__/toBeCallableWith.tst.ts:37:12
+       at ./__typetests__/toBeCallableWith.tst.ts:41:12
 
 Error: An argument for 'source' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
-  63 | 
-  64 |   test("is rejected type?", () => {
-  65 |     expect("abc" as any).type.toBeCallableWith();
+  69 | 
+  70 |   test("is rejected type?", () => {
+  71 |     expect("abc" as any).type.toBeCallableWith();
      |            ~~~~~~~~~~~~
-  66 |     expect("abc" as never).type.toBeCallableWith();
-  67 |   });
-  68 | });
+  72 |     expect("abc" as never).type.toBeCallableWith();
+  73 |   });
+  74 | });
 
-       at ./__typetests__/toBeCallableWith.tst.ts:65:12
+       at ./__typetests__/toBeCallableWith.tst.ts:71:12
 
 Error: An argument for 'source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, pass 'never' as the type argument explicitly.
 
-  64 |   test("is rejected type?", () => {
-  65 |     expect("abc" as any).type.toBeCallableWith();
-  66 |     expect("abc" as never).type.toBeCallableWith();
+  70 |   test("is rejected type?", () => {
+  71 |     expect("abc" as any).type.toBeCallableWith();
+  72 |     expect("abc" as never).type.toBeCallableWith();
      |            ~~~~~~~~~~~~~~
-  67 |   });
-  68 | });
-  69 | 
+  73 |   });
+  74 | });
+  75 | 
 
-       at ./__typetests__/toBeCallableWith.tst.ts:66:12
+       at ./__typetests__/toBeCallableWith.tst.ts:72:12
 

--- a/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
@@ -10,7 +10,7 @@ fail ./__typetests__/toBeCallableWith.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      3 failed, 1 passed, 4 total
-Assertions: 10 failed, 12 passed, 22 total
+Assertions: 10 failed, 13 passed, 23 total
 Duration:   <<timestamp>>
 
 Ran all test files.

--- a/tests/__snapshots__/validation-toBeConstructableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeConstructableWith-stderr.snap.txt
@@ -1,206 +1,206 @@
 Error: An argument for 'source' or type argument for 'Source' must be provided.
 
-  23 | describe("argument for 'source'", () => {
-  24 |   test("must be provided", () => {
-  25 |     expect().type.toBeConstructableWith(false);
+  27 | describe("argument for 'source'", () => {
+  28 |   test("must be provided", () => {
+  29 |     expect().type.toBeConstructableWith(false);
      |     ~~~~~~
-  26 |   });
-  27 | 
-  28 |   test("must be a constructable expression", () => {
+  30 |   });
+  31 | 
+  32 |   test("must be a constructable expression", () => {
 
-       at ./__typetests__/toBeConstructableWith.tst.ts:25:5
+       at ./__typetests__/toBeConstructableWith.tst.ts:29:5
 
 Error: An argument for 'source' must be a constructable expression.
 
-  27 | 
-  28 |   test("must be a constructable expression", () => {
-  29 |     expect("abc").type.toBeConstructableWith();
+  31 | 
+  32 |   test("must be a constructable expression", () => {
+  33 |     expect("abc").type.toBeConstructableWith();
      |            ~~~~~
-  30 |     expect(123).type.toBeConstructableWith();
-  31 |     expect(false).type.toBeConstructableWith();
-  32 |     expect(undefined).type.toBeConstructableWith();
-
-       at ./__typetests__/toBeConstructableWith.tst.ts:29:12
-
-Error: An argument for 'source' must be a constructable expression.
-
-  28 |   test("must be a constructable expression", () => {
-  29 |     expect("abc").type.toBeConstructableWith();
-  30 |     expect(123).type.toBeConstructableWith();
-     |            ~~~
-  31 |     expect(false).type.toBeConstructableWith();
-  32 |     expect(undefined).type.toBeConstructableWith();
-  33 |     expect(null).type.toBeConstructableWith();
-
-       at ./__typetests__/toBeConstructableWith.tst.ts:30:12
-
-Error: An argument for 'source' must be a constructable expression.
-
-  29 |     expect("abc").type.toBeConstructableWith();
-  30 |     expect(123).type.toBeConstructableWith();
-  31 |     expect(false).type.toBeConstructableWith();
-     |            ~~~~~
-  32 |     expect(undefined).type.toBeConstructableWith();
-  33 |     expect(null).type.toBeConstructableWith();
-  34 | 
-
-       at ./__typetests__/toBeConstructableWith.tst.ts:31:12
-
-Error: An argument for 'source' must be a constructable expression.
-
-  30 |     expect(123).type.toBeConstructableWith();
-  31 |     expect(false).type.toBeConstructableWith();
-  32 |     expect(undefined).type.toBeConstructableWith();
-     |            ~~~~~~~~~
-  33 |     expect(null).type.toBeConstructableWith();
-  34 | 
-  35 |     expect(() => undefined).type.toBeConstructableWith();
-
-       at ./__typetests__/toBeConstructableWith.tst.ts:32:12
-
-Error: An argument for 'source' must be a constructable expression.
-
-  31 |     expect(false).type.toBeConstructableWith();
-  32 |     expect(undefined).type.toBeConstructableWith();
-  33 |     expect(null).type.toBeConstructableWith();
-     |            ~~~~
-  34 | 
-  35 |     expect(() => undefined).type.toBeConstructableWith();
-  36 |     expect(() => {}).type.toBeConstructableWith();
+  34 |     expect(123).type.toBeConstructableWith();
+  35 |     expect(false).type.toBeConstructableWith();
+  36 |     expect(undefined).type.toBeConstructableWith();
 
        at ./__typetests__/toBeConstructableWith.tst.ts:33:12
 
 Error: An argument for 'source' must be a constructable expression.
 
-  33 |     expect(null).type.toBeConstructableWith();
-  34 | 
-  35 |     expect(() => undefined).type.toBeConstructableWith();
-     |            ~~~~~~~~~~~~~~~
-  36 |     expect(() => {}).type.toBeConstructableWith();
-  37 |     expect(() => () => false).type.toBeConstructableWith();
+  32 |   test("must be a constructable expression", () => {
+  33 |     expect("abc").type.toBeConstructableWith();
+  34 |     expect(123).type.toBeConstructableWith();
+     |            ~~~
+  35 |     expect(false).type.toBeConstructableWith();
+  36 |     expect(undefined).type.toBeConstructableWith();
+  37 |     expect(null).type.toBeConstructableWith();
+
+       at ./__typetests__/toBeConstructableWith.tst.ts:34:12
+
+Error: An argument for 'source' must be a constructable expression.
+
+  33 |     expect("abc").type.toBeConstructableWith();
+  34 |     expect(123).type.toBeConstructableWith();
+  35 |     expect(false).type.toBeConstructableWith();
+     |            ~~~~~
+  36 |     expect(undefined).type.toBeConstructableWith();
+  37 |     expect(null).type.toBeConstructableWith();
   38 | 
 
        at ./__typetests__/toBeConstructableWith.tst.ts:35:12
 
 Error: An argument for 'source' must be a constructable expression.
 
-  34 | 
-  35 |     expect(() => undefined).type.toBeConstructableWith();
-  36 |     expect(() => {}).type.toBeConstructableWith();
-     |            ~~~~~~~~
-  37 |     expect(() => () => false).type.toBeConstructableWith();
+  34 |     expect(123).type.toBeConstructableWith();
+  35 |     expect(false).type.toBeConstructableWith();
+  36 |     expect(undefined).type.toBeConstructableWith();
+     |            ~~~~~~~~~
+  37 |     expect(null).type.toBeConstructableWith();
   38 | 
-  39 |     expect(getPerson).type.toBeConstructableWith("abc");
+  39 |     expect(() => undefined).type.toBeConstructableWith();
 
        at ./__typetests__/toBeConstructableWith.tst.ts:36:12
 
 Error: An argument for 'source' must be a constructable expression.
 
-  35 |     expect(() => undefined).type.toBeConstructableWith();
-  36 |     expect(() => {}).type.toBeConstructableWith();
-  37 |     expect(() => () => false).type.toBeConstructableWith();
-     |            ~~~~~~~~~~~~~~~~~
+  35 |     expect(false).type.toBeConstructableWith();
+  36 |     expect(undefined).type.toBeConstructableWith();
+  37 |     expect(null).type.toBeConstructableWith();
+     |            ~~~~
   38 | 
-  39 |     expect(getPerson).type.toBeConstructableWith("abc");
-  40 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
+  39 |     expect(() => undefined).type.toBeConstructableWith();
+  40 |     expect(() => {}).type.toBeConstructableWith();
 
        at ./__typetests__/toBeConstructableWith.tst.ts:37:12
 
 Error: An argument for 'source' must be a constructable expression.
 
-Did you mean to use the '.toBeCallableWith()' matcher?
-
-  37 |     expect(() => () => false).type.toBeConstructableWith();
+  37 |     expect(null).type.toBeConstructableWith();
   38 | 
-  39 |     expect(getPerson).type.toBeConstructableWith("abc");
-     |            ~~~~~~~~~
-  40 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
-  41 | 
-  42 |     expect(getPersonGetter).type.toBeConstructableWith();
+  39 |     expect(() => undefined).type.toBeConstructableWith();
+     |            ~~~~~~~~~~~~~~~
+  40 |     expect(() => {}).type.toBeConstructableWith();
+  41 |     expect(() => () => false).type.toBeConstructableWith();
+  42 | 
 
        at ./__typetests__/toBeConstructableWith.tst.ts:39:12
 
 Error: An argument for 'source' must be a constructable expression.
 
   38 | 
-  39 |     expect(getPerson).type.toBeConstructableWith("abc");
-  40 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
-     |            ~~~~~~~~~~~~~~~~
-  41 | 
-  42 |     expect(getPersonGetter).type.toBeConstructableWith();
-  43 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
+  39 |     expect(() => undefined).type.toBeConstructableWith();
+  40 |     expect(() => {}).type.toBeConstructableWith();
+     |            ~~~~~~~~
+  41 |     expect(() => () => false).type.toBeConstructableWith();
+  42 | 
+  43 |     expect(getPerson).type.toBeConstructableWith("abc");
 
        at ./__typetests__/toBeConstructableWith.tst.ts:40:12
 
 Error: An argument for 'source' must be a constructable expression.
 
-Did you mean to use the '.toBeCallableWith()' matcher?
+  39 |     expect(() => undefined).type.toBeConstructableWith();
+  40 |     expect(() => {}).type.toBeConstructableWith();
+  41 |     expect(() => () => false).type.toBeConstructableWith();
+     |            ~~~~~~~~~~~~~~~~~
+  42 | 
+  43 |     expect(getPerson).type.toBeConstructableWith("abc");
+  44 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
 
-  40 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
-  41 | 
-  42 |     expect(getPersonGetter).type.toBeConstructableWith();
-     |            ~~~~~~~~~~~~~~~
-  43 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
-  44 |     expect(getPersonConstructor).type.toBeConstructableWith("abc");
-  45 |   });
-
-       at ./__typetests__/toBeConstructableWith.tst.ts:42:12
+       at ./__typetests__/toBeConstructableWith.tst.ts:41:12
 
 Error: An argument for 'source' must be a constructable expression.
 
 Did you mean to use the '.toBeCallableWith()' matcher?
 
-  41 | 
-  42 |     expect(getPersonGetter).type.toBeConstructableWith();
-  43 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
-     |            ~~~~~~~~~~~~~~~~~
-  44 |     expect(getPersonConstructor).type.toBeConstructableWith("abc");
-  45 |   });
-  46 | 
+  41 |     expect(() => () => false).type.toBeConstructableWith();
+  42 | 
+  43 |     expect(getPerson).type.toBeConstructableWith("abc");
+     |            ~~~~~~~~~
+  44 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
+  45 | 
+  46 |     expect(getPersonGetter).type.toBeConstructableWith();
 
        at ./__typetests__/toBeConstructableWith.tst.ts:43:12
 
 Error: An argument for 'source' must be a constructable expression.
 
-Did you mean to use the '.toBeCallableWith()' matcher?
-
-  42 |     expect(getPersonGetter).type.toBeConstructableWith();
-  43 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
-  44 |     expect(getPersonConstructor).type.toBeConstructableWith("abc");
-     |            ~~~~~~~~~~~~~~~~~~~~
-  45 |   });
-  46 | 
-  47 |   test("allowed expressions", () => {
+  42 | 
+  43 |     expect(getPerson).type.toBeConstructableWith("abc");
+  44 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
+     |            ~~~~~~~~~~~~~~~~
+  45 | 
+  46 |     expect(getPersonGetter).type.toBeConstructableWith();
+  47 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
 
        at ./__typetests__/toBeConstructableWith.tst.ts:44:12
+
+Error: An argument for 'source' must be a constructable expression.
+
+Did you mean to use the '.toBeCallableWith()' matcher?
+
+  44 |     expect(getPerson("abc")).type.toBeConstructableWith("abc");
+  45 | 
+  46 |     expect(getPersonGetter).type.toBeConstructableWith();
+     |            ~~~~~~~~~~~~~~~
+  47 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
+  48 |     expect(getPersonConstructor).type.toBeConstructableWith("abc");
+  49 |   });
+
+       at ./__typetests__/toBeConstructableWith.tst.ts:46:12
+
+Error: An argument for 'source' must be a constructable expression.
+
+Did you mean to use the '.toBeCallableWith()' matcher?
+
+  45 | 
+  46 |     expect(getPersonGetter).type.toBeConstructableWith();
+  47 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
+     |            ~~~~~~~~~~~~~~~~~
+  48 |     expect(getPersonConstructor).type.toBeConstructableWith("abc");
+  49 |   });
+  50 | 
+
+       at ./__typetests__/toBeConstructableWith.tst.ts:47:12
+
+Error: An argument for 'source' must be a constructable expression.
+
+Did you mean to use the '.toBeCallableWith()' matcher?
+
+  46 |     expect(getPersonGetter).type.toBeConstructableWith();
+  47 |     expect(getPersonGetter()).type.toBeConstructableWith("abc");
+  48 |     expect(getPersonConstructor).type.toBeConstructableWith("abc");
+     |            ~~~~~~~~~~~~~~~~~~~~
+  49 |   });
+  50 | 
+  51 |   test("allowed expressions", () => {
+
+       at ./__typetests__/toBeConstructableWith.tst.ts:48:12
 
 Error: An argument for 'source' cannot be of the 'any' type.
 
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
-  51 | 
-  52 |   test("is rejected type?", () => {
-  53 |     expect("abc" as any).type.toBeConstructableWith();
+  56 | 
+  57 |   test("is rejected type?", () => {
+  58 |     expect("abc" as any).type.toBeConstructableWith();
      |            ~~~~~~~~~~~~
-  54 |     expect("abc" as never).type.toBeConstructableWith();
-  55 |   });
-  56 | });
+  59 |     expect("abc" as never).type.toBeConstructableWith();
+  60 |   });
+  61 | });
 
-       at ./__typetests__/toBeConstructableWith.tst.ts:53:12
+       at ./__typetests__/toBeConstructableWith.tst.ts:58:12
 
 Error: An argument for 'source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, pass 'never' as the type argument explicitly.
 
-  52 |   test("is rejected type?", () => {
-  53 |     expect("abc" as any).type.toBeConstructableWith();
-  54 |     expect("abc" as never).type.toBeConstructableWith();
+  57 |   test("is rejected type?", () => {
+  58 |     expect("abc" as any).type.toBeConstructableWith();
+  59 |     expect("abc" as never).type.toBeConstructableWith();
      |            ~~~~~~~~~~~~~~
-  55 |   });
-  56 | });
-  57 | 
+  60 |   });
+  61 | });
+  62 | 
 
-       at ./__typetests__/toBeConstructableWith.tst.ts:54:12
+       at ./__typetests__/toBeConstructableWith.tst.ts:59:12
 

--- a/tests/__snapshots__/validation-toBeConstructableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeConstructableWith-stdout.snap.txt
@@ -10,7 +10,7 @@ fail ./__typetests__/toBeConstructableWith.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      3 failed, 1 passed, 4 total
-Assertions: 16 failed, 2 passed, 18 total
+Assertions: 16 failed, 3 passed, 19 total
 Duration:   <<timestamp>>
 
 Ran all test files.


### PR DESCRIPTION
Property access expressions must be accepted by the callability matchers.