### PR TITLE
feat: add the `toAcceptChildren` matcher

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -124,6 +124,17 @@
     },
 
     {
+      "include": ["source/react.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useNamingConvention": "off"
+          }
+        }
+      }
+    },
+
+    {
       "include": ["source/types.ts"],
       "linter": {
         "rules": {

--- a/examples/Button.tst.tsx
+++ b/examples/Button.tst.tsx
@@ -1,4 +1,4 @@
-import { expect, test } from "tstyche";
+import "tstyche/react";
 
 interface ButtonProps {
   text: string;
@@ -9,10 +9,30 @@ function Button({ text, type }: ButtonProps) {
   return <button type={type}>{text}</button>;
 }
 
-test("accepts props?", () => {
-  expect(Button).type.toAcceptProps({ text: "Send" });
-  expect(Button).type.toAcceptProps({ text: "Clear", type: "reset" as const });
+<tst:test name="Button">
+  <tst:expect component={Button}>
+    <tst:toAcceptProps text="Send" />
+  </tst:expect>
 
-  expect(Button).type.not.toAcceptProps({ text: "Download", type: "button" as const });
-  expect(Button).type.not.toAcceptProps({});
-});
+  <tst:expect component={Button}>
+    <tst:toAcceptProps text="Clear" type={"reset" as const} />
+  </tst:expect>
+
+  <tst:expect component={Button}>
+    <tst:not>
+      <tst:toAcceptProps text="Download" type={"button" as const} />
+    </tst:not>
+  </tst:expect>
+
+  <tst:expect component={Button}>
+    <tst:not>
+      <tst:toAcceptProps />
+    </tst:not>
+  </tst:expect>
+
+  <tst:expect component={Button}>
+    <tst:not>
+      <tst:toAcceptChildren>Nope</tst:toAcceptChildren>
+    </tst:not>
+  </tst:expect>
+</tst:test>;

--- a/examples/Plural.tst.tsx
+++ b/examples/Plural.tst.tsx
@@ -1,0 +1,41 @@
+import "tstyche/react";
+
+interface PluralProps {
+  children: string | undefined;
+  count: number;
+}
+
+function Plural({ children, count }: PluralProps) {
+  return <>{count === 1 ? children : `${children}s`}</>;
+}
+
+<tst:test name="Plural">
+  <tst:expect component={Plural}>
+    <tst:toAcceptProps count={10} />
+    <tst:toAcceptChildren>Sample</tst:toAcceptChildren>
+  </tst:expect>
+
+  <tst:expect component={Plural}>
+    <tst:not>
+      <tst:toAcceptProps />
+    </tst:not>
+    Sample
+  </tst:expect>
+
+  <tst:expect component={Plural}>
+    <tst:toAcceptProps count={10} />
+    <tst:not>
+      <tst:toAcceptChildren>{123}</tst:toAcceptChildren>
+    </tst:not>
+  </tst:expect>
+
+  <tst:expect component={Plural}>
+    <tst:toAcceptProps count={10} />
+    <tst:not>
+      <tst:toAcceptChildren>
+        {"Sample"}
+        {"Sample"}
+      </tst:toAcceptChildren>
+    </tst:not>
+  </tst:expect>
+</tst:test>;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "import": "./build/index.js",
       "require": "./build/index.cjs"
     },
+    "./react": "./build/react.d.ts",
     "./package.json": "./package.json",
     "./tstyche": "./build/tstyche.js"
   },

--- a/source/react.ts
+++ b/source/react.ts
@@ -1,0 +1,15 @@
+import type react from "react";
+
+declare module "react" {
+  export namespace JSX {
+    interface IntrinsicElements {
+      "tst:describe": { name: string; children: react.ReactElement | Array<react.ReactElement> };
+      "tst:test": { name: string; children: react.ReactElement | Array<react.ReactElement> };
+      "tst:it": { name: string; children: react.ReactElement | Array<react.ReactElement> };
+      "tst:expect": { component: unknown; children: react.ReactNode };
+      "tst:not": { children: react.ReactElement };
+      "tst:toAcceptProps": { [key: PropertyKey]: unknown; children?: never };
+      "tst:toAcceptChildren": { children?: unknown | undefined };
+    }
+  }
+}


### PR DESCRIPTION
Closes #463

This is an idea how testing of React component could be reshaped. 

Instead of pure JavaScript, here JSX component are use to define the assertions. This means the Santa is arable and the ability layer could be used.

The testing API is provided as intrinsic elements that are leveraging the XML namespace: `<tst:* />`.