### PR TITLE
feat: add the `.toHaveCallSignatures()` matcher

### DIFF
--- a/source/expect/ExpectDiagnosticText.ts
+++ b/source/expect/ExpectDiagnosticText.ts
@@ -117,6 +117,10 @@ export class ExpectDiagnosticText {
     return `Type '${typeText}' requires property '${propertyNameText}'.`;
   }
 
+  static typeArgumentMustBeOmitted(argumentNameText: string, signatureKindText: string): string {
+    return `The '${argumentNameText}' type argument must be omitted or have at least one ${signatureKindText} signature.`;
+  }
+
   static typesOfPropertyAreNotCompatible(propertyNameText: string): string {
     return `Types of property '${propertyNameText}' are not compatible.`;
   }

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -12,6 +12,7 @@ import { ToBeAssignableTo } from "./ToBeAssignableTo.js";
 import { ToBeAssignableWith } from "./ToBeAssignableWith.js";
 import { ToBeCallableWith } from "./ToBeCallableWith.js";
 import { ToBeConstructableWith } from "./ToBeConstructableWith.js";
+import { ToHaveCallSignatures } from "./ToHaveCallSignatures.js";
 import { ToHaveProperty } from "./ToHaveProperty.js";
 import { ToRaiseError } from "./ToRaiseError.js";
 import type { MatchResult, TypeChecker } from "./types.js";
@@ -28,6 +29,7 @@ export class ExpectService {
   private toBeAssignableWith: ToBeAssignableWith;
   private toBeCallableWith: ToBeCallableWith;
   private toBeConstructableWith: ToBeConstructableWith;
+  private toHaveCallSignatures: ToHaveCallSignatures;
   private toHaveProperty: ToHaveProperty;
   private toRaiseError: ToRaiseError;
 
@@ -43,6 +45,7 @@ export class ExpectService {
     this.toBeAssignableWith = new ToBeAssignableWith();
     this.toBeCallableWith = new ToBeCallableWith(compiler);
     this.toBeConstructableWith = new ToBeConstructableWith(compiler);
+    this.toHaveCallSignatures = new ToHaveCallSignatures(compiler, typeChecker);
     this.toHaveProperty = new ToHaveProperty(compiler);
     this.toRaiseError = new ToRaiseError(compiler);
   }
@@ -107,6 +110,9 @@ export class ExpectService {
       case "toRaiseError":
         // biome-ignore lint/style/noNonNullAssertion: collect logic makes sure that 'target' is defined
         return this[matcherNameText].match(matchWorker, assertion.source[0], assertion.target!, onDiagnostics);
+
+      case "toHaveCallSignatures":
+        return this.toHaveCallSignatures.match(matchWorker, assertion.source[0], assertion.target?.[0], onDiagnostics);
 
       case "toHaveProperty":
         if (!argumentIsProvided("key", assertion.target?.[0], assertion.matcherNameNode.name, onDiagnostics)) {

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -15,6 +15,27 @@ export class MatchWorker {
     this.assertion = assertion;
   }
 
+  areSignaturesIdentical(sourceSignatures: ReadonlyArray<ts.Signature>, targetSignatures: ReadonlyArray<ts.Signature>) {
+    if (sourceSignatures.length !== targetSignatures.length) {
+      return false;
+    }
+
+    for (let index = 0; index < sourceSignatures.length; index++) {
+      if (
+        !this.checkIsIdenticalTo(
+          // biome-ignore lint/style/noNonNullAssertion: lengths were checked
+          sourceSignatures[index]!.getDeclaration(),
+          // biome-ignore lint/style/noNonNullAssertion: lengths were checked
+          targetSignatures[index]!.getDeclaration(),
+        )
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   checkHasApplicableIndexType(sourceNode: ts.Node, targetNode: ts.Node): boolean {
     const sourceType = this.getType(sourceNode);
     const targetType = this.getType(targetNode);

--- a/source/expect/ToHaveCallSignatures.ts
+++ b/source/expect/ToHaveCallSignatures.ts
@@ -1,0 +1,72 @@
+import type ts from "typescript";
+import { nodeBelongsToArgumentList } from "#collect";
+import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
+import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
+import type { MatchWorker } from "./MatchWorker.js";
+import type { ArgumentNode, MatchResult, TypeChecker } from "./types.js";
+
+export class ToHaveCallSignatures {
+  #compiler: typeof ts;
+  #typeChecker: TypeChecker;
+
+  constructor(compiler: typeof ts, typeChecker: TypeChecker) {
+    this.#compiler = compiler;
+    this.#typeChecker = typeChecker;
+  }
+
+  #explain(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNode: ArgumentNode | undefined) {
+    const isExpression = nodeBelongsToArgumentList(this.#compiler, sourceNode);
+
+    if (!targetNode) {
+      const text = matchWorker.assertion.isNot
+        ? `The source ${isExpression ? "expression" : "type"} has call signatures.`
+        : `The source ${isExpression ? "expression" : "type"} does not have call signatures.`;
+
+      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+
+      return [Diagnostic.error(text, origin)];
+    }
+
+    const text = matchWorker.assertion.isNot
+      ? `The source ${isExpression ? "expression" : "type"} has the same call signatures.`
+      : `The source ${isExpression ? "expression" : "type"} does not have the same call signatures.`; // TODO this branch should explain the difference
+
+    const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+
+    return [Diagnostic.error(text, origin)];
+  }
+
+  match(
+    matchWorker: MatchWorker,
+    sourceNode: ArgumentNode,
+    targetNode: ArgumentNode | undefined,
+    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
+  ): MatchResult | undefined {
+    const sourceType = this.#typeChecker.getTypeAtLocation(sourceNode);
+    const sourceSignatures = sourceType.getCallSignatures();
+
+    if (!targetNode) {
+      return {
+        explain: () => this.#explain(matchWorker, sourceNode, targetNode),
+        isMatch: sourceSignatures.length > 0,
+      };
+    }
+
+    const targetType = this.#typeChecker.getTypeAtLocation(targetNode);
+    const targetSignatures = targetType.getCallSignatures();
+
+    if (targetSignatures.length === 0) {
+      const text = ExpectDiagnosticText.typeArgumentMustBeOmitted("Target", "call");
+      const origin = DiagnosticOrigin.fromNode(targetNode);
+
+      onDiagnostics([Diagnostic.error(text, origin)]);
+
+      return;
+    }
+
+    return {
+      explain: () => this.#explain(matchWorker, sourceNode, targetNode),
+      isMatch: matchWorker.areSignaturesIdentical(sourceSignatures, targetSignatures),
+    };
+  }
+}

--- a/source/types.ts
+++ b/source/types.ts
@@ -138,6 +138,10 @@ interface Matchers {
    */
   toBeConstructableWith: (...target: Array<unknown>) => void;
   /**
+   * Checks if the source type has given signatures.
+   */
+  toHaveCallSignatures: <Target>() => void;
+  /**
    * Checks if a property key exists on the source type.
    */
   toHaveProperty: (key: string | number | symbol) => void;


### PR DESCRIPTION
First half of #484 and #485

Adding the `.toHaveCallSignatures()` matcher.

Examples and test will follow.