### PR TITLE
fix: always use default compiler options when file is not included

### DIFF
--- a/tests/__snapshots__/config-tsconfig-not-include-stdout.snap.txt
+++ b/tests/__snapshots__/config-tsconfig-not-include-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>>
+
+pass ./__typetests__/isNumber.tst.ts
+pass ./__typetests__/isString.tst.ts
+
+Targets:    1 passed, 1 total
+Test files: 2 passed, 2 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>

--- a/tests/config-tsconfig.test.js
+++ b/tests/config-tsconfig.test.js
@@ -84,6 +84,25 @@ await test("'--tsconfig' command line option", async (t) => {
     assert.equal(exitCode, 0);
   });
 
+  await t.test("uses default compiler options when file is not included in specified 'tsconfig.json'", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tsconfig.test.json"]: JSON.stringify({ extends: "../../tsconfig.json", include: [] }, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--tsconfig", "./tsconfig.test.json"]);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-not-include-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
   await t.test("overrides configuration file option", async () => {
     const config = {
       tsconfig: "ignore",
@@ -176,6 +195,30 @@ await test("'tsconfig' configuration file option", async (t) => {
 
     await assert.matchSnapshot(normalizeOutput(stdout), {
       fileName: `${testFileName}-specified-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("uses default compiler options when file is not included in specified 'tsconfig.json'", async () => {
+    const config = {
+      tsconfig: "./tsconfig.test.json",
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tsconfig.test.json"]: JSON.stringify({ extends: "../../tsconfig.json", include: [] }, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-not-include-stdout`,
       testFileUrl: import.meta.url,
     });
 

--- a/tests/config-tsconfig.test.js
+++ b/tests/config-tsconfig.test.js
@@ -89,7 +89,7 @@ await test("'--tsconfig' command line option", async (t) => {
       ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
       ["__typetests__/isString.tst.ts"]: isStringTestText,
       ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
-      ["tsconfig.test.json"]: JSON.stringify({ extends: "../../tsconfig.json", include: [] }, null, 2),
+      ["tsconfig.test.json"]: JSON.stringify({ extends: "../../tsconfig.json", include: ["src/**/*"] }, null, 2),
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--tsconfig", "./tsconfig.test.json"]);
@@ -211,7 +211,7 @@ await test("'tsconfig' configuration file option", async (t) => {
       ["__typetests__/isNumber.tst.ts"]: isNumberTestText,
       ["__typetests__/isString.tst.ts"]: isStringTestText,
       ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
-      ["tsconfig.test.json"]: JSON.stringify({ extends: "../../tsconfig.json", include: [] }, null, 2),
+      ["tsconfig.test.json"]: JSON.stringify({ extends: "../../tsconfig.json", include: ["src/**/*"] }, null, 2),
       ["tstyche.config.json"]: JSON.stringify(config, null, 2),
     });
 


### PR DESCRIPTION
Fixes #472

When the `tsconfig` option is used to provide path to TSConfig file explicitly, the default compiler option must be used when file is not included.