### PR TITLE
feat: add the `// @tstyche broken` directive

### DIFF
--- a/source/config/Directive.ts
+++ b/source/config/Directive.ts
@@ -122,6 +122,7 @@ export class Directive {
         }
         return;
 
+      case "broken":
       case "template":
         if (ranges.argument?.text != null) {
           const text = DirectiveDiagnosticText.doesNotTakeArgument(ranges.directive.text);
@@ -130,7 +131,7 @@ export class Directive {
           Directive.#onDiagnostics(Diagnostic.error(text, origin));
         }
 
-        inlineConfig.template = true;
+        inlineConfig[ranges.directive?.text] = true;
         return;
     }
 

--- a/source/config/types.ts
+++ b/source/config/types.ts
@@ -7,6 +7,7 @@ export type { CommandLineOptions } from "../../models/CommandLineOptions.js";
 export type OptionValue = Array<OptionValue> | string | number | boolean | null | undefined;
 
 export interface InlineConfig {
+  broken?: boolean;
   if?: { target?: Array<string> };
   template?: boolean;
 }

--- a/source/diagnostic/DiagnosticOrigin.ts
+++ b/source/diagnostic/DiagnosticOrigin.ts
@@ -8,9 +8,14 @@ export class DiagnosticOrigin {
   sourceFile: SourceFile | ts.SourceFile;
   start: number;
 
-  constructor(start: number, end: number, sourceFile: SourceFile | ts.SourceFile, assertion?: AssertionNode) {
+  constructor(
+    start: number,
+    end: number | undefined,
+    sourceFile: SourceFile | ts.SourceFile,
+    assertion?: AssertionNode,
+  ) {
     this.start = start;
-    this.end = end;
+    this.end = end ?? start + 1;
     this.sourceFile = sourceFile;
     this.assertion = assertion;
   }

--- a/source/runner/RunMode.enum.ts
+++ b/source/runner/RunMode.enum.ts
@@ -1,6 +1,6 @@
 export const enum RunMode {
   Normal = 0,
-  Fail = 1 << 0,
+  Broken = 1 << 0,
   Only = 1 << 1,
   Skip = 1 << 2,
   Todo = 1 << 3,

--- a/source/runner/RunnerDiagnosticText.ts
+++ b/source/runner/RunnerDiagnosticText.ts
@@ -1,0 +1,9 @@
+export class RunnerDiagnosticText {
+  static considerRemoving(target: string): string {
+    return `Consider removing the ${target}.`;
+  }
+
+  static assertionSupposedTo(action: string): string {
+    return `The assertion was supposed to ${action}, but it passed.`;
+  }
+}

--- a/tests/__snapshots__/validation-broken-does-not-take-argument-stderr.snap.txt
+++ b/tests/__snapshots__/validation-broken-does-not-take-argument-stderr.snap.txt
@@ -1,0 +1,11 @@
+Error: Directive 'broken' does not take an argument.
+
+  1 | import { expect } from "tstyche";
+  2 | 
+  3 | // @tstyche broken true
+    |             ~~~~~~
+  4 | expect<string>().type.toBe<number>();
+  5 | 
+
+      at ./__typetests__/sample.tst.ts:3:13
+

--- a/tests/__snapshots__/validation-broken-does-not-take-argument-stdout.snap.txt
+++ b/tests/__snapshots__/validation-broken-does-not-take-argument-stdout.snap.txt
@@ -1,0 +1,8 @@
+uses TypeScript <<version>>
+
+fail ./__typetests__/sample.tst.ts
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Assertions: 1 passed, 1 total
+Duration:   <<timestamp>>

--- a/tests/validation-broken.test.js
+++ b/tests/validation-broken.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'// @tstyche broken' directive", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("does not take an argument", async () => {
+    const testFileText = `import { expect } from "tstyche";
+
+// @tstyche broken true
+expect<string>().type.toBe<number>();
+`;
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/sample.tst.ts"]: testFileText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-does-not-take-argument-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-does-not-take-argument-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+});


### PR DESCRIPTION
Adding the `// @tstyche broken` comment directive, which is supposed to replace the `.fail` run mode flag.

I think `.only.fail` or `.skip.fail` is somewhat too much. Turning all that into a comment directive simplifies tests and makes them more readable:

```ts
import { expect, test } from "tstyche";

type Awaitable<T> = T | PromiseLike<T>;

test("is assignable with?", () => {
  // @tstyche broken -- Known bug, see: #345.
  expect<Awaitable<number>>().type.toBeAssignableWith("abc");
});
```