### PR TITLE
fix: allow skipping `target` type errors

### DIFF
--- a/examples/conditional.tst.ts
+++ b/examples/conditional.tst.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "tstyche";
+
+const isUint8Array = (input: unknown): input is Uint8Array => input instanceof Uint8Array;
+
+test("isUint8Array", () => {
+  const unknowns: ReadonlyArray<unknown> = [];
+
+  // @tstyche if { target: [">=5.7"] }
+  expect(unknowns.filter(isUint8Array)).type.toBe<Array<Uint8Array<ArrayBufferLike>>>();
+
+  // @tstyche if { target: ["<5.7"] } -- Before TypeScript 5.7, 'Uint8Array' was not generic
+  // Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#typedarrays-are-now-generic-over-arraybufferlike
+  expect(unknowns.filter(isUint8Array)).type.toBe<Array<Uint8Array>>();
+});

--- a/source/collect/AssertionNode.ts
+++ b/source/collect/AssertionNode.ts
@@ -39,7 +39,10 @@ export class AssertionNode extends TestTreeNode {
     }
 
     for (const diagnostic of parent.diagnostics) {
-      if (diagnosticBelongsToNode(diagnostic, this.source)) {
+      if (
+        diagnosticBelongsToNode(diagnostic, this.source) ||
+        (this.target != null && diagnosticBelongsToNode(diagnostic, this.target))
+      ) {
         this.diagnostics.add(diagnostic);
         parent.diagnostics.delete(diagnostic);
       }

--- a/tests/__fixtures__/api-expect/__typetests__/expect-skip.tst.ts
+++ b/tests/__fixtures__/api-expect/__typetests__/expect-skip.tst.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "tstyche";
 
+type One = () => void;
+declare const one: One;
+
 expect<string>().type.toBe<string>();
 expect.skip<never>().type.toBe<string>();
 
@@ -39,3 +42,13 @@ test.skip("is skipped?", () => {
 });
 
 test.todo("is todo?");
+
+test("skips source type error?", () => {
+  expect.skip(one("pass")).type.toRaiseError();
+
+  expect.skip(one("fail")).type.toBe<void>();
+});
+
+test("skips target type error?", () => {
+  expect.skip<void>().type.toBe(one("fail"));
+});

--- a/tests/__snapshots__/api-expect-skip-stdout.snap.txt
+++ b/tests/__snapshots__/api-expect-skip-stdout.snap.txt
@@ -9,9 +9,11 @@ pass ./__typetests__/expect-skip.tst.ts
   + is assignable?
   - skip is skipped?
   - todo is todo?
+  + skips source type error?
+  + skips target type error?
 
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
-Tests:      2 skipped, 1 todo, 3 passed, 6 total
-Assertions: 7 skipped, 4 passed, 11 total
+Tests:      2 skipped, 1 todo, 5 passed, 8 total
+Assertions: 10 skipped, 4 passed, 14 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
It should be allowed to skip `target` type errors as well.