### PR TITLE
fix: prepend comma on before expression statements in the ability layer

### DIFF
--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -4,7 +4,7 @@ import type { ResolvedConfig } from "#config";
 import { diagnosticBelongsToNode } from "#diagnostic";
 import type { ProjectService } from "#project";
 import type { WhenNode } from "./WhenNode.js";
-import { nodeBelongsToArgumentList } from "./helpers.js";
+import { nodeIsChildOfExpressionStatement } from "./helpers.js";
 
 interface TextRange {
   start: number;
@@ -111,7 +111,7 @@ export class AbilityLayer {
           {
             start: whenStart,
             end: whenExpressionEnd,
-            replacement: nodeBelongsToArgumentList(this.#compiler, whenNode.actionNode) ? "" : ";",
+            replacement: nodeIsChildOfExpressionStatement(this.#compiler, whenNode.actionNode) ? ";" : "",
           },
           { start: whenEnd, end: actionNameEnd },
         ]);
@@ -142,7 +142,7 @@ export class AbilityLayer {
           {
             start: expectStart,
             end: expectExpressionEnd,
-            replacement: nodeBelongsToArgumentList(this.#compiler, assertionNode.matcherNode) ? "" : ";",
+            replacement: nodeIsChildOfExpressionStatement(this.#compiler, assertionNode.matcherNode) ? ";" : "",
           },
           { start: expectEnd, end: matcherNameEnd },
         ]);
@@ -156,7 +156,7 @@ export class AbilityLayer {
           {
             start: expectStart,
             end: expectExpressionEnd,
-            replacement: nodeBelongsToArgumentList(this.#compiler, assertionNode.matcherNode) ? "new" : "; new",
+            replacement: nodeIsChildOfExpressionStatement(this.#compiler, assertionNode.matcherNode) ? "; new" : "new",
           },
           { start: expectEnd, end: matcherNameEnd },
         ]);

--- a/source/collect/helpers.ts
+++ b/source/collect/helpers.ts
@@ -1,11 +1,7 @@
 import type ts from "typescript";
 
 export function nodeBelongsToArgumentList(compiler: typeof ts, node: ts.Node): boolean {
-  if (compiler.isCallExpression(node.parent)) {
-    return node.parent.arguments.some((argument) => argument === node);
-  }
-
-  return false;
+  return compiler.isCallExpression(node.parent) && node.parent.arguments.some((argument) => argument === node);
 }
 
 export function nodeIsChildOfExpressionStatement(compiler: typeof ts, node: ts.Node): boolean {

--- a/source/collect/helpers.ts
+++ b/source/collect/helpers.ts
@@ -7,3 +7,7 @@ export function nodeBelongsToArgumentList(compiler: typeof ts, node: ts.Node): b
 
   return false;
 }
+
+export function nodeIsChildOfExpressionStatement(compiler: typeof ts, node: ts.Node): boolean {
+  return compiler.isExpressionStatement(node.parent);
+}


### PR DESCRIPTION
Prepend comma on before expression statements in the ability layer.

I found a case where `expect()` can be used as a body of an arrow function: `const x = () => expect...`. Probably there are other cases.