### PR TITLE
fix: do not report unmatched conditional tests or assertions

### DIFF
--- a/examples/conditional.tst.ts
+++ b/examples/conditional.tst.ts
@@ -7,9 +7,9 @@ function isUint8Array(input: unknown): input is Uint8Array {
 test("isUint8Array", () => {
   const unknowns: Array<unknown> = [];
 
-  // @tstyche if { target: [">=5.7"] }
+  // @tstyche if { target: [">=5.7"] } -- Before TypeScript 5.7, 'Uint8Array' was not generic
   expect(unknowns.filter(isUint8Array)).type.toBe<Array<Uint8Array<ArrayBufferLike>>>();
 
-  // @tstyche if { target: ["<5.7"] } -- Before TypeScript 5.7, 'Uint8Array' was not generic
+  // @tstyche if { target: ["<5.7"] }
   expect(unknowns.filter(isUint8Array)).type.toBe<Array<Uint8Array>>();
 });

--- a/source/runner/RunMode.enum.ts
+++ b/source/runner/RunMode.enum.ts
@@ -4,5 +4,5 @@ export const enum RunMode {
   Only = 1 << 1,
   Skip = 1 << 2,
   Todo = 1 << 3,
-  Void = 1 << 4, // for @tstyche-if
+  Void = 1 << 4,
 }

--- a/source/runner/RunMode.enum.ts
+++ b/source/runner/RunMode.enum.ts
@@ -4,4 +4,5 @@ export const enum RunMode {
   Only = 1 << 1,
   Skip = 1 << 2,
   Todo = 1 << 3,
+  Void = 1 << 4, // for @tstyche-if
 }

--- a/tests/__snapshots__/directive-if-target-describe-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -9,22 +9,16 @@ adds TypeScript 5.3.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.3.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.4.5 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.4.5
 uses TypeScript 5.4.5 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -42,6 +36,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    6 passed, 6 total
 Test files: 6 passed, 6 total
-Tests:      3 skipped, 3 passed, 6 total
-Assertions: 3 skipped, 3 passed, 6 total
+Tests:      3 passed, 3 total
+Assertions: 3 passed, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-kebab-case-stdout.snap.txt
@@ -2,8 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -16,11 +14,9 @@ adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      2 skipped, 1 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-matching-range-stdout.snap.txt
@@ -2,8 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -21,6 +19,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      1 skipped, 2 passed, 3 total
-Assertions: 1 skipped, 2 passed, 3 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -2,8 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -16,11 +14,9 @@ adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      2 skipped, 1 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-multiple-matching-stdout.snap.txt
@@ -18,6 +18,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      4 skipped, 2 passed, 6 total
-Assertions: 4 skipped, 2 passed, 6 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-multiple-not-matching-stdout.snap.txt
@@ -18,6 +18,4 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      6 skipped, 6 total
-Assertions: 6 skipped, 6 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -2,25 +2,17 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.7.3
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      3 skipped, 3 total
-Assertions: 3 skipped, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-single-matching-stdout.snap.txt
@@ -18,6 +18,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      5 skipped, 1 passed, 6 total
-Assertions: 5 skipped, 1 passed, 6 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-single-not-matching-stdout.snap.txt
@@ -18,6 +18,4 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      6 skipped, 6 total
-Assertions: 6 skipped, 6 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-describe-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-with-note-stdout.snap.txt
@@ -2,8 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -16,11 +14,9 @@ adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  is skipped?
-    - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      2 skipped, 1 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -37,5 +37,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    6 passed, 6 total
 Test files: 6 passed, 6 total
 Tests:      6 passed, 6 total
-Assertions: 3 skipped, 3 passed, 6 total
+Assertions: 3 passed, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-kebab-case-stdout.snap.txt
@@ -19,5 +19,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
 Tests:      3 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-matching-range-stdout.snap.txt
@@ -19,5 +19,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
 Tests:      3 passed, 3 total
-Assertions: 1 skipped, 2 passed, 3 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -19,5 +19,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
 Tests:      3 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-multiple-matching-stdout.snap.txt
@@ -19,5 +19,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
 Tests:      6 passed, 6 total
-Assertions: 4 skipped, 2 passed, 6 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-multiple-not-matching-stdout.snap.txt
@@ -19,5 +19,4 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
 Tests:      6 passed, 6 total
-Assertions: 6 skipped, 6 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -19,5 +19,4 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
 Tests:      3 passed, 3 total
-Assertions: 3 skipped, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-single-matching-stdout.snap.txt
@@ -19,5 +19,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
 Tests:      6 passed, 6 total
-Assertions: 5 skipped, 1 passed, 6 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-single-not-matching-stdout.snap.txt
@@ -19,5 +19,4 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
 Tests:      6 passed, 6 total
-Assertions: 6 skipped, 6 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-expect-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-with-note-stdout.snap.txt
@@ -19,5 +19,5 @@ pass ./__typetests__/isString.tst.ts
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
 Tests:      3 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -8,19 +8,16 @@ adds TypeScript 5.3.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.3.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.4.5 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.4.5
 uses TypeScript 5.4.5 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -36,6 +33,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    6 passed, 6 total
 Test files: 6 passed, 6 total
-Tests:      3 skipped, 3 passed, 6 total
-Assertions: 3 skipped, 3 passed, 6 total
+Tests:      3 passed, 3 total
+Assertions: 3 passed, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-kebab-case-stdout.snap.txt
@@ -2,7 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -14,10 +13,9 @@ adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      2 skipped, 1 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-matching-range-stdout.snap.txt
@@ -2,7 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -18,6 +17,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      1 skipped, 2 passed, 3 total
-Assertions: 1 skipped, 2 passed, 3 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -2,7 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -14,10 +13,9 @@ adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      2 skipped, 1 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-multiple-matching-stdout.snap.txt
@@ -18,6 +18,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      4 skipped, 2 passed, 6 total
-Assertions: 4 skipped, 2 passed, 6 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-multiple-not-matching-stdout.snap.txt
@@ -18,6 +18,4 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      6 skipped, 6 total
-Assertions: 6 skipped, 6 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -2,22 +2,17 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.7.3
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      3 skipped, 3 total
-Assertions: 3 skipped, 3 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-single-matching-stdout.snap.txt
@@ -18,6 +18,6 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      5 skipped, 1 passed, 6 total
-Assertions: 5 skipped, 1 passed, 6 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-single-not-matching-stdout.snap.txt
@@ -18,6 +18,4 @@ pass ./__typetests__/isString.tst.ts
 
 Targets:    3 passed, 3 total
 Test files: 6 passed, 6 total
-Tests:      6 skipped, 6 total
-Assertions: 6 skipped, 6 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/directive-if-target-test-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-with-note-stdout.snap.txt
@@ -2,7 +2,6 @@ adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.5.4 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3 with ./tsconfig.json
@@ -14,10 +13,9 @@ adds TypeScript 5.7.3 to <<basePath>>/tests/__fixtures__/.generated/directive-if
 uses TypeScript 5.7.3 with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts
-  - skip is string?
 
 Targets:    3 passed, 3 total
 Test files: 3 passed, 3 total
-Tests:      2 skipped, 1 passed, 3 total
-Assertions: 2 skipped, 1 passed, 3 total
+Tests:      1 passed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
Unmatched conditional tests or assertions should be handled silently as if they do not exist at all.