### PR TITLE
feat: add `when()` nesting validation

### DIFF
--- a/source/collect/CollectDiagnosticText.ts
+++ b/source/collect/CollectDiagnosticText.ts
@@ -1,0 +1,5 @@
+export class CollectDiagnosticText {
+  static cannotBeNestedWithin(source: string, target: string): string {
+    return `'${source}()' cannot be nested within '${target}()'.`;
+  }
+}

--- a/source/events/types.ts
+++ b/source/events/types.ts
@@ -21,6 +21,7 @@ export type Event =
   | ["task:error", { diagnostics: Array<Diagnostic>; result: TaskResult }]
   | ["task:end", { result: TaskResult }]
   | ["collect:start", { tree: TestTree }]
+  | ["collect:error", { diagnostics: Array<Diagnostic> }]
   | ["collect:node", { node: TestTreeNode | AssertionNode | WhenNode }]
   | ["collect:end", { tree: TestTree }]
   | ["describe:start", { result: DescribeResult }]

--- a/source/handlers/ResultHandler.ts
+++ b/source/handlers/ResultHandler.ts
@@ -83,6 +83,7 @@ export class ResultHandler implements EventHandler {
         break;
 
       case "task:error":
+      case "collect:error":
         this.#targetResult!.status = ResultStatus.Failed;
         this.#taskResult!.status = ResultStatus.Failed;
         this.#taskResult!.diagnostics.push(...payload.diagnostics);

--- a/source/reporters/ListReporter.ts
+++ b/source/reporters/ListReporter.ts
@@ -66,6 +66,7 @@ export class ListReporter extends BaseReporter {
         break;
 
       case "task:error":
+      case "collect:error":
         for (const diagnostic of payload.diagnostics) {
           this.#fileView.addMessage(diagnosticText(diagnostic));
         }

--- a/source/token/CancellationReason.enum.ts
+++ b/source/token/CancellationReason.enum.ts
@@ -1,6 +1,7 @@
 export const enum CancellationReason {
   ConfigChange = "configChange",
   ConfigError = "configError",
+  CollectError = "collectError",
   FailFast = "failFast",
   WatchClose = "watchClose",
 }

--- a/tests/__fixtures__/validation-when/__typetests__/handles-nested.tst.ts
+++ b/tests/__fixtures__/validation-when/__typetests__/handles-nested.tst.ts
@@ -27,6 +27,6 @@ when(pipe).isCalledWith(
 );
 
 expect(() => {
-  // can be nested!
+  // 'when()' or 'expect()' can be nested!
   when(pipe).isCalledWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));
-}).type.toBe<void>();
+}).type.toBe<() => void>();

--- a/tests/__snapshots__/validation-when-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stderr.snap.txt
@@ -1,0 +1,48 @@
+Error: 'describe()' cannot be nested within 'when()'.
+
+   8 | when(pipe).isCalledWith(
+   9 |   { valid: true },
+  10 |   describe("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  11 |     //
+     | ~~~~~~
+  12 |   }),
+     | ~~~~
+  13 | );
+  14 | 
+  15 | when(pipe).isCalledWith(
+
+       at ./__typetests__/handles-nested.tst.ts:10:3
+
+Error: 'it()' cannot be nested within 'when()'.
+
+  15 | when(pipe).isCalledWith(
+  16 |   { valid: true },
+  17 |   it("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  18 |     //
+     | ~~~~~~
+  19 |   }),
+     | ~~~~
+  20 | );
+  21 | 
+  22 | when(pipe).isCalledWith(
+
+       at ./__typetests__/handles-nested.tst.ts:17:3
+
+Error: 'test()' cannot be nested within 'when()'.
+
+  22 | when(pipe).isCalledWith(
+  23 |   { valid: true },
+  24 |   test("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  25 |     //
+     | ~~~~~~
+  26 |   }),
+     | ~~~~
+  27 | );
+  28 | 
+  29 | expect(() => {
+
+       at ./__typetests__/handles-nested.tst.ts:24:3
+

--- a/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
@@ -1,0 +1,7 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/handles-nested.tst.ts
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Duration:   <<timestamp>>

--- a/tests/api-when.test.js
+++ b/tests/api-when.test.js
@@ -8,7 +8,7 @@ import { spawnTyche } from "./__utilities__/tstyche.js";
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
-await test("toBe", async (t) => {
+await test("when", async (t) => {
   await t.test("'when' implementation", () => {
     /**
      * @param {string} source

--- a/tests/validation-when.test.js
+++ b/tests/validation-when.test.js
@@ -7,7 +7,7 @@ import { spawnTyche } from "./__utilities__/tstyche.js";
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
-await test("when", { skip: true }, async (t) => {
+await test("when", async (t) => {
   await t.test("handles nested 'describe' or 'test'", async () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
 


### PR DESCRIPTION
This is adding the missing nesting validation of the `when()` utility.