### PR TITLE
feat: add template test file support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,8 +97,6 @@ jobs:
           path: build
       - run: yarn test:types --target '>=5.0'
       - run: yarn test:examples --target '>=5.0'
-        env:
-          NODE_OPTIONS: '--import ts-blank-space/register'
       - run: yarn tstyche tests/*.js --target '>=5.4'
 
   test-node:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,6 +96,8 @@ jobs:
           name: build-${{ github.sha }}
           path: build
       - run: yarn test:types --target '>=5.0'
+        env:
+          NODE_OPTIONS: --experimental-strip-types
       - run: yarn test:examples --target '>=5.0'
       - run: yarn tstyche tests/*.js --target '>=5.4'
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,8 +98,7 @@ jobs:
       - run: yarn test:types --target '>=5.0'
       - run: yarn test:examples --target '>=5.0'
         env:
-          # TODO remove after dropping dupport for Node.js 22
-          NODE_OPTIONS: '--experimental-strip-types'
+          NODE_OPTIONS: '--import ts-blank-space/register'
       - run: yarn tstyche tests/*.js --target '>=5.4'
 
   test-node:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,10 +96,10 @@ jobs:
           name: build-${{ github.sha }}
           path: build
       - run: yarn test:types --target '>=5.0'
+      - run: yarn test:examples --target '>=5.0'
         env:
           # TODO remove after dropping dupport for Node.js 22
           NODE_OPTIONS: '--experimental-strip-types'
-      - run: yarn test:examples --target '>=5.0'
       - run: yarn tstyche tests/*.js --target '>=5.4'
 
   test-node:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,6 +97,7 @@ jobs:
           path: build
       - run: yarn test:types --target '>=5.0'
         env:
+          # TODO remove after dropping dupport for Node.js 22
           NODE_OPTIONS: --experimental-strip-types
       - run: yarn test:examples --target '>=5.0'
       - run: yarn tstyche tests/*.js --target '>=5.4'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
       - run: yarn test:types --target '>=5.0'
         env:
           # TODO remove after dropping dupport for Node.js 22
-          NODE_OPTIONS: --experimental-strip-types
+          NODE_OPTIONS: '--experimental-strip-types'
       - run: yarn test:examples --target '>=5.0'
       - run: yarn tstyche tests/*.js --target '>=5.4'
 

--- a/benchmarks/tstyche.bench.sh
+++ b/benchmarks/tstyche.bench.sh
@@ -4,21 +4,21 @@ hyperfine \
   --export-json 'tstyche.bench.json' \
   --time-unit 'second' \
   --warmup 2 \
-  'tstyche examples' \
+  'yarn test:examples' \
   --command-name 'warm cache: tstyche examples' \
   --prepare '' \
-  'tstyche examples --target next' \
+  'yarn test:examples --target next' \
   --command-name 'warm cache: tstyche examples --target next' \
   --prepare '' \
-  'tstyche examples --target 5.2' \
+  'yarn test:examples --target 5.2' \
   --command-name 'warm cache: tstyche examples --target 5.2' \
   --prepare '' \
-  'tstyche examples' \
+  'yarn test:examples' \
   --command-name 'cold cache: tstyche examples' \
   --prepare 'tstyche --prune' \
-  'tstyche examples --target next' \
+  'yarn test:examples --target next' \
   --command-name 'cold cache: tstyche examples --target next' \
   --prepare 'tstyche --prune' \
-  'tstyche examples --target 5.2' \
+  'yarn test:examples --target 5.2' \
   --command-name 'cold cache: tstyche examples --target 5.2' \
   --prepare 'tstyche --prune'

--- a/examples/template.tst.ts
+++ b/examples/template.tst.ts
@@ -1,0 +1,14 @@
+// @tstyche-template
+
+let testText = `
+import { expect, test } from "tstyche";
+`;
+
+for (const target of ["string", "number"]) {
+  testText += `test("is ${target} a string?", () => {
+  expect<string>().type.toBe<${target}>();
+});
+`;
+}
+
+export default testText;

--- a/examples/template.tst.ts
+++ b/examples/template.tst.ts
@@ -4,9 +4,9 @@ let testText = `
 import { expect, test } from "tstyche";
 `;
 
-for (const target of ["string", "number"]) {
-  testText += `test("is ${target} a string?", () => {
-  expect<string>().type.toBe<${target}>();
+for (const typeText of ["string", "number"]) {
+  testText += `test("is ${typeText} a ${typeText}?", () => {
+  expect<${typeText}>().type.toBe<${typeText}>();
 });
 `;
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:e2e": "yarn test:e2e:parallel && yarn test:e2e:serial",
     "test:e2e:parallel": "yarn test:run tests/*.test.js --exclude feature --parallel",
     "test:e2e:serial": "yarn test:run tests/*.test.js --include feature",
-    "test:examples": "tstyche examples",
+    "test:examples": "NODE_OPTIONS='--import ts-blank-space/register' tstyche examples",
     "test:run": "rm -rf ./tests/__fixtures__/.generated && yarn node ./tests/__utilities__/runner.js",
     "test:types": "tstyche typetests",
     "test:unit": "yarn test:run **/__tests__/*.test.js --parallel"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "pretty-ansi": "3.0.0",
     "rollup": "4.40.1",
     "rollup-plugin-dts": "6.2.1",
+    "ts-blank-space": "0.6.1",
     "tslib": "2.8.1",
     "typescript": "5.8.3"
   },

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -93,7 +93,7 @@ export class Runner {
         const taskRunner = new TaskRunner(compiler, this.#resolvedConfig);
 
         for (const task of tasks) {
-          taskRunner.run(task, cancellationToken);
+          await taskRunner.run(task, cancellationToken);
         }
       }
 

--- a/tests/__fixtures__/api-template/__typetests__/template.tst.ts
+++ b/tests/__fixtures__/api-template/__typetests__/template.tst.ts
@@ -1,0 +1,14 @@
+// @tstyche-template
+
+let testText = `
+import { expect, test } from "tstyche";
+`;
+
+for (const target of ["string", "number"]) {
+  testText += `test("is ${target} a string?", () => {
+  expect<string>().type.toBe<${target}>();
+});
+`;
+}
+
+export default testText;

--- a/tests/__fixtures__/api-template/tsconfig.json
+++ b/tests/__fixtures__/api-template/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/tests/__snapshots__/api-template-stderr.snap.txt
+++ b/tests/__snapshots__/api-template-stderr.snap.txt
@@ -1,0 +1,13 @@
+Error: Type 'string' is not identical to type 'number'.
+
+  5 | });
+  6 | test("is number a string?", () => {
+  7 |   expect<string>().type.toBe<number>();
+    |                              ~~~~~~
+  8 | });
+  9 | 
+
+      at ./__typetests__/template.tst.ts:7:30 ❭ is number a string?
+
+(node:44235) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)

--- a/tests/__snapshots__/api-template-stderr.snap.txt
+++ b/tests/__snapshots__/api-template-stderr.snap.txt
@@ -9,5 +9,3 @@ Error: Type 'string' is not identical to type 'number'.
 
       at ./__typetests__/template.tst.ts:7:30 ❭ is number a string?
 
-(node:44235) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)

--- a/tests/__snapshots__/api-template-stdout.snap.txt
+++ b/tests/__snapshots__/api-template-stdout.snap.txt
@@ -1,0 +1,11 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/template.tst.ts
+  + is string a string?
+  × is number a string?
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      1 failed, 1 passed, 2 total
+Assertions: 1 failed, 1 passed, 2 total
+Duration:   <<timestamp>>

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -17,7 +17,7 @@ await test("template", async (t) => {
 
   await t.test("template", async () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
-      env: { ["NODE_OPTIONS"]: "--experimental-strip-types" },
+      env: { ["NODE_OPTIONS"]: "--import ts-blank-space/register" },
     });
 
     await assert.matchSnapshot(normalizeOutput(stdout), {
@@ -25,7 +25,10 @@ await test("template", async (t) => {
       testFileUrl: import.meta.url,
     });
 
-    assert.equal(stderr.startsWith(`Error: Type 'string' is not identical to type 'number'.`), true);
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-stderr`,
+      testFileUrl: import.meta.url,
+    });
 
     assert.equal(exitCode, 1);
   });

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -8,6 +8,13 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
 await test("template", async (t) => {
+  // TODO figure out why this is failing on Windows
+  if (process.platform !== "win32") {
+    t.skip();
+
+    return;
+  }
+
   await t.test("template", async () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
       env: { ["NODE_OPTIONS"]: "--import ts-blank-space/register" },

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -8,13 +8,6 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
 await test("template", async (t) => {
-  // TODO remove this check after dropping support for Node.js 20
-  if (process.versions.node.startsWith("20")) {
-    t.skip();
-
-    return;
-  }
-
   await t.test("template", async () => {
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
       env: { ["NODE_OPTIONS"]: "--import ts-blank-space/register" },

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -9,7 +9,7 @@ const fixtureUrl = getFixtureFileUrl(testFileName);
 
 await test("template", async (t) => {
   // TODO figure out why this is failing on Windows
-  if (process.platform !== "win32") {
+  if (process.platform === "win32") {
     t.skip();
 
     return;

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { getFixtureFileUrl, getTestFileName } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName);
+
+await test("template", async (t) => {
+  // TODO remove this check after dropping support for Node.js 20
+  if (process.versions.node.startsWith("20")) {
+    t.skip();
+
+    return;
+  }
+
+  await t.test("template", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
+      env: { ["NODE_OPTIONS"]: "--experimental-strip-types" },
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(
+      stderr.startsWith(`Error: Type 'string' is not identical to type 'number'.\n
+  5 | });
+  6 | test("is number a string?", () => {
+  7 |   expect<string>().type.toBe<number>();
+    |                              ~~~~~~
+  8 | });
+  9 | \n
+      at ./__typetests__/template.tst.ts:7:30 ❭ is number a string?`),
+      true,
+    );
+
+    assert.equal(exitCode, 1);
+  });
+});

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -25,17 +25,7 @@ await test("template", async (t) => {
       testFileUrl: import.meta.url,
     });
 
-    assert.equal(
-      stderr.startsWith(`Error: Type 'string' is not identical to type 'number'.\n
-  5 | });
-  6 | test("is number a string?", () => {
-  7 |   expect<string>().type.toBe<number>();
-    |                              ~~~~~~
-  8 | });
-  9 | \n
-      at ./__typetests__/template.tst.ts`),
-      true,
-    );
+    assert.equal(stderr.startsWith(`Error: Type 'string' is not identical to type 'number'.`), true);
 
     assert.equal(exitCode, 1);
   });

--- a/tests/api-template.test.js
+++ b/tests/api-template.test.js
@@ -33,7 +33,7 @@ await test("template", async (t) => {
     |                              ~~~~~~
   8 | });
   9 | \n
-      at ./__typetests__/template.tst.ts:7:30 ❭ is number a string?`),
+      at ./__typetests__/template.tst.ts`),
       true,
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,6 +2384,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-blank-space@npm:0.6.1":
+  version: 0.6.1
+  resolution: "ts-blank-space@npm:0.6.1"
+  dependencies:
+    typescript: "npm:5.1.6 - 5.8.x"
+  checksum: 10c0/cf674e96d204c3f6d99e29966580b7c3526680ff012dfa3e45aef10a1052011b5ced55bae81d57f46b153053ed9413082a2d15db7812c2c0eb138d178b0f376c
+  languageName: node
+  linkType: hard
+
 "tslib@npm:2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -2406,6 +2415,7 @@ __metadata:
     pretty-ansi: "npm:3.0.0"
     rollup: "npm:4.40.1"
     rollup-plugin-dts: "npm:6.2.1"
+    ts-blank-space: "npm:0.6.1"
     tslib: "npm:2.8.1"
     typescript: "npm:5.8.3"
   peerDependencies:
@@ -2418,7 +2428,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"typescript@npm:5.8.3":
+"typescript@npm:5.1.6 - 5.8.x, typescript@npm:5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -2428,7 +2438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.1.6 - 5.8.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:


### PR DESCRIPTION
Closes #465

This adds template test file support.

To mark a test file as a temple, a user must include `// @tstyche-template` as the first line of a test file.

When the `// @tstyche-template` directive is detected, the default export of a file is treated as a type test file.

For example, the following:

```ts
// @tstyche-template

let testText = `
import { expect, test } from "tstyche";
`;

for (const target of ["string", "number"]) {
  testText += `test("is ${target} a string?", () => {
  expect<string>().type.toBe<${target}>();
});
`;
}

export default testText;
```

is treated as:

```ts
import { expect, test } from "tstyche";
test("is string a string?", () => {
  expect<string>().type.toBe<string>();
});
test("is number a string?", () => {
  expect<string>().type.toBe<number>();
});
```
