### PR TITLE
feat: Make it possible to skip tests or assertions conditionally

### DIFF
--- a/source/collect/CollectService.ts
+++ b/source/collect/CollectService.ts
@@ -1,5 +1,5 @@
 import type ts from "typescript";
-import { Directive, type InlineConfig, type ResolvedConfig } from "#config";
+import type { ResolvedConfig } from "#config";
 import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
 import { EventEmitter } from "#events";
 import type { ProjectService } from "#project";
@@ -148,16 +148,8 @@ export class CollectService {
     });
   }
 
-  async createTestTree(sourceFile: ts.SourceFile, semanticDiagnostics: Array<ts.Diagnostic> = []): Promise<TestTree> {
-    const directiveRanges = Directive.getDirectiveRanges(this.#compiler, sourceFile);
-
-    let inlineConfig: InlineConfig | undefined;
-
-    if (directiveRanges != null) {
-      inlineConfig = await Directive.getInlineConfig(directiveRanges, sourceFile);
-    }
-
-    const testTree = new TestTree(new Set(semanticDiagnostics), sourceFile, inlineConfig);
+  createTestTree(sourceFile: ts.SourceFile, semanticDiagnostics: Array<ts.Diagnostic> = []): TestTree {
+    const testTree = new TestTree(this.#compiler, new Set(semanticDiagnostics), sourceFile);
 
     EventEmitter.dispatch(["collect:start", { tree: testTree }]);
 

--- a/source/collect/TestTree.ts
+++ b/source/collect/TestTree.ts
@@ -1,19 +1,33 @@
 import type ts from "typescript";
-import type { InlineConfig } from "#config";
+import { Directive, type DirectiveRange, type InlineConfig } from "#config";
 import type { AssertionNode } from "./AssertionNode.js";
 import type { TestTreeNode } from "./TestTreeNode.js";
 import type { WhenNode } from "./WhenNode.js";
 
 export class TestTree {
   children: Array<TestTreeNode | AssertionNode | WhenNode> = [];
+  #compiler: typeof ts;
   diagnostics: Set<ts.Diagnostic>;
   hasOnly = false;
-  inlineConfig: InlineConfig | undefined;
   sourceFile: ts.SourceFile;
 
-  constructor(diagnostics: Set<ts.Diagnostic>, sourceFile: ts.SourceFile, inlineConfig: InlineConfig | undefined) {
+  constructor(compiler: typeof ts, diagnostics: Set<ts.Diagnostic>, sourceFile: ts.SourceFile) {
+    this.#compiler = compiler;
     this.diagnostics = diagnostics;
     this.sourceFile = sourceFile;
-    this.inlineConfig = inlineConfig;
+  }
+
+  getDirectiveRanges(): Array<DirectiveRange> | undefined {
+    return Directive.getDirectiveRanges(this.#compiler, this.sourceFile);
+  }
+
+  async getInlineConfig(): Promise<InlineConfig | undefined> {
+    const directiveRanges = this.getDirectiveRanges();
+
+    if (directiveRanges != null) {
+      return await Directive.getInlineConfig(directiveRanges, this.sourceFile);
+    }
+
+    return;
   }
 }

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -76,18 +76,16 @@ export class TaskRunner {
       return;
     }
 
-    const testTree = await this.#collectService.createTestTree(sourceFile, semanticDiagnostics);
+    const testTree = this.#collectService.createTestTree(sourceFile, semanticDiagnostics);
 
-    if (
-      testTree?.inlineConfig?.if?.target != null &&
-      !Version.isIncluded(this.#compiler.version, testTree.inlineConfig.if.target)
-    ) {
+    const inlineConfig = await testTree.getInlineConfig();
+
+    if (inlineConfig?.if?.target != null && !Version.isIncluded(this.#compiler.version, inlineConfig.if.target)) {
       runMode |= RunMode.Skip;
     }
 
-    if (testTree?.inlineConfig?.template) {
+    if (inlineConfig?.template) {
       // TODO testTree.children must be not allowed in template files
-      //      since the 'CollectService' knows it deals with a template file, this can be validated early
 
       if (semanticDiagnostics != null && semanticDiagnostics.length > 0) {
         this.#onDiagnostics(Diagnostic.fromDiagnostics(semanticDiagnostics), taskResult);
@@ -147,6 +145,6 @@ export class TaskRunner {
       },
     );
 
-    testTreeWalker.visit(facts.testTree.children, facts.runMode, /* parentResult */ undefined);
+    await testTreeWalker.visit(facts.testTree.children, facts.runMode, /* parentResult */ undefined);
   }
 }

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -7,6 +7,7 @@ import { ExpectService, type TypeChecker } from "#expect";
 import { Reject } from "#reject";
 import { DescribeResult, ExpectResult, TestResult } from "#result";
 import type { CancellationToken } from "#token";
+import { Version } from "#version";
 import { WhenService } from "#when";
 import type { WhenNode } from "../collect/WhenNode.js";
 import { RunMode } from "./RunMode.enum.js";
@@ -19,6 +20,7 @@ interface TestTreeWalkerOptions {
 
 export class TestTreeWalker {
   #cancellationToken: CancellationToken | undefined;
+  #compiler: typeof ts;
   #expectService: ExpectService;
   #hasOnly: boolean;
   #onTaskDiagnostics: DiagnosticsHandler<Array<Diagnostic>>;
@@ -33,6 +35,7 @@ export class TestTreeWalker {
     onTaskDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
     options: TestTreeWalkerOptions,
   ) {
+    this.#compiler = compiler;
     this.#resolvedConfig = resolvedConfig;
     this.#onTaskDiagnostics = onTaskDiagnostics;
 
@@ -46,32 +49,36 @@ export class TestTreeWalker {
     this.#whenService = new WhenService(reject, onTaskDiagnostics);
   }
 
-  #resolveRunMode(mode: RunMode, testNode: TestTreeNode): RunMode {
-    if (testNode.flags & TestTreeNodeFlags.Fail) {
+  async #resolveRunMode(mode: RunMode, node: TestTreeNode) {
+    const inlineConfig = await node.getInlineConfig();
+
+    if (inlineConfig?.if?.target != null && !Version.isIncluded(this.#compiler.version, inlineConfig.if.target)) {
+      mode |= RunMode.Skip;
+    }
+
+    if (node.flags & TestTreeNodeFlags.Fail) {
       mode |= RunMode.Fail;
     }
 
     if (
-      testNode.flags & TestTreeNodeFlags.Only ||
-      (this.#resolvedConfig.only != null &&
-        testNode.name.toLowerCase().includes(this.#resolvedConfig.only.toLowerCase()))
+      node.flags & TestTreeNodeFlags.Only ||
+      (this.#resolvedConfig.only != null && node.name.toLowerCase().includes(this.#resolvedConfig.only.toLowerCase()))
     ) {
       mode |= RunMode.Only;
     }
 
     if (
-      testNode.flags & TestTreeNodeFlags.Skip ||
-      (this.#resolvedConfig.skip != null &&
-        testNode.name.toLowerCase().includes(this.#resolvedConfig.skip.toLowerCase()))
+      node.flags & TestTreeNodeFlags.Skip ||
+      (this.#resolvedConfig.skip != null && node.name.toLowerCase().includes(this.#resolvedConfig.skip.toLowerCase()))
     ) {
       mode |= RunMode.Skip;
     }
 
-    if (testNode.flags & TestTreeNodeFlags.Todo) {
+    if (node.flags & TestTreeNodeFlags.Todo) {
       mode |= RunMode.Todo;
     }
 
-    if (this.#position != null && testNode.node.getStart() === this.#position) {
+    if (this.#position != null && node.node.getStart() === this.#position) {
       mode |= RunMode.Only;
       // skip mode is overridden, when 'position' is specified
       mode &= ~RunMode.Skip;
@@ -80,11 +87,11 @@ export class TestTreeWalker {
     return mode;
   }
 
-  visit(
+  async visit(
     nodes: Array<TestTreeNode | AssertionNode | WhenNode>,
     runMode: RunMode,
     parentResult: DescribeResult | TestResult | undefined,
-  ): void {
+  ): Promise<void> {
     for (const node of nodes) {
       if (this.#cancellationToken?.isCancellationRequested) {
         break;
@@ -92,15 +99,15 @@ export class TestTreeWalker {
 
       switch (node.brand) {
         case TestTreeNodeBrand.Describe:
-          this.#visitDescribe(node, runMode, parentResult as DescribeResult | undefined);
+          await this.#visitDescribe(node, runMode, parentResult as DescribeResult | undefined);
           break;
 
         case TestTreeNodeBrand.Test:
-          this.#visitTest(node, runMode, parentResult as DescribeResult | undefined);
+          await this.#visitTest(node, runMode, parentResult as DescribeResult | undefined);
           break;
 
         case TestTreeNodeBrand.Expect:
-          this.#visitAssertion(node as AssertionNode, runMode, parentResult as TestResult | undefined);
+          await this.#visitAssertion(node as AssertionNode, runMode, parentResult as TestResult | undefined);
           break;
 
         case TestTreeNodeBrand.When:
@@ -110,14 +117,14 @@ export class TestTreeWalker {
     }
   }
 
-  #visitAssertion(assertion: AssertionNode, runMode: RunMode, parentResult: TestResult | undefined) {
-    this.visit(assertion.children, runMode, parentResult);
+  async #visitAssertion(assertion: AssertionNode, runMode: RunMode, parentResult: TestResult | undefined) {
+    await this.visit(assertion.children, runMode, parentResult);
 
     const expectResult = new ExpectResult(assertion, parentResult);
 
     EventEmitter.dispatch(["expect:start", { result: expectResult }]);
 
-    runMode = this.#resolveRunMode(runMode, assertion);
+    runMode = await this.#resolveRunMode(runMode, assertion);
 
     if (runMode & RunMode.Skip || (this.#hasOnly && !(runMode & RunMode.Only))) {
       EventEmitter.dispatch(["expect:skip", { result: expectResult }]);
@@ -161,12 +168,12 @@ export class TestTreeWalker {
     }
   }
 
-  #visitDescribe(describe: TestTreeNode, runMode: RunMode, parentResult: DescribeResult | undefined) {
+  async #visitDescribe(describe: TestTreeNode, runMode: RunMode, parentResult: DescribeResult | undefined) {
     const describeResult = new DescribeResult(describe, parentResult);
 
     EventEmitter.dispatch(["describe:start", { result: describeResult }]);
 
-    runMode = this.#resolveRunMode(runMode, describe);
+    runMode = await this.#resolveRunMode(runMode, describe);
 
     if (
       !(runMode & RunMode.Skip || (this.#hasOnly && !(runMode & RunMode.Only)) || runMode & RunMode.Todo) &&
@@ -174,18 +181,18 @@ export class TestTreeWalker {
     ) {
       this.#onTaskDiagnostics(Diagnostic.fromDiagnostics([...describe.diagnostics]));
     } else {
-      this.visit(describe.children, runMode, describeResult);
+      await this.visit(describe.children, runMode, describeResult);
     }
 
     EventEmitter.dispatch(["describe:end", { result: describeResult }]);
   }
 
-  #visitTest(test: TestTreeNode, runMode: RunMode, parentResult: DescribeResult | undefined) {
+  async #visitTest(test: TestTreeNode, runMode: RunMode, parentResult: DescribeResult | undefined) {
     const testResult = new TestResult(test, parentResult);
 
     EventEmitter.dispatch(["test:start", { result: testResult }]);
 
-    runMode = this.#resolveRunMode(runMode, test);
+    runMode = await this.#resolveRunMode(runMode, test);
 
     if (runMode & RunMode.Todo) {
       EventEmitter.dispatch(["test:todo", { result: testResult }]);
@@ -205,7 +212,7 @@ export class TestTreeWalker {
       return;
     }
 
-    this.visit(test.children, runMode, testResult);
+    await this.visit(test.children, runMode, testResult);
 
     if (runMode & RunMode.Skip || (this.#hasOnly && !(runMode & RunMode.Only))) {
       EventEmitter.dispatch(["test:skip", { result: testResult }]);


### PR DESCRIPTION
Closes #429

This PR makes it possible to use the `// @tstyche if` directive to skip tests or assertions conditionally:

```ts
import { expect, test } from "tstyche";

type Awaitable<T> = T | PromiseLike<T>;

// @tstyche if { target: [">=5.6"] }
test("is assignable with?", () => {
  expect<Awaitable<string>>().type.toBeAssignableWith("abc");
  expect<Awaitable<string>>().type.toBeAssignableWith(Promise.resolve("abc"));

  // @tstyche if { target: ["5.7"] }
  expect<Awaitable<string>>().type.not.toBeAssignableWith(123);
  expect<Awaitable<string>>().type.not.toBeAssignableWith(Promise.resolve(123));
});
```