### PR TITLE
refactor!: move test tree validation logic

### DIFF
--- a/source/collect/CollectService.ts
+++ b/source/collect/CollectService.ts
@@ -6,7 +6,7 @@ import type { ProjectService } from "#project";
 import { AbilityLayer } from "./AbilityLayer.js";
 import { AssertionNode } from "./AssertionNode.js";
 import { CollectDiagnosticText } from "./CollectDiagnosticText.js";
-import { IdentifierLookup } from "./IdentifierLookup.js";
+import { IdentifierLookup, type TestTreeNodeMeta } from "./IdentifierLookup.js";
 import { TestTree } from "./TestTree.js";
 import { TestTreeNode } from "./TestTreeNode.js";
 import { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
@@ -32,99 +32,113 @@ export class CollectService {
 
   #collectTestTreeNodes(node: ts.Node, parent: TestTree | TestTreeNode) {
     if (this.#compiler.isCallExpression(node)) {
-      const meta = this.#identifierLookup.resolveTestMemberMeta(node);
+      const meta = this.#identifierLookup.resolveTestTreeNodeMeta(node);
 
-      if (meta != null && (meta.brand === TestTreeNodeBrand.Describe || meta.brand === TestTreeNodeBrand.Test)) {
-        const testTreeNode = new TestTreeNode(this.#compiler, meta.brand, node, parent, meta.flags);
-
-        this.#compiler.forEachChild(node, (node) => {
-          this.#collectTestTreeNodes(node, testTreeNode);
-        });
-
-        this.#onNode(testTreeNode, parent);
-
-        return;
-      }
-
-      if (meta != null && meta.brand === TestTreeNodeBrand.Expect) {
-        const modifierNode = this.#getChainedNode(node, "type");
-
-        if (!modifierNode) {
+      if (meta != null) {
+        if (!this.#checkNode(node, meta, parent)) {
           return;
         }
 
-        const notNode = this.#getChainedNode(modifierNode, "not");
+        if (meta.brand === TestTreeNodeBrand.Describe || meta.brand === TestTreeNodeBrand.Test) {
+          const testTreeNode = new TestTreeNode(this.#compiler, meta.brand, node, parent, meta.flags);
 
-        const matcherNameNode = this.#getChainedNode(notNode ?? modifierNode);
+          this.#compiler.forEachChild(node, (node) => {
+            this.#collectTestTreeNodes(node, testTreeNode);
+          });
 
-        if (!matcherNameNode) {
+          this.#onNode(testTreeNode, parent);
+
           return;
         }
 
-        const matcherNode = this.#getMatcherNode(matcherNameNode);
+        if (meta.brand === TestTreeNodeBrand.Expect) {
+          const modifierNode = this.#getChainedNode(node, "type");
 
-        if (!matcherNode) {
-          return;
-        }
-
-        const assertionNode = new AssertionNode(
-          this.#compiler,
-          meta.brand,
-          node,
-          parent,
-          meta.flags,
-          matcherNode,
-          matcherNameNode,
-          modifierNode,
-          notNode,
-        );
-
-        this.#abilityLayer.handleAssertion(assertionNode);
-
-        this.#compiler.forEachChild(node, (node) => {
-          this.#collectTestTreeNodes(node, assertionNode);
-        });
-
-        this.#onNode(assertionNode, parent);
-
-        return;
-      }
-
-      if (meta != null && meta.brand === TestTreeNodeBrand.When) {
-        const actionNameNode = this.#getChainedNode(node);
-
-        if (!actionNameNode) {
-          return;
-        }
-
-        const actionNode = this.#getActionNode(actionNameNode);
-
-        if (!actionNode) {
-          // TODO make sure that the 'actionNode' is actually called
-          // "'.isCalledWith()' must be called with an argument."
-          return;
-        }
-
-        this.#compiler.forEachChild(actionNode, (node) => {
-          if (this.#compiler.isCallExpression(node)) {
-            const meta = this.#identifierLookup.resolveTestMemberMeta(node);
-
-            if (meta != null && (meta.brand === TestTreeNodeBrand.Describe || meta.brand === TestTreeNodeBrand.Test)) {
-              const text = CollectDiagnosticText.cannotBeNestedWithin(meta.identifier, "when");
-              const origin = DiagnosticOrigin.fromNode(node);
-
-              this.#onDiagnostics(Diagnostic.error(text, origin));
-            }
+          if (!modifierNode) {
+            return;
           }
-        });
 
-        const whenNode = new WhenNode(this.#compiler, meta.brand, node, parent, meta.flags, actionNode, actionNameNode);
+          const notNode = this.#getChainedNode(modifierNode, "not");
 
-        this.#abilityLayer.handleWhen(whenNode);
+          const matcherNameNode = this.#getChainedNode(notNode ?? modifierNode);
 
-        this.#onNode(whenNode, parent);
+          if (!matcherNameNode) {
+            return;
+          }
 
-        return;
+          const matcherNode = this.#getMatcherNode(matcherNameNode);
+
+          if (!matcherNode) {
+            return;
+          }
+
+          const assertionNode = new AssertionNode(
+            this.#compiler,
+            meta.brand,
+            node,
+            parent,
+            meta.flags,
+            matcherNode,
+            matcherNameNode,
+            modifierNode,
+            notNode,
+          );
+
+          this.#abilityLayer.handleAssertion(assertionNode);
+
+          this.#compiler.forEachChild(node, (node) => {
+            this.#collectTestTreeNodes(node, assertionNode);
+          });
+
+          this.#onNode(assertionNode, parent);
+
+          return;
+        }
+
+        if (meta.brand === TestTreeNodeBrand.When) {
+          const actionNameNode = this.#getChainedNode(node);
+
+          if (!actionNameNode) {
+            return;
+          }
+
+          const actionNode = this.#getActionNode(actionNameNode);
+
+          if (!actionNode) {
+            // TODO make sure that the 'actionNode' is actually called
+            // "'.isCalledWith()' must be called with an argument."
+            return;
+          }
+
+          this.#compiler.forEachChild(actionNode, (node) => {
+            if (this.#compiler.isCallExpression(node)) {
+              const meta = this.#identifierLookup.resolveTestTreeNodeMeta(node);
+
+              if (meta?.brand === TestTreeNodeBrand.Describe || meta?.brand === TestTreeNodeBrand.Test) {
+                const text = CollectDiagnosticText.cannotBeNestedWithin(meta.identifier, "when");
+                const origin = DiagnosticOrigin.fromNode(node);
+
+                this.#onDiagnostics(Diagnostic.error(text, origin));
+              }
+            }
+          });
+
+          const whenNode = new WhenNode(
+            this.#compiler,
+            meta.brand,
+            node,
+            parent,
+            meta.flags,
+            actionNode,
+            actionNameNode,
+          );
+
+          this.#abilityLayer.handleWhen(whenNode);
+
+          this.#onNode(whenNode, parent);
+
+          return;
+        }
       }
     }
 
@@ -157,6 +171,39 @@ export class CollectService {
     EventEmitter.dispatch(["collect:end", { tree: testTree }]);
 
     return testTree;
+  }
+
+  #checkNode(node: ts.Node, meta: TestTreeNodeMeta, parent: TestTree | TestTreeNode) {
+    if ("brand" in parent && !this.#isNodeAllowed(meta, parent)) {
+      const text = CollectDiagnosticText.cannotBeNestedWithin(meta.identifier, parent.node.expression.getText());
+      const origin = DiagnosticOrigin.fromNode(node);
+
+      this.#onDiagnostics(Diagnostic.error(text, origin));
+
+      return false;
+    }
+
+    return true;
+  }
+
+  #isNodeAllowed(meta: TestTreeNodeMeta, parent: TestTreeNode) {
+    switch (meta.brand) {
+      case TestTreeNodeBrand.Describe:
+      case TestTreeNodeBrand.Test:
+        if (parent.brand === TestTreeNodeBrand.Test || parent.brand === TestTreeNodeBrand.Expect) {
+          return false;
+        }
+        break;
+
+      case TestTreeNodeBrand.Expect:
+      case TestTreeNodeBrand.When:
+        if (parent.brand === TestTreeNodeBrand.Describe) {
+          return false;
+        }
+        break;
+    }
+
+    return true;
   }
 
   #getChainedNode({ parent }: ts.Node, name?: string) {

--- a/source/collect/CollectService.ts
+++ b/source/collect/CollectService.ts
@@ -16,7 +16,7 @@ import { WhenNode } from "./WhenNode.js";
 export class CollectService {
   #abilityLayer: AbilityLayer;
   #compiler: typeof ts;
-  #identifierLookup: IdentifierLookup;
+  #identifierLookup!: IdentifierLookup;
   #projectService: ProjectService;
   #resolvedConfig: ResolvedConfig;
   #testTree: TestTree | undefined;
@@ -27,7 +27,6 @@ export class CollectService {
     this.#resolvedConfig = resolvedConfig;
 
     this.#abilityLayer = new AbilityLayer(compiler, this.#projectService, this.#resolvedConfig);
-    this.#identifierLookup = new IdentifierLookup(compiler);
   }
 
   #collectTestTreeNodes(node: ts.Node, parent: TestTree | TestTreeNode) {
@@ -155,6 +154,8 @@ export class CollectService {
 
   createTestTree(sourceFile: ts.SourceFile, semanticDiagnostics: Array<ts.Diagnostic> = []): TestTree {
     const testTree = new TestTree(new Set(semanticDiagnostics), sourceFile);
+
+    this.#identifierLookup = new IdentifierLookup(this.#compiler);
 
     EventEmitter.dispatch(["collect:start", { tree: testTree }]);
 

--- a/source/collect/IdentifierLookup.ts
+++ b/source/collect/IdentifierLookup.ts
@@ -7,7 +7,7 @@ export interface Identifiers {
   namespace: string | undefined;
 }
 
-export interface TestMemberMeta {
+export interface TestTreeNodeMeta {
   brand: TestTreeNodeBrand;
   flags: TestTreeNodeFlags;
   identifier: string;
@@ -66,7 +66,7 @@ export class IdentifierLookup {
     }
   }
 
-  resolveTestMemberMeta(node: ts.CallExpression): TestMemberMeta | undefined {
+  resolveTestTreeNodeMeta(node: ts.CallExpression): TestTreeNodeMeta | undefined {
     let flags = TestTreeNodeFlags.None;
     let expression = node.expression;
 

--- a/source/collect/IdentifierLookup.ts
+++ b/source/collect/IdentifierLookup.ts
@@ -18,10 +18,10 @@ export class IdentifierLookup {
   #identifiers: Identifiers;
   #moduleSpecifiers = ['"tstyche"', "'tstyche'"];
 
-  constructor(compiler: typeof ts, identifiers?: Identifiers) {
+  constructor(compiler: typeof ts) {
     this.#compiler = compiler;
 
-    this.#identifiers = identifiers ?? {
+    this.#identifiers = {
       namedImports: {
         describe: undefined,
         expect: undefined,

--- a/source/collect/IdentifierLookup.ts
+++ b/source/collect/IdentifierLookup.ts
@@ -15,23 +15,11 @@ export interface TestTreeNodeMeta {
 
 export class IdentifierLookup {
   #compiler: typeof ts;
-  #identifiers: Identifiers;
+  #identifiers!: Identifiers;
   #moduleSpecifiers = ['"tstyche"', "'tstyche'"];
 
   constructor(compiler: typeof ts) {
     this.#compiler = compiler;
-
-    this.#identifiers = {
-      namedImports: {
-        describe: undefined,
-        expect: undefined,
-        it: undefined,
-        namespace: undefined,
-        test: undefined,
-        when: undefined,
-      },
-      namespace: undefined,
-    };
   }
 
   handleImportDeclaration(node: ts.ImportDeclaration): void {
@@ -64,6 +52,20 @@ export class IdentifierLookup {
         this.#identifiers.namespace = node.importClause.namedBindings.name.getText();
       }
     }
+  }
+
+  open() {
+    this.#identifiers = {
+      namedImports: {
+        describe: undefined,
+        expect: undefined,
+        it: undefined,
+        namespace: undefined,
+        test: undefined,
+        when: undefined,
+      },
+      namespace: undefined,
+    };
   }
 
   resolveTestTreeNodeMeta(node: ts.CallExpression): TestTreeNodeMeta | undefined {

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -6,11 +6,10 @@ import type { ResolvedConfig } from "#config";
 import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
 import type { TypeChecker } from "#expect";
-import { CancellationHandler } from "#handlers";
 import { ProjectService } from "#project";
 import { TaskResult } from "#result";
 import type { Task } from "#task";
-import { CancellationReason, type CancellationToken } from "#token";
+import type { CancellationToken } from "#token";
 import { RunMode } from "./RunMode.enum.js";
 import { TestTreeWalker } from "./TestTreeWalker.js";
 
@@ -115,16 +114,7 @@ export class TaskRunner {
       return;
     }
 
-    const cancellationHandler = new CancellationHandler(cancellationToken, CancellationReason.CollectError);
-    this.#eventEmitter.addHandler(cancellationHandler);
-
     const testTree = this.#collectService.createTestTree(sourceFile, semanticDiagnostics);
-
-    this.#eventEmitter.removeHandler(cancellationHandler);
-
-    if (cancellationToken.isCancellationRequested) {
-      return;
-    }
 
     if (testTree.diagnostics.size > 0) {
       this.#onDiagnostics(Diagnostic.fromDiagnostics([...testTree.diagnostics]), taskResult);

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -92,14 +92,6 @@ export class TestTreeWalker {
         break;
       }
 
-      const validationError = testNode.validate();
-
-      if (validationError.length > 0) {
-        EventEmitter.dispatch(["task:error", { diagnostics: validationError, result: this.#taskResult }]);
-
-        break;
-      }
-
       switch (testNode.brand) {
         case TestTreeNodeBrand.Describe:
           this.#visitDescribe(testNode, runMode, parentResult as DescribeResult | undefined);
@@ -236,8 +228,14 @@ export class TestTreeWalker {
     }
   }
 
-  #visitWhen(when: WhenNode, runMode: RunMode, parentResult: TestResult | undefined) {
+  #visitWhen(when: WhenNode, _runMode: RunMode, _parentResult: TestResult | undefined) {
     // TODO make sure a function was passed to '.isCalledWith()' action
+
+    // must be a switch with all possible actions
+    // and 'default' similar to '.onMatcherIsNotSupported()'
+
+    // the 'isCalledWith' branch checks:
+    //   - if argument is callable
 
     if (when.abilityDiagnostics != null && when.abilityDiagnostics.size > 0) {
       const diagnostics: Array<Diagnostic> = [];
@@ -269,6 +267,8 @@ export class TestTreeWalker {
       return;
     }
 
-    this.visit(when.children, runMode, parentResult);
+    // TODO are there any children?
+
+    // this.visit(when.children, runMode, parentResult);
   }
 }

--- a/source/token/CancellationReason.enum.ts
+++ b/source/token/CancellationReason.enum.ts
@@ -1,7 +1,6 @@
 export const enum CancellationReason {
   ConfigChange = "configChange",
   ConfigError = "configError",
-  CollectError = "collectError",
   FailFast = "failFast",
   WatchClose = "watchClose",
 }

--- a/tests/__fixtures__/validation-it/__typetests__/handles-nested.tst.ts
+++ b/tests/__fixtures__/validation-it/__typetests__/handles-nested.tst.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "tstyche";
 
 it("is string?", () => {
-  describe("nested describe is handled?", () => {
+  describe("nested 'describe()' is handled?", () => {
     expect<number>().type.toBe<number>();
   });
 
-  it("nested it is handled?", () => {
+  it("nested 'it()' is handled?", () => {
     expect<never>().type.toBe<never>();
   });
 

--- a/tests/__fixtures__/validation-test/__typetests__/handles-nested.tst.ts
+++ b/tests/__fixtures__/validation-test/__typetests__/handles-nested.tst.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "tstyche";
 
 test("is string?", () => {
-  describe("nested describe is handled?", () => {
+  describe("nested 'describe()' is handled?", () => {
     expect<number>().type.toBe<number>();
   });
 
-  test("nested test is handled?", () => {
+  test("nested 'test()' is handled?", () => {
     expect<never>().type.toBe<never>();
   });
 

--- a/tests/__fixtures__/validation-when/__typetests__/handles-nested.tst.ts
+++ b/tests/__fixtures__/validation-when/__typetests__/handles-nested.tst.ts
@@ -28,5 +28,5 @@ when(pipe).isCalledWith(
 
 expect(() => {
   // 'when()' or 'expect()' can be nested!
-  when(pipe).isCalledWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));
-}).type.toBe<() => void>();
+  when(pipe).isCalledWith({ valid: true }, expect(pick).type.toBeCallableWith(true));
+}).type.toBe<void>();

--- a/tests/__snapshots__/validation-describe-handles-expect-stderr.snap.txt
+++ b/tests/__snapshots__/validation-describe-handles-expect-stderr.snap.txt
@@ -3,7 +3,7 @@ Error: 'expect()' cannot be nested within 'describe()'.
    6 | 
    7 | describe("nested 'expect()' is handled?", () => {
    8 |   expect<never>().type.toBe<never>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~
    9 |   expect<null>().type.toBe<null>();
   10 | 
   11 |   test("is number?", () => {
@@ -15,7 +15,7 @@ Error: 'expect()' cannot be nested within 'describe()'.
    7 | describe("nested 'expect()' is handled?", () => {
    8 |   expect<never>().type.toBe<never>();
    9 |   expect<null>().type.toBe<null>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~
   10 | 
   11 |   test("is number?", () => {
   12 |     expect<number>().type.toBe<number>();

--- a/tests/__snapshots__/validation-describe-handles-expect-stdout.snap.txt
+++ b/tests/__snapshots__/validation-describe-handles-expect-stdout.snap.txt
@@ -2,9 +2,11 @@ uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-expect.tst.ts
   + is string?
+  nested 'expect()' is handled?
+    + is number?
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      1 passed, 1 total
-Assertions: 1 passed, 1 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
@@ -46,3 +46,24 @@ Error: 'test()' cannot be nested within 'expect()'.
 
        at ./__typetests__/handles-nested.tst.ts:12:3
 
+Error: Type 'number' is not identical to type 'string'.
+
+  15 | 
+  16 |   // can be nested!
+  17 |   expect<number>().type.toBe<string>();
+     |                              ~~~~~~
+  18 | }).type.toBe<void>();
+  19 | 
+
+       at ./__typetests__/handles-nested.tst.ts:17:30 ❭ 
+
+Error: Type '() => void' is not identical to type 'void'.
+
+  16 |   // can be nested!
+  17 |   expect<number>().type.toBe<string>();
+  18 | }).type.toBe<void>();
+     |              ~~~~
+  19 | 
+
+       at ./__typetests__/handles-nested.tst.ts:18:14
+

--- a/tests/__snapshots__/validation-expect-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stdout.snap.txt
@@ -4,4 +4,5 @@ fail ./__typetests__/handles-nested.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
+Assertions: 2 failed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-it-handles-nested-stderr.snap.txt
@@ -2,14 +2,14 @@ Error: 'describe()' cannot be nested within 'it()'.
 
   2 | 
   3 | it("is string?", () => {
-  4 |   describe("nested describe is handled?", () => {
-    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  4 |   describe("nested 'describe()' is handled?", () => {
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     expect<number>().type.toBe<number>();
     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   6 |   });
     | ~~~~
   7 | 
-  8 |   it("nested it is handled?", () => {
+  8 |   it("nested 'it()' is handled?", () => {
   9 |     expect<never>().type.toBe<never>();
 
       at ./__typetests__/handles-nested.tst.ts:4:3
@@ -18,8 +18,8 @@ Error: 'it()' cannot be nested within 'it()'.
 
    6 |   });
    7 | 
-   8 |   it("nested it is handled?", () => {
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 |   it("nested 'it()' is handled?", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     expect<never>().type.toBe<never>();
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 |   });

--- a/tests/__snapshots__/validation-it-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-it-handles-nested-stdout.snap.txt
@@ -1,7 +1,10 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts
+  + is string?
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-test-handles-nested-stderr.snap.txt
@@ -2,14 +2,14 @@ Error: 'describe()' cannot be nested within 'test()'.
 
   2 | 
   3 | test("is string?", () => {
-  4 |   describe("nested describe is handled?", () => {
-    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  4 |   describe("nested 'describe()' is handled?", () => {
+    |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     expect<number>().type.toBe<number>();
     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   6 |   });
     | ~~~~
   7 | 
-  8 |   test("nested test is handled?", () => {
+  8 |   test("nested 'test()' is handled?", () => {
   9 |     expect<never>().type.toBe<never>();
 
       at ./__typetests__/handles-nested.tst.ts:4:3
@@ -18,8 +18,8 @@ Error: 'test()' cannot be nested within 'test()'.
 
    6 |   });
    7 | 
-   8 |   test("nested test is handled?", () => {
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 |   test("nested 'test()' is handled?", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    9 |     expect<never>().type.toBe<never>();
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 |   });

--- a/tests/__snapshots__/validation-test-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-test-handles-nested-stdout.snap.txt
@@ -1,7 +1,10 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts
+  + is string?
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-when-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stderr.snap.txt
@@ -94,3 +94,26 @@ Error: Argument of type 'void' is not assignable to parameter of type '(source: 
 
        at ./__typetests__/handles-nested.tst.ts:24:3
 
+Error: Expression is not callable with the given argument.
+
+Argument of type 'true' is not assignable to parameter of type '"valid"'.
+
+  29 | expect(() => {
+  30 |   // 'when()' or 'expect()' can be nested!
+  31 |   when(pipe).isCalledWith({ valid: true }, expect(pick).type.toBeCallableWith(true));
+     |                                                                               ~~~~
+  32 | }).type.toBe<void>();
+  33 | 
+
+       at ./__typetests__/handles-nested.tst.ts:31:79
+
+Error: Type '() => void' is not identical to type 'void'.
+
+  30 |   // 'when()' or 'expect()' can be nested!
+  31 |   when(pipe).isCalledWith({ valid: true }, expect(pick).type.toBeCallableWith(true));
+  32 | }).type.toBe<void>();
+     |              ~~~~
+  33 | 
+
+       at ./__typetests__/handles-nested.tst.ts:32:14
+

--- a/tests/__snapshots__/validation-when-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stderr.snap.txt
@@ -46,3 +46,51 @@ Error: 'test()' cannot be nested within 'when()'.
 
        at ./__typetests__/handles-nested.tst.ts:24:3
 
+Error: Argument of type 'void' is not assignable to parameter of type '(source: { valid: boolean; }) => { valid: boolean; }'.
+
+   8 | when(pipe).isCalledWith(
+   9 |   { valid: true },
+  10 |   describe("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  11 |     //
+     | ~~~~~~
+  12 |   }),
+     | ~~~~
+  13 | );
+  14 | 
+  15 | when(pipe).isCalledWith(
+
+       at ./__typetests__/handles-nested.tst.ts:10:3
+
+Error: Argument of type 'void' is not assignable to parameter of type '(source: { valid: boolean; }) => { valid: boolean; }'.
+
+  15 | when(pipe).isCalledWith(
+  16 |   { valid: true },
+  17 |   it("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  18 |     //
+     | ~~~~~~
+  19 |   }),
+     | ~~~~
+  20 | );
+  21 | 
+  22 | when(pipe).isCalledWith(
+
+       at ./__typetests__/handles-nested.tst.ts:17:3
+
+Error: Argument of type 'void' is not assignable to parameter of type '(source: { valid: boolean; }) => { valid: boolean; }'.
+
+  22 | when(pipe).isCalledWith(
+  23 |   { valid: true },
+  24 |   test("cannot be nested", () => {
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  25 |     //
+     | ~~~~~~
+  26 |   }),
+     | ~~~~
+  27 | );
+  28 | 
+  29 | expect(() => {
+
+       at ./__typetests__/handles-nested.tst.ts:24:3
+

--- a/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
@@ -1,7 +1,12 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts
+  cannot be nested
+  + cannot be nested
+  + cannot be nested
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
+Tests:      2 passed, 2 total
+Assertions: 3 passed, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
@@ -8,5 +8,5 @@ fail ./__typetests__/handles-nested.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      2 passed, 2 total
-Assertions: 3 passed, 3 total
+Assertions: 2 failed, 1 passed, 3 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
Moving test tree validation logic to the collect service.

This is breaking change, because the invalid nodes are not included in the tree anymore. Errors are emitted as diagnostics, test file fails, but all healthy nodes are analyzed and results are reported.