### PR TITLE
feat: bring back support for TypeScript `>=4.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "5.8.3"
   },
   "peerDependencies": {
-    "typescript": "5.x"
+    "typescript": ">=4.7"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -4,6 +4,7 @@ import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
 import { Path } from "#path";
 import { Select } from "#select";
+import { Version } from "#version";
 
 export class ProjectService {
   #compiler: typeof ts;
@@ -64,7 +65,6 @@ export class ProjectService {
 
   #getDefaultCompilerOptions() {
     const defaultCompilerOptions: ts.server.protocol.CompilerOptions = {
-      allowImportingTsExtensions: true,
       allowJs: true,
       checkJs: true,
       exactOptionalPropertyTypes: true,
@@ -75,8 +75,12 @@ export class ProjectService {
       resolveJsonModule: true,
       strict: true,
       target: this.#compiler.ScriptTarget.ESNext,
-      verbatimModuleSyntax: true,
     };
+
+    if (Version.isSatisfiedWith(this.#compiler.version, "5.0")) {
+      defaultCompilerOptions.allowImportingTsExtensions = true;
+      defaultCompilerOptions.verbatimModuleSyntax = true;
+    }
 
     return defaultCompilerOptions;
   }

--- a/source/store/ManifestService.ts
+++ b/source/store/ManifestService.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { Diagnostic } from "#diagnostic";
 import { Path } from "#path";
+import { Version } from "#version";
 import type { Fetcher } from "./Fetcher.js";
 import { Manifest } from "./Manifest.js";
 import { StoreDiagnosticText } from "./StoreDiagnosticText.js";
@@ -18,7 +19,6 @@ export class ManifestService {
   #manifestFilePath: string;
   #npmRegistry: string;
   #storePath: string;
-  #supportedVersionRegex = /^(5)\.\d\.\d$/;
 
   constructor(storePath: string, npmRegistry: string, fetcher: Fetcher) {
     this.#storePath = storePath;
@@ -61,7 +61,7 @@ export class ManifestService {
     const packageMetadata = (await response.json()) as PackageMetadata;
 
     for (const [tag, meta] of Object.entries(packageMetadata.versions)) {
-      if (this.#supportedVersionRegex.test(tag)) {
+      if (!tag.includes("-") && Version.isSatisfiedWith(tag, "4.7.2")) {
         versions.push(tag);
 
         packages[tag] = { integrity: meta.dist.integrity, tarball: meta.dist.tarball };

--- a/source/store/PackageService.ts
+++ b/source/store/PackageService.ts
@@ -29,6 +29,11 @@ export class PackageService {
       const targetPath = `${packagePath}-${Math.random().toString(32).slice(2)}`;
 
       for await (const file of TarReader.extract(response.body)) {
+        // TODO remove this check after dropping support for TypeScript 4.8
+        if (!file.name.startsWith("package/")) {
+          continue;
+        }
+
         const filePath = Path.join(targetPath, file.name.replace("package/", ""));
         const directoryPath = Path.dirname(filePath);
 

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -110,6 +110,50 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 const storeUrl = new URL("./.store/", fixtureUrl);
 
+await test("TypeScript 4.x", async (t) => {
+  t.after(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await writeFixture(fixtureUrl, {
+    ["__typetests__/subtype.test.ts"]: `import { omit, pick } from "tstyche"\n${subtypeTestText}`,
+    ["__typetests__/toAcceptProps.test.tsx"]: toAcceptPropsTestText,
+    ["__typetests__/toBe.test.ts"]: toBeTestText,
+    ["__typetests__/toBeAssignableTo.test.ts"]: toBeAssignableToTestText,
+    ["__typetests__/toBeAssignableWith.test.ts"]: toBeAssignableWithTestText,
+    ["__typetests__/toHaveProperty.test.ts"]: toHavePropertyTestText,
+    ["__typetests__/toRaiseError.test.ts"]: toRaiseErrorTestText,
+  });
+
+  await spawnTyche(fixtureUrl, ["--update"]);
+
+  const manifestText = await fs.readFile(new URL("./store-manifest.json", storeUrl), { encoding: "utf8" });
+
+  const { resolutions } = /** @type {{ resolutions: Record<string, string> }} */ (JSON.parse(manifestText));
+
+  const versions = Object.entries(resolutions)
+    .filter((resolution) => resolution[0].startsWith("4"))
+    .map((resolution) => resolution[1]);
+
+  const testCases = ["4.7.2", ...versions];
+
+  for (const version of testCases) {
+    await t.test(`uses TypeScript ${version} as current target`, async () => {
+      await spawnTyche(fixtureUrl, ["--fetch", "--target", version]);
+
+      const typescriptModule = new URL(`./typescript@${version}/lib/typescript.js`, storeUrl).toString();
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", "current"], {
+        env: { ["TSTYCHE_TYPESCRIPT_MODULE"]: typescriptModule },
+      });
+
+      assert.match(stdout, new RegExp(`^uses TypeScript ${version}\n`));
+      assert.equal(stderr, "");
+      assert.equal(exitCode, 0);
+    });
+  }
+});
+
 await test("TypeScript 5.x", async (t) => {
   t.after(async () => {
     await clearFixture(fixtureUrl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,7 +2419,7 @@ __metadata:
     tslib: "npm:2.8.1"
     typescript: "npm:5.8.3"
   peerDependencies:
-    typescript: 5.x
+    typescript: ">=4.7"
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
Bringing back support for TypeScript `>=4.7`. This was suggested by one user in https://github.com/tstyche/tstyche/issues/472#issuecomment-2851488722

TypeScript 4.7 was released on May 24, 2022 (roughly three years ago) and it was the first version with modern `node16` module resolution. I think it is fine to keep it around for some time.