### PR TITLE
chore: use Node.js LTS version to collect coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           check-latest: true
-          node-version: 20
+          node-version: lts/*
       - run: corepack enable
       - run: yarn install
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
Bumping Node.js version used to collect coverage.