### PR TITLE
feat: allow adding notes to the directive comments

### DIFF
--- a/source/config/Directive.ts
+++ b/source/config/Directive.ts
@@ -21,6 +21,7 @@ export interface DirectiveRange {
 }
 
 export class Directive {
+  static #commentSeparatorRegex = /--+/;
   static #directiveRegex = /^(\/\/\s*@tstyche)(\s*|-)?(\S*)?(\s*)?(.*)?/i;
 
   static getDirectiveRanges(
@@ -62,7 +63,8 @@ export class Directive {
   }
 
   static #getRange(sourceFile: ts.SourceFile, comment: ts.CommentRange) {
-    const found = sourceFile.text.substring(comment.pos, comment.end).match(Directive.#directiveRegex);
+    const [text] = sourceFile.text.substring(comment.pos, comment.end).split(Directive.#commentSeparatorRegex);
+    const found = text?.match(Directive.#directiveRegex);
 
     const namespaceText = found?.[1];
 

--- a/tests/__snapshots__/directive-if-target-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-with-note-stdout.snap.txt
@@ -1,0 +1,23 @@
+adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
+uses TypeScript 5.5.4 with ./tsconfig.json
+
+pass ./__typetests__/isString.tst.ts
+  - skip is string?
+
+adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
+uses TypeScript 5.6.3 with ./tsconfig.json
+
+pass ./__typetests__/isString.tst.ts
+  + is string?
+
+adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.7.3
+uses TypeScript 5.7.3 with ./tsconfig.json
+
+pass ./__typetests__/isString.tst.ts
+  - skip is string?
+
+Targets:    3 passed, 3 total
+Test files: 3 passed, 3 total
+Tests:      2 skipped, 1 passed, 3 total
+Assertions: 2 skipped, 1 passed, 3 total
+Duration:   <<timestamp>>

--- a/tests/directive-if-target.test.js
+++ b/tests/directive-if-target.test.js
@@ -211,8 +211,62 @@ await test("'// @tstyche if { target: <range> }' directive", async (t) => {
     assert.equal(exitCode, 0);
   });
 
+  await t.test("when specified with a note", async () => {
+    const isStringTestText = `// @tstyche if { target: ["5.6"] } -- For lower versions, the inferred type is 'unknown'.
+
+import { expect, test } from "tstyche";
+
+test("is string?", () => {
+  expect<string>().type.toBe<string>();
+});
+`;
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '">=5.5 <5.8"']);
+
+    assert.equal(stderr, "");
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-with-note-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
   await t.test("when specified in kebab case", async () => {
     const isStringTestText = `//@tstyche-if { target: ["5.6"] }
+
+import { expect, test } from "tstyche";
+
+test("is string?", () => {
+  expect<string>().type.toBe<string>();
+});
+`;
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/isString.tst.ts"]: isStringTestText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '">=5.5 <5.8"']);
+
+    assert.equal(stderr, "");
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-kebab-case-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when specified in kebab case with a note", async () => {
+    const isStringTestText = `//@tstyche-if { target: ["5.6"] } --- For lower versions, the inferred type is 'unknown'.
 
 import { expect, test } from "tstyche";
 

--- a/tests/directive-template.test.js
+++ b/tests/directive-template.test.js
@@ -68,9 +68,59 @@ await test("'// @tstyche template' directive", async (t) => {
     assert.equal(exitCode, 1);
   });
 
+  await t.test("when specified with a note", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/template.tst.ts"]: getTemplateTestText(
+        "// @tstyche template -- For documentation, see: https://tstyche.org/guide/template-test-files.",
+      ),
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
+      env: { ["NODE_OPTIONS"]: "--experimental-strip-types --no-warnings" },
+    });
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
   await t.test("when specified in kebab case", async () => {
     await writeFixture(fixtureUrl, {
       ["__typetests__/template.tst.ts"]: getTemplateTestText("//@tstyche-template"),
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
+      env: { ["NODE_OPTIONS"]: "--experimental-strip-types --no-warnings" },
+    });
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when specified in kebab case with a note", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/template.tst.ts"]: getTemplateTestText(
+        "//@tstyche-template --- For documentation, see: https://tstyche.org/guide/template-test-files.",
+      ),
       ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
     });
 


### PR DESCRIPTION
The directives are comments. Adding a note with explanation is useful. The note text must be separated by two or more dashes:

```ts
// @tstyche template -- For documentation, see: https://tstyche.org/guide/template-test-files.
```

```ts
// @tstyche if { target: [">=5.7"] } -- For lower versions, the inferred type is 'unknown'.
```