### PR TITLE
fix(ability): always erase the `// @ts-expect-error` directives

### DIFF
--- a/source/collect/types.ts
+++ b/source/collect/types.ts
@@ -1,0 +1,10 @@
+import type ts from "typescript";
+import type { TextRange } from "#config";
+
+export interface SuppressedError {
+  directive: TextRange;
+  argument?: TextRange;
+  diagnostics: Array<ts.Diagnostic>;
+}
+
+export type SuppressedErrors = Array<SuppressedError> & { sourceFile: ts.SourceFile };

--- a/source/config/Directive.ts
+++ b/source/config/Directive.ts
@@ -8,7 +8,7 @@ import { OptionGroup } from "./OptionGroup.enum.js";
 import { Target } from "./Target.js";
 import type { InlineConfig, OptionValue } from "./types.js";
 
-interface TextRange {
+export interface TextRange {
   start: number;
   end: number;
   text: string;

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -1,6 +1,6 @@
 export { Config } from "./Config.js";
 export { ConfigDiagnosticText } from "./ConfigDiagnosticText.js";
-export { Directive, type DirectiveRange, type DirectiveRanges } from "./Directive.js";
+export { Directive, type DirectiveRange, type DirectiveRanges, type TextRange } from "./Directive.js";
 export { defaultOptions } from "./defaultOptions.js";
 export { OptionBrand } from "./OptionBrand.enum.js";
 export { OptionGroup } from "./OptionGroup.enum.js";

--- a/source/expect/AbilityMatcherBase.ts
+++ b/source/expect/AbilityMatcherBase.ts
@@ -1,0 +1,96 @@
+import type ts from "typescript";
+import { nodeBelongsToArgumentList } from "#collect";
+import {
+  Diagnostic,
+  DiagnosticOrigin,
+  type DiagnosticsHandler,
+  diagnosticBelongsToNode,
+  getDiagnosticMessageText,
+  getTextSpanEnd,
+  isDiagnosticWithLocation,
+} from "#diagnostic";
+import type { MatchWorker } from "./MatchWorker.js";
+import type { ArgumentNode, MatchResult } from "./types.js";
+
+export abstract class AbilityMatcherBase {
+  abstract explainText(isExpression: boolean, targetText: string): string;
+  abstract explainNotText(isExpression: boolean, targetText: string): string;
+
+  protected compiler: typeof ts;
+
+  constructor(compiler: typeof ts) {
+    this.compiler = compiler;
+  }
+
+  #resolveTargetText(nodes: ts.NodeArray<ArgumentNode>) {
+    if (nodes.length === 0) {
+      return "without arguments";
+    }
+
+    if (nodes.length === 1 && nodes[0]?.kind === this.compiler.SyntaxKind.SpreadElement) {
+      return "with the given arguments";
+    }
+
+    return `with the given argument${nodes.length === 1 ? "" : "s"}`;
+  }
+
+  explain(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNodes: ts.NodeArray<ArgumentNode>) {
+    const isExpression = nodeBelongsToArgumentList(this.compiler, sourceNode);
+
+    const targetText = this.#resolveTargetText(targetNodes);
+
+    const diagnostics: Array<Diagnostic> = [];
+
+    if (matchWorker.assertion.abilityDiagnostics) {
+      for (const diagnostic of matchWorker.assertion.abilityDiagnostics) {
+        let origin: DiagnosticOrigin;
+        const text: Array<string | Array<string>> = [];
+
+        if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, sourceNode)) {
+          origin = new DiagnosticOrigin(
+            diagnostic.start,
+            getTextSpanEnd(diagnostic),
+            sourceNode.getSourceFile(),
+            matchWorker.assertion,
+          );
+
+          text.push(getDiagnosticMessageText(diagnostic));
+        } else {
+          if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, targetNodes)) {
+            origin = new DiagnosticOrigin(
+              diagnostic.start,
+              getTextSpanEnd(diagnostic),
+              sourceNode.getSourceFile(),
+              matchWorker.assertion,
+            );
+          } else {
+            origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+          }
+
+          text.push(this.explainNotText(isExpression, targetText), getDiagnosticMessageText(diagnostic));
+        }
+
+        let related: Array<Diagnostic> | undefined;
+
+        if (diagnostic.relatedInformation != null) {
+          related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation, sourceNode.getSourceFile());
+        }
+
+        diagnostics.push(Diagnostic.error(text.flat(), origin).add({ related }));
+      }
+    } else {
+      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+
+      diagnostics.push(Diagnostic.error(this.explainText(isExpression, targetText), origin));
+    }
+
+    return diagnostics;
+  }
+
+  abstract match(
+    matchWorker: MatchWorker,
+    sourceNode: ArgumentNode,
+    targetNodes: ts.NodeArray<ArgumentNode>,
+    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
+  ): MatchResult | undefined;
+}

--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -1,89 +1,14 @@
 import type ts from "typescript";
 import { nodeBelongsToArgumentList } from "#collect";
-import {
-  Diagnostic,
-  DiagnosticOrigin,
-  type DiagnosticsHandler,
-  diagnosticBelongsToNode,
-  getDiagnosticMessageText,
-  getTextSpanEnd,
-  isDiagnosticWithLocation,
-} from "#diagnostic";
+import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
+import { AbilityMatcherBase } from "./AbilityMatcherBase.js";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchWorker } from "./MatchWorker.js";
 import type { ArgumentNode, MatchResult } from "./types.js";
 
-export class ToBeCallableWith {
-  #compiler: typeof ts;
-
-  constructor(compiler: typeof ts) {
-    this.#compiler = compiler;
-  }
-
-  #resolveTargetText(nodes: ts.NodeArray<ArgumentNode>) {
-    if (nodes.length === 0) {
-      return "without arguments";
-    }
-
-    if (nodes.length === 1 && nodes[0]?.kind === this.#compiler.SyntaxKind.SpreadElement) {
-      return "with the given arguments";
-    }
-
-    return `with the given argument${nodes.length === 1 ? "" : "s"}`;
-  }
-
-  #explain(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNodes: ts.NodeArray<ArgumentNode>) {
-    const isExpression = nodeBelongsToArgumentList(this.#compiler, sourceNode);
-
-    const targetText = this.#resolveTargetText(targetNodes);
-
-    const diagnostics: Array<Diagnostic> = [];
-
-    if (matchWorker.assertion.abilityDiagnostics) {
-      for (const diagnostic of matchWorker.assertion.abilityDiagnostics) {
-        let origin: DiagnosticOrigin;
-        const text: Array<string | Array<string>> = [];
-
-        if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, sourceNode)) {
-          origin = new DiagnosticOrigin(
-            diagnostic.start,
-            getTextSpanEnd(diagnostic),
-            sourceNode.getSourceFile(),
-            matchWorker.assertion,
-          );
-
-          text.push(getDiagnosticMessageText(diagnostic));
-        } else {
-          if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, targetNodes)) {
-            origin = new DiagnosticOrigin(
-              diagnostic.start,
-              getTextSpanEnd(diagnostic),
-              sourceNode.getSourceFile(),
-              matchWorker.assertion,
-            );
-          } else {
-            origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
-          }
-
-          text.push(ExpectDiagnosticText.isNotCallable(isExpression, targetText), getDiagnosticMessageText(diagnostic));
-        }
-
-        let related: Array<Diagnostic> | undefined;
-
-        if (diagnostic.relatedInformation != null) {
-          related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation, sourceNode.getSourceFile());
-        }
-
-        diagnostics.push(Diagnostic.error(text.flat(), origin).add({ related }));
-      }
-    } else {
-      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
-
-      diagnostics.push(Diagnostic.error(ExpectDiagnosticText.isCallable(isExpression, targetText), origin));
-    }
-
-    return diagnostics;
-  }
+export class ToBeCallableWith extends AbilityMatcherBase {
+  explainText = ExpectDiagnosticText.isCallable;
+  explainNotText = ExpectDiagnosticText.isNotCallable;
 
   match(
     matchWorker: MatchWorker,
@@ -93,18 +18,18 @@ export class ToBeCallableWith {
   ): MatchResult | undefined {
     let type: ts.Type | undefined;
 
-    if (this.#compiler.isCallExpression(sourceNode)) {
+    if (this.compiler.isCallExpression(sourceNode)) {
       type = matchWorker.typeChecker.getResolvedSignature(sourceNode)?.getReturnType();
     }
 
     if (
-      this.#compiler.isArrowFunction(sourceNode) ||
-      this.#compiler.isFunctionDeclaration(sourceNode) ||
-      this.#compiler.isFunctionExpression(sourceNode) ||
+      this.compiler.isArrowFunction(sourceNode) ||
+      this.compiler.isFunctionDeclaration(sourceNode) ||
+      this.compiler.isFunctionExpression(sourceNode) ||
       // allows instantiation expressions
-      this.#compiler.isExpressionWithTypeArguments(sourceNode) ||
-      this.#compiler.isIdentifier(sourceNode) ||
-      this.#compiler.isPropertyAccessExpression(sourceNode)
+      this.compiler.isExpressionWithTypeArguments(sourceNode) ||
+      this.compiler.isIdentifier(sourceNode) ||
+      this.compiler.isPropertyAccessExpression(sourceNode)
     ) {
       type = matchWorker.getType(sourceNode);
     }
@@ -112,7 +37,7 @@ export class ToBeCallableWith {
     if (!type || type.getCallSignatures().length === 0) {
       const text: Array<string> = [];
 
-      if (nodeBelongsToArgumentList(this.#compiler, sourceNode)) {
+      if (nodeBelongsToArgumentList(this.compiler, sourceNode)) {
         text.push(ExpectDiagnosticText.argumentMustBe("source", "a callable expression"));
       } else {
         text.push(ExpectDiagnosticText.typeArgumentMustBe("Source", "a callable type"));
@@ -130,7 +55,7 @@ export class ToBeCallableWith {
     }
 
     return {
-      explain: () => this.#explain(matchWorker, sourceNode, targetNodes),
+      explain: () => this.explain(matchWorker, sourceNode, targetNodes),
       isMatch: !matchWorker.assertion.abilityDiagnostics,
     };
   }

--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -41,20 +41,21 @@ export class ToBeCallableWith {
 
     if (matchWorker.assertion.abilityDiagnostics) {
       for (const diagnostic of matchWorker.assertion.abilityDiagnostics) {
-        const text = [
-          ExpectDiagnosticText.isNotCallable(isExpression, targetText),
-          getDiagnosticMessageText(diagnostic),
-        ];
-
         let origin: DiagnosticOrigin;
+        const text: Array<string | Array<string>> = [];
 
-        if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, targetNodes)) {
+        if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, sourceNode)) {
           origin = new DiagnosticOrigin(diagnostic.start, getTextSpanEnd(diagnostic), sourceNode.getSourceFile());
+
+          text.push(getDiagnosticMessageText(diagnostic));
         } else {
-          origin =
-            targetNodes.length > 0
-              ? DiagnosticOrigin.fromNodes(targetNodes)
-              : DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+          if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, targetNodes)) {
+            origin = new DiagnosticOrigin(diagnostic.start, getTextSpanEnd(diagnostic), sourceNode.getSourceFile());
+          } else {
+            origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+          }
+
+          text.push(ExpectDiagnosticText.isNotCallable(isExpression, targetText), getDiagnosticMessageText(diagnostic));
         }
 
         let related: Array<Diagnostic> | undefined;

--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -45,12 +45,22 @@ export class ToBeCallableWith {
         const text: Array<string | Array<string>> = [];
 
         if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, sourceNode)) {
-          origin = new DiagnosticOrigin(diagnostic.start, getTextSpanEnd(diagnostic), sourceNode.getSourceFile());
+          origin = new DiagnosticOrigin(
+            diagnostic.start,
+            getTextSpanEnd(diagnostic),
+            sourceNode.getSourceFile(),
+            matchWorker.assertion,
+          );
 
           text.push(getDiagnosticMessageText(diagnostic));
         } else {
           if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, targetNodes)) {
-            origin = new DiagnosticOrigin(diagnostic.start, getTextSpanEnd(diagnostic), sourceNode.getSourceFile());
+            origin = new DiagnosticOrigin(
+              diagnostic.start,
+              getTextSpanEnd(diagnostic),
+              sourceNode.getSourceFile(),
+              matchWorker.assertion,
+            );
           } else {
             origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
           }
@@ -61,7 +71,7 @@ export class ToBeCallableWith {
         let related: Array<Diagnostic> | undefined;
 
         if (diagnostic.relatedInformation != null) {
-          related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation);
+          related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation, sourceNode.getSourceFile());
         }
 
         diagnostics.push(Diagnostic.error(text.flat(), origin).add({ related }));

--- a/source/expect/ToBeConstructableWith.ts
+++ b/source/expect/ToBeConstructableWith.ts
@@ -1,78 +1,14 @@
 import type ts from "typescript";
 import { nodeBelongsToArgumentList } from "#collect";
-import {
-  Diagnostic,
-  DiagnosticOrigin,
-  type DiagnosticsHandler,
-  diagnosticBelongsToNode,
-  getDiagnosticMessageText,
-  getTextSpanEnd,
-  isDiagnosticWithLocation,
-} from "#diagnostic";
+import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler } from "#diagnostic";
+import { AbilityMatcherBase } from "./AbilityMatcherBase.js";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchWorker } from "./MatchWorker.js";
 import type { ArgumentNode, MatchResult } from "./types.js";
 
-export class ToBeConstructableWith {
-  #compiler: typeof ts;
-
-  constructor(compiler: typeof ts) {
-    this.#compiler = compiler;
-  }
-
-  #resolveTargetText(nodes: ts.NodeArray<ArgumentNode>) {
-    if (nodes.length === 0) {
-      return "without arguments";
-    }
-
-    if (nodes.length === 1 && nodes[0]?.kind === this.#compiler.SyntaxKind.SpreadElement) {
-      return "with the given arguments";
-    }
-
-    return `with the given argument${nodes.length === 1 ? "" : "s"}`;
-  }
-
-  #explain(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNodes: ts.NodeArray<ArgumentNode>) {
-    const isExpression = nodeBelongsToArgumentList(this.#compiler, sourceNode);
-
-    const targetText = this.#resolveTargetText(targetNodes);
-
-    const diagnostics: Array<Diagnostic> = [];
-
-    if (matchWorker.assertion.abilityDiagnostics) {
-      for (const diagnostic of matchWorker.assertion.abilityDiagnostics) {
-        const text = [
-          ExpectDiagnosticText.isNotConstructable(isExpression, targetText),
-          getDiagnosticMessageText(diagnostic),
-        ];
-
-        let origin: DiagnosticOrigin;
-
-        if (isDiagnosticWithLocation(diagnostic) && diagnosticBelongsToNode(diagnostic, targetNodes)) {
-          origin = new DiagnosticOrigin(diagnostic.start, getTextSpanEnd(diagnostic), sourceNode.getSourceFile());
-        } else {
-          origin =
-            targetNodes.length > 0
-              ? DiagnosticOrigin.fromNodes(targetNodes)
-              : DiagnosticOrigin.fromAssertion(matchWorker.assertion);
-        }
-
-        let related: Array<Diagnostic> | undefined;
-
-        if (diagnostic.relatedInformation != null) {
-          related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation);
-        }
-
-        diagnostics.push(Diagnostic.error(text.flat(), origin).add({ related }));
-      }
-    } else {
-      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
-
-      diagnostics.push(Diagnostic.error(ExpectDiagnosticText.isConstructable(isExpression, targetText), origin));
-    }
-
-    return diagnostics;
-  }
+export class ToBeConstructableWith extends AbilityMatcherBase {
+  explainText = ExpectDiagnosticText.isConstructable;
+  explainNotText = ExpectDiagnosticText.isNotConstructable;
 
   match(
     matchWorker: MatchWorker,
@@ -82,15 +18,15 @@ export class ToBeConstructableWith {
   ): MatchResult | undefined {
     let type: ts.Type | undefined;
 
-    if (this.#compiler.isCallExpression(sourceNode)) {
+    if (this.compiler.isCallExpression(sourceNode)) {
       type = matchWorker.typeChecker.getResolvedSignature(sourceNode)?.getReturnType();
     }
 
     if (
       // allows instantiation expressions
-      this.#compiler.isExpressionWithTypeArguments(sourceNode) ||
-      this.#compiler.isIdentifier(sourceNode) ||
-      this.#compiler.isPropertyAccessExpression(sourceNode)
+      this.compiler.isExpressionWithTypeArguments(sourceNode) ||
+      this.compiler.isIdentifier(sourceNode) ||
+      this.compiler.isPropertyAccessExpression(sourceNode)
     ) {
       type = matchWorker.getType(sourceNode);
     }
@@ -98,7 +34,7 @@ export class ToBeConstructableWith {
     if (!type || type.getConstructSignatures().length === 0) {
       const text: Array<string> = [];
 
-      if (nodeBelongsToArgumentList(this.#compiler, sourceNode)) {
+      if (nodeBelongsToArgumentList(this.compiler, sourceNode)) {
         text.push(ExpectDiagnosticText.argumentMustBe("source", "a constructable expression"));
       } else {
         text.push(ExpectDiagnosticText.typeArgumentMustBe("Source", "a constructable type"));
@@ -116,7 +52,7 @@ export class ToBeConstructableWith {
     }
 
     return {
-      explain: () => this.#explain(matchWorker, sourceNode, targetNodes),
+      explain: () => this.explain(matchWorker, sourceNode, targetNodes),
       isMatch: !matchWorker.assertion.abilityDiagnostics,
     };
   }

--- a/source/output/CodeFrameText.tsx
+++ b/source/output/CodeFrameText.tsx
@@ -12,7 +12,10 @@ function BreadcrumbsText({ ancestor }: BreadcrumbsTextProps) {
   const text: Array<string> = [];
 
   while ("name" in ancestor) {
-    text.push(ancestor.name);
+    if (ancestor.name !== "") {
+      text.push(ancestor.name);
+    }
+
     ancestor = ancestor.parent;
   }
 

--- a/tests/__snapshots__/api-toBeCallableWith-generic-functions-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-generic-functions-stderr.snap.txt
@@ -96,7 +96,7 @@ Type 'string' is not assignable to type 'number'.
   46 |     expect(getLonger).type.not.toBeCallableWith("zero", [123]);
   47 |     expect(getLonger).type.toBeCallableWith("zero", [123]); // fail
 
-       at ./__typetests__/generic-functions.tst.ts:44:44
+       at ./__typetests__/generic-functions.tst.ts:44:44 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -110,7 +110,7 @@ Type 'string' is not assignable to type 'number'.
   46 |     expect(getLonger).type.not.toBeCallableWith("zero", [123]);
   47 |     expect(getLonger).type.toBeCallableWith("zero", [123]); // fail
 
-       at ./__typetests__/generic-functions.tst.ts:44:49
+       at ./__typetests__/generic-functions.tst.ts:44:49 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -124,7 +124,7 @@ Argument of type 'number[]' is not assignable to parameter of type '"zero"'.
   49 |     expect(getLonger).type.not.toBeCallableWith(1, 2);
   50 |     expect(getLonger).type.toBeCallableWith(1, 2); // fail
 
-       at ./__typetests__/generic-functions.tst.ts:47:53
+       at ./__typetests__/generic-functions.tst.ts:47:53 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -138,5 +138,5 @@ Argument of type 'number' is not assignable to parameter of type '{ length: numb
   52 | });
   53 | 
 
-       at ./__typetests__/generic-functions.tst.ts:50:45
+       at ./__typetests__/generic-functions.tst.ts:50:45 ❭ when target is an expression ❭ is not callable with the given arguments
 

--- a/tests/__snapshots__/api-toBeCallableWith-overload-signatures-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-overload-signatures-stderr.snap.txt
@@ -150,5 +150,5 @@ Expected 1-3 arguments, but got 4.
   53 | });
   54 | 
 
-       at ./__typetests__/overload-signatures.tst.ts:51:53
+       at ./__typetests__/overload-signatures.tst.ts:51:53 ❭ when target is an expression ❭ is not callable with the given arguments
 

--- a/tests/__snapshots__/api-toBeCallableWith-overload-signatures-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-overload-signatures-stderr.snap.txt
@@ -105,12 +105,12 @@ Expected 2 arguments, but got 1.
   41 |   test("is not callable with the given argument", () => {
   42 |     expect(t).type.not.toBeCallableWith("nope");
   43 |     expect(t).type.toBeCallableWith("nope"); // fail: Expected 2 arguments, but got 1.
-     |                                     ~~~~~~
+     |                    ~~~~~~~~~~~~~~~~
   44 |   });
   45 | 
   46 |   test("is not callable with the given arguments", () => {
 
-       at ./__typetests__/overload-signatures.tst.ts:43:37
+       at ./__typetests__/overload-signatures.tst.ts:43:20 ❭ when target is an expression ❭ is not callable with the given argument
 
     An argument for 'cb' was not provided. ts(6210)
 
@@ -131,12 +131,12 @@ No overload expects 2 arguments, but overloads do exist that expect either 1 or 
   46 |   test("is not callable with the given arguments", () => {
   47 |     expect(makeDate).type.not.toBeCallableWith(2, 3);
   48 |     expect(makeDate).type.toBeCallableWith(2, 3); // fail: No overload expects 2 arguments, but overloads do exist that expect either 1 or 3 arguments.
-     |                                            ~~~~
+     |                           ~~~~~~~~~~~~~~~~
   49 | 
   50 |     expect(makeDate).type.not.toBeCallableWith(4, 5, 6, 7);
   51 |     expect(makeDate).type.toBeCallableWith(4, 5, 6, 7); // fail: Expected 1-3 arguments, but got 4.
 
-       at ./__typetests__/overload-signatures.tst.ts:48:44
+       at ./__typetests__/overload-signatures.tst.ts:48:27 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 

--- a/tests/__snapshots__/api-toBeCallableWith-parameter-arity-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-parameter-arity-stderr.snap.txt
@@ -208,7 +208,7 @@ Expected 0 arguments, but got 1.
   67 | 
   68 |   test("is callable with the given arguments", () => {
 
-       at ./__typetests__/parameter-arity.tst.ts:65:47
+       at ./__typetests__/parameter-arity.tst.ts:65:47 ❭ when target is an expression ❭ is not callable with the given argument
 
 Error: Expression is callable with the given arguments.
 
@@ -318,7 +318,7 @@ Expected 1 arguments, but got 2.
   98 |     expect(oneArgument).type.not.toBeCallableWith(...["one", "two"]);
   99 |     expect(oneArgument).type.toBeCallableWith(...["one", "two"]); // fail: Expected 1 arguments, but got 2.
 
-       at ./__typetests__/parameter-arity.tst.ts:96:54
+       at ./__typetests__/parameter-arity.tst.ts:96:54 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -332,7 +332,7 @@ Expected 1 arguments, but got 2.
   101 |     expect(optionalFirst).type.not.toBeCallableWith("one", "two");
   102 |     expect(optionalFirst).type.toBeCallableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:99:47
+        at ./__typetests__/parameter-arity.tst.ts:99:47 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -346,7 +346,7 @@ Expected 0-1 arguments, but got 2.
   104 |     expect(optionalFirst).type.not.toBeCallableWith(...["one", "two"]);
   105 |     expect(optionalFirst).type.toBeCallableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:102:56
+        at ./__typetests__/parameter-arity.tst.ts:102:56 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -360,7 +360,7 @@ Expected 0-1 arguments, but got 2.
   107 |     expect(optionalSecond).type.not.toBeCallableWith("one", 123, true);
   108 |     expect(optionalSecond).type.toBeCallableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:105:49
+        at ./__typetests__/parameter-arity.tst.ts:105:49 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -374,7 +374,7 @@ Expected 1-2 arguments, but got 3.
   110 |     expect(optionalSecond).type.not.toBeCallableWith(...["one", 123, true]);
   111 |     expect(optionalSecond).type.toBeCallableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:108:62
+        at ./__typetests__/parameter-arity.tst.ts:108:62 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -388,7 +388,7 @@ Expected 1-2 arguments, but got 3.
   113 |     expect(defaultFirst).type.not.toBeCallableWith("one", "two");
   114 |     expect(defaultFirst).type.toBeCallableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:111:50
+        at ./__typetests__/parameter-arity.tst.ts:111:50 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -402,7 +402,7 @@ Expected 0-1 arguments, but got 2.
   116 |     expect(defaultFirst).type.not.toBeCallableWith(...["one", "two"]);
   117 |     expect(defaultFirst).type.toBeCallableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:114:55
+        at ./__typetests__/parameter-arity.tst.ts:114:55 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -416,7 +416,7 @@ Expected 0-1 arguments, but got 2.
   119 |     expect(defaultSecond).type.not.toBeCallableWith("one", 123, true);
   120 |     expect(defaultSecond).type.toBeCallableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:117:48
+        at ./__typetests__/parameter-arity.tst.ts:117:48 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -430,7 +430,7 @@ Expected 1-2 arguments, but got 3.
   122 |     expect(defaultSecond).type.not.toBeCallableWith(...["one", 123, true]);
   123 |     expect(defaultSecond).type.toBeCallableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:120:61
+        at ./__typetests__/parameter-arity.tst.ts:120:61 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -444,5 +444,5 @@ Expected 1-2 arguments, but got 3.
   125 | });
   126 | 
 
-        at ./__typetests__/parameter-arity.tst.ts:123:49
+        at ./__typetests__/parameter-arity.tst.ts:123:49 ❭ when target is an expression ❭ is not callable with the given arguments
 

--- a/tests/__snapshots__/api-toBeCallableWith-rest-parameters-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-rest-parameters-stderr.snap.txt
@@ -211,7 +211,7 @@ Type 'string' is not assignable to type 'boolean'.
   64 |     expect(leading).type.not.toBeCallableWith(...["one", "two"]);
   65 |     expect(leading).type.toBeCallableWith(...["one", "two"]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:62:43
+       at ./__typetests__/rest-parameters.tst.ts:62:43 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -227,7 +227,7 @@ Type 'string' is not assignable to type 'boolean'.
   67 |     expect(leading).type.not.toBeCallableWith(3, 4, true);
   68 |     expect(leading).type.toBeCallableWith(3, 4, true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:65:43
+       at ./__typetests__/rest-parameters.tst.ts:65:43 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -243,7 +243,7 @@ Type 'number' is not assignable to type 'string'.
   70 |     expect(leading).type.not.toBeCallableWith(...[3, 4], true);
   71 |     expect(leading).type.toBeCallableWith(...[3, 4], true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:68:43
+       at ./__typetests__/rest-parameters.tst.ts:68:43 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -259,7 +259,7 @@ Type 'number' is not assignable to type 'string'.
   73 |     expect(middle).type.not.toBeCallableWith("one", 2, 3);
   74 |     expect(middle).type.toBeCallableWith("one", 2, 3); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:71:43
+       at ./__typetests__/rest-parameters.tst.ts:71:43 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -275,7 +275,7 @@ Type 'number' is not assignable to type 'boolean'.
   76 |     expect(middle).type.not.toBeCallableWith(...["one", 2, 3]);
   77 |     expect(middle).type.toBeCallableWith(...["one", 2, 3]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:74:49
+       at ./__typetests__/rest-parameters.tst.ts:74:49 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -291,7 +291,7 @@ Type 'number' is not assignable to type 'boolean'.
   79 |     expect(middle).type.not.toBeCallableWith("one", "two", "three", true);
   80 |     expect(middle).type.toBeCallableWith("one", "two", "three", true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:77:42
+       at ./__typetests__/rest-parameters.tst.ts:77:42 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -307,7 +307,7 @@ Type 'string' is not assignable to type 'number'.
   82 |     expect(middle).type.not.toBeCallableWith(...["one", "two", "three", true]);
   83 |     expect(middle).type.toBeCallableWith(...["one", "two", "three", true]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:80:49
+       at ./__typetests__/rest-parameters.tst.ts:80:49 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -323,7 +323,7 @@ Type 'string' is not assignable to type 'number'.
   85 |     expect(trailing).type.not.toBeCallableWith("ten", "eleven");
   86 |     expect(trailing).type.toBeCallableWith("ten", "eleven"); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:83:42
+       at ./__typetests__/rest-parameters.tst.ts:83:42 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -337,7 +337,7 @@ Argument of type 'string' is not assignable to parameter of type 'boolean'.
   88 |     expect(trailing).type.not.toBeCallableWith(...["ten", "eleven"]);
   89 |     expect(trailing).type.toBeCallableWith(...["ten", "eleven"]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:86:44
+       at ./__typetests__/rest-parameters.tst.ts:86:44 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -351,7 +351,7 @@ Argument of type 'string' is not assignable to parameter of type 'boolean'.
   91 |     expect(trailing).type.not.toBeCallableWith(false, 10, 11);
   92 |     expect(trailing).type.toBeCallableWith(false, 10, 11); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:89:44
+       at ./__typetests__/rest-parameters.tst.ts:89:44 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -365,7 +365,7 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   94 |     expect(trailing).type.not.toBeCallableWith(false, ...[10, 11]);
   95 |     expect(trailing).type.toBeCallableWith(false, ...[10, 11]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:92:51
+       at ./__typetests__/rest-parameters.tst.ts:92:51 ❭ when target is an expression ❭ is not callable with the given arguments
 
 Error: Expression is not callable with the given arguments.
 
@@ -379,5 +379,5 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   97 | });
   98 | 
 
-       at ./__typetests__/rest-parameters.tst.ts:95:51
+       at ./__typetests__/rest-parameters.tst.ts:95:51 ❭ when target is an expression ❭ is not callable with the given arguments
 

--- a/tests/__snapshots__/api-toBeCallableWith-trailing-comma-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-trailing-comma-stderr.snap.txt
@@ -22,7 +22,7 @@ Argument of type 'number' is not assignable to parameter of type '{ length: numb
   15 |     isSameLength  ,
   16 |   ).type.toBeCallableWith("zero", [123]); // fail
 
-       at ./__typetests__/toBeCallableWith.tst.ts:13:27
+       at ./__typetests__/toBeCallableWith.tst.ts:13:27 ❭ handles trailing comma?
 
 Error: Expression is not callable with the given arguments.
 
@@ -35,5 +35,5 @@ Argument of type 'number[]' is not assignable to parameter of type 'string'.
   17 | });
   18 | 
 
-       at ./__typetests__/toBeCallableWith.tst.ts:16:35
+       at ./__typetests__/toBeCallableWith.tst.ts:16:35 ❭ handles trailing comma?
 

--- a/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stderr.snap.txt
@@ -8,7 +8,7 @@ Error: Argument of type 'number' is not assignable to parameter of type 'string'
   14 |   // @ts-expect-error
   15 |   expect(concat(3)).type.toBeCallableWith(4); // fail
 
-       at ./__typetests__/toBeCallableWith.tst.ts:12:17
+       at ./__typetests__/toBeCallableWith.tst.ts:12:17 ❭ handles '// @ts-expect-error' directive
 
 Error: Argument of type 'number' is not assignable to parameter of type 'string'.
 
@@ -19,7 +19,7 @@ Error: Argument of type 'number' is not assignable to parameter of type 'string'
   16 | });
   17 | 
 
-       at ./__typetests__/toBeCallableWith.tst.ts:15:17
+       at ./__typetests__/toBeCallableWith.tst.ts:15:17 ❭ handles '// @ts-expect-error' directive
 
 Error: Expression is not callable with the given argument.
 
@@ -32,5 +32,5 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   16 | });
   17 | 
 
-       at ./__typetests__/toBeCallableWith.tst.ts:15:43
+       at ./__typetests__/toBeCallableWith.tst.ts:15:43 ❭ handles '// @ts-expect-error' directive
 

--- a/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stderr.snap.txt
@@ -1,0 +1,36 @@
+Error: Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  10 | 
+  11 |   // @ts-expect-error
+  12 |   expect(concat(1)).type.toBeCallableWith("two"); // fail
+     |                 ~
+  13 | 
+  14 |   // @ts-expect-error
+  15 |   expect(concat(3)).type.toBeCallableWith(4); // fail
+
+       at ./__typetests__/toBeCallableWith.tst.ts:12:17
+
+Error: Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  13 | 
+  14 |   // @ts-expect-error
+  15 |   expect(concat(3)).type.toBeCallableWith(4); // fail
+     |                 ~
+  16 | });
+  17 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:15:17
+
+Error: Expression is not callable with the given argument.
+
+Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  13 | 
+  14 |   // @ts-expect-error
+  15 |   expect(concat(3)).type.toBeCallableWith(4); // fail
+     |                                           ~
+  16 | });
+  17 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:15:43
+

--- a/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>>
+
+fail ./__typetests__/toBeCallableWith.tst.ts
+  × handles '// @ts-expect-error' directive
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      1 failed, 1 total
+Assertions: 2 failed, 1 passed, 3 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stderr.snap.txt
@@ -72,7 +72,7 @@ Type 'string' is not assignable to type 'number'.
   42 |     expect(Second).type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
   43 |     expect(Second).type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
 
-       at ./__typetests__/generic-classes.tst.ts:40:48
+       at ./__typetests__/generic-classes.tst.ts:40:48 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -86,7 +86,7 @@ Type 'string' is not assignable to type 'number'.
   42 |     expect(Second).type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
   43 |     expect(Second).type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
 
-       at ./__typetests__/generic-classes.tst.ts:40:53
+       at ./__typetests__/generic-classes.tst.ts:40:53 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -100,5 +100,5 @@ Type 'number' is not assignable to type 'string'.
   45 | });
   46 | 
 
-       at ./__typetests__/generic-classes.tst.ts:43:53
+       at ./__typetests__/generic-classes.tst.ts:43:53 ❭ when target is an expression ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stderr.snap.txt
@@ -22,7 +22,7 @@ Expected 1-2 arguments, but got 3.
   35 | 
   36 |     expect(Test).type.toBeConstructableWith("one", () => {});
 
-       at ./__typetests__/overload-signatures.tst.ts:33:52
+       at ./__typetests__/overload-signatures.tst.ts:33:52 ❭ when target is an expression ❭ is constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -37,7 +37,7 @@ Type 'void' is not assignable to type 'Promise<unknown>'.
   38 | 
   39 |     expect(Test).type.toBeConstructableWith("two", () => Promise.resolve());
 
-       at ./__typetests__/overload-signatures.tst.ts:36:52
+       at ./__typetests__/overload-signatures.tst.ts:36:52 ❭ when target is an expression ❭ is constructable with the given arguments
 
     The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible. ts(2793)
 
@@ -122,12 +122,12 @@ Expected 2 arguments, but got 1.
   51 |   test("is not constructable with the given argument", () => {
   52 |     expect(Test).type.not.toBeConstructableWith("nope");
   53 |     expect(Test).type.toBeConstructableWith("nope"); // fail: Expected 2 arguments, but got 1.
-     |                                             ~~~~~~
+     |                       ~~~~~~~~~~~~~~~~~~~~~
   54 |   });
   55 | 
   56 |   test("is not constructable with the given arguments", () => {
 
-       at ./__typetests__/overload-signatures.tst.ts:53:45
+       at ./__typetests__/overload-signatures.tst.ts:53:23 ❭ when target is an expression ❭ is not constructable with the given argument
 
     An argument for 'cb' was not provided. ts(6210)
 
@@ -165,5 +165,5 @@ Expected 1-2 arguments, but got 4.
   63 | });
   64 | 
 
-       at ./__typetests__/overload-signatures.tst.ts:61:52
+       at ./__typetests__/overload-signatures.tst.ts:61:52 ❭ when target is an expression ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stderr.snap.txt
@@ -208,7 +208,7 @@ Expected 0 arguments, but got 1.
   94 | 
   95 |   test("is constructable with the given arguments", () => {
 
-       at ./__typetests__/parameter-arity.tst.ts:92:45
+       at ./__typetests__/parameter-arity.tst.ts:92:45 ❭ when target is an expression ❭ is not constructable with the given argument
 
 Error: Expression is constructable with the given arguments.
 
@@ -318,7 +318,7 @@ Expected 1 arguments, but got 2.
   125 |     expect(One).type.not.toBeConstructableWith(...["one", "two"]);
   126 |     expect(One).type.toBeConstructableWith(...["one", "two"]); // fail: Expected 1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:123:51
+        at ./__typetests__/parameter-arity.tst.ts:123:51 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -332,7 +332,7 @@ Expected 1 arguments, but got 2.
   128 |     expect(OptionalFirst).type.not.toBeConstructableWith("one", "two");
   129 |     expect(OptionalFirst).type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:126:44
+        at ./__typetests__/parameter-arity.tst.ts:126:44 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -346,7 +346,7 @@ Expected 0-1 arguments, but got 2.
   131 |     expect(OptionalFirst).type.not.toBeConstructableWith(...["one", "two"]);
   132 |     expect(OptionalFirst).type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:129:61
+        at ./__typetests__/parameter-arity.tst.ts:129:61 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -360,7 +360,7 @@ Expected 0-1 arguments, but got 2.
   134 |     expect(OptionalSecond).type.not.toBeConstructableWith("one", 123, true);
   135 |     expect(OptionalSecond).type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:132:54
+        at ./__typetests__/parameter-arity.tst.ts:132:54 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -374,7 +374,7 @@ Expected 1-2 arguments, but got 3.
   137 |     expect(OptionalSecond).type.not.toBeConstructableWith(...["one", 123, true]);
   138 |     expect(OptionalSecond).type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:135:67
+        at ./__typetests__/parameter-arity.tst.ts:135:67 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -388,7 +388,7 @@ Expected 1-2 arguments, but got 3.
   140 |     expect(DefaultFirst).type.not.toBeConstructableWith("one", "two");
   141 |     expect(DefaultFirst).type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:138:55
+        at ./__typetests__/parameter-arity.tst.ts:138:55 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -402,7 +402,7 @@ Expected 0-1 arguments, but got 2.
   143 |     expect(DefaultFirst).type.not.toBeConstructableWith(...["one", "two"]);
   144 |     expect(DefaultFirst).type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:141:60
+        at ./__typetests__/parameter-arity.tst.ts:141:60 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -416,7 +416,7 @@ Expected 0-1 arguments, but got 2.
   146 |     expect(DefaultSecond).type.not.toBeConstructableWith("one", 123, true);
   147 |     expect(DefaultSecond).type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:144:53
+        at ./__typetests__/parameter-arity.tst.ts:144:53 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -430,7 +430,7 @@ Expected 1-2 arguments, but got 3.
   149 |     expect(DefaultSecond).type.not.toBeConstructableWith(...["one", 123, true]);
   150 |     expect(DefaultSecond).type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:147:66
+        at ./__typetests__/parameter-arity.tst.ts:147:66 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -444,5 +444,5 @@ Expected 1-2 arguments, but got 3.
   152 | });
   153 | 
 
-        at ./__typetests__/parameter-arity.tst.ts:150:54
+        at ./__typetests__/parameter-arity.tst.ts:150:54 ❭ when target is an expression ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stderr.snap.txt
@@ -211,7 +211,7 @@ Type 'string' is not assignable to type 'boolean'.
   88 |     expect(Leading).type.not.toBeConstructableWith(...["one", "two"]);
   89 |     expect(Leading).type.toBeConstructableWith(...["one", "two"]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:86:48
+       at ./__typetests__/rest-parameters.tst.ts:86:48 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -227,7 +227,7 @@ Type 'string' is not assignable to type 'boolean'.
   91 |     expect(Leading).type.not.toBeConstructableWith(3, 4, true);
   92 |     expect(Leading).type.toBeConstructableWith(3, 4, true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:89:48
+       at ./__typetests__/rest-parameters.tst.ts:89:48 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -243,7 +243,7 @@ Type 'number' is not assignable to type 'string'.
   94 |     expect(Leading).type.not.toBeConstructableWith(...[3, 4], true);
   95 |     expect(Leading).type.toBeConstructableWith(...[3, 4], true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:92:48
+       at ./__typetests__/rest-parameters.tst.ts:92:48 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -259,7 +259,7 @@ Type 'number' is not assignable to type 'string'.
   97 |     expect(Middle).type.not.toBeConstructableWith("one", 2, 3);
   98 |     expect(Middle).type.toBeConstructableWith("one", 2, 3); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:95:48
+       at ./__typetests__/rest-parameters.tst.ts:95:48 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -275,7 +275,7 @@ Type 'number' is not assignable to type 'boolean'.
   100 |     expect(Middle).type.not.toBeConstructableWith(...["one", 2, 3]);
   101 |     expect(Middle).type.toBeConstructableWith(...["one", 2, 3]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:98:54
+        at ./__typetests__/rest-parameters.tst.ts:98:54 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -291,7 +291,7 @@ Type 'number' is not assignable to type 'boolean'.
   103 |     expect(Middle).type.not.toBeConstructableWith("one", "two", "three", true);
   104 |     expect(Middle).type.toBeConstructableWith("one", "two", "three", true); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:101:47
+        at ./__typetests__/rest-parameters.tst.ts:101:47 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -307,7 +307,7 @@ Type 'string' is not assignable to type 'number'.
   106 |     expect(Middle).type.not.toBeConstructableWith(...["one", "two", "three", true]);
   107 |     expect(Middle).type.toBeConstructableWith(...["one", "two", "three", true]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:104:54
+        at ./__typetests__/rest-parameters.tst.ts:104:54 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -323,7 +323,7 @@ Type 'string' is not assignable to type 'number'.
   109 |     expect(Trailing).type.not.toBeConstructableWith("ten", "eleven");
   110 |     expect(Trailing).type.toBeConstructableWith("ten", "eleven"); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:107:47
+        at ./__typetests__/rest-parameters.tst.ts:107:47 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -337,7 +337,7 @@ Argument of type 'string' is not assignable to parameter of type 'boolean'.
   112 |     expect(Trailing).type.not.toBeConstructableWith(...["ten", "eleven"]);
   113 |     expect(Trailing).type.toBeConstructableWith(...["ten", "eleven"]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:110:49
+        at ./__typetests__/rest-parameters.tst.ts:110:49 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -351,7 +351,7 @@ Argument of type 'string' is not assignable to parameter of type 'boolean'.
   115 |     expect(Trailing).type.not.toBeConstructableWith(false, 10, 11);
   116 |     expect(Trailing).type.toBeConstructableWith(false, 10, 11); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:113:49
+        at ./__typetests__/rest-parameters.tst.ts:113:49 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -365,7 +365,7 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   118 |     expect(Trailing).type.not.toBeConstructableWith(false, ...[10, 11]);
   119 |     expect(Trailing).type.toBeConstructableWith(false, ...[10, 11]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:116:56
+        at ./__typetests__/rest-parameters.tst.ts:116:56 ❭ when target is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -379,5 +379,5 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   121 | });
   122 | 
 
-        at ./__typetests__/rest-parameters.tst.ts:119:56
+        at ./__typetests__/rest-parameters.tst.ts:119:56 ❭ when target is an expression ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-trailing-comma-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-trailing-comma-stderr.snap.txt
@@ -29,11 +29,11 @@ Expected 2 arguments, but got 1.
   21 |   expect(
   22 |     Pair,
   23 |   ).type.toBeConstructableWith("nope"); // fail
-     |                                ~~~~~~
+     |          ~~~~~~~~~~~~~~~~~~~~~
   24 | });
   25 | 
 
-       at ./__typetests__/toBeConstructableWith.tst.ts:23:32
+       at ./__typetests__/toBeConstructableWith.tst.ts:23:10 ❭ Pair
 
     An argument for 'right' was not provided. ts(6210)
 

--- a/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stderr.snap.txt
@@ -1,0 +1,36 @@
+Error: Expected 0 arguments, but got 1.
+
+  17 | 
+  18 |   // @ts-expect-error
+  19 |   expect(getPersonConstructor(true)).type.toBeConstructableWith("abc"); // fail
+     |                               ~~~~
+  20 | 
+  21 |   // @ts-expect-error
+  22 |   expect(getPersonConstructor(true)).type.toBeConstructableWith(123); // fail
+
+       at ./__typetests__/toBeCallableWith.tst.ts:19:31 ❭ handles '// @ts-expect-error' directive
+
+Error: Expected 0 arguments, but got 1.
+
+  20 | 
+  21 |   // @ts-expect-error
+  22 |   expect(getPersonConstructor(true)).type.toBeConstructableWith(123); // fail
+     |                               ~~~~
+  23 | });
+  24 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:22:31 ❭ handles '// @ts-expect-error' directive
+
+Error: Expression is not constructable with the given argument.
+
+Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  20 | 
+  21 |   // @ts-expect-error
+  22 |   expect(getPersonConstructor(true)).type.toBeConstructableWith(123); // fail
+     |                                                                 ~~~
+  23 | });
+  24 | 
+
+       at ./__typetests__/toBeCallableWith.tst.ts:22:65 ❭ handles '// @ts-expect-error' directive
+

--- a/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>>
+
+fail ./__typetests__/toBeCallableWith.tst.ts
+  × handles '// @ts-expect-error' directive
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      1 failed, 1 total
+Assertions: 2 failed, 1 passed, 3 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-when-stderr.snap.txt
+++ b/tests/__snapshots__/api-when-stderr.snap.txt
@@ -22,7 +22,7 @@ Argument of type '"required"' is not assignable to parameter of type '"valid"'.
   14 | 
   15 |   test("argument type is not assignable to parameter type?", () => {
 
-       at ./__typetests__/when.tst.ts:12:81
+       at ./__typetests__/when.tst.ts:12:81 ❭ when target is an expression ❭ is called with?
 
 Error: Argument of type 'boolean' is not assignable to parameter of type '(source: { valid: boolean; }) => { valid: boolean; }'.
 

--- a/tests/__snapshots__/api-when-trailing-comma-stderr.snap.txt
+++ b/tests/__snapshots__/api-when-trailing-comma-stderr.snap.txt
@@ -22,7 +22,7 @@ Argument of type '"required"' is not assignable to parameter of type '"valid"'.
   14 |     pipe,
   15 |   ).isCalledWith({ valid: true }, expect(pick).type.toBeCallableWith("nope")); // fail
 
-       at ./__typetests__/when.tst.ts:12:70
+       at ./__typetests__/when.tst.ts:12:70 ❭ pick
 
 Error: Expression is not callable with the given argument.
 
@@ -35,5 +35,5 @@ Argument of type '"nope"' is not assignable to parameter of type '"valid"'.
   16 | });
   17 | 
 
-       at ./__typetests__/when.tst.ts:15:70
+       at ./__typetests__/when.tst.ts:15:70 ❭ pick
 

--- a/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stderr.snap.txt
@@ -55,7 +55,7 @@ Error: Type 'number' is not the same as type 'string'.
   18 | }).type.toBe<void>();
   19 | 
 
-       at ./__typetests__/handles-nested.tst.ts:17:30 ❭ 
+       at ./__typetests__/handles-nested.tst.ts:17:30
 
 Error: Type '() => void' is not the same as type 'void'.
 

--- a/tests/__snapshots__/validation-when-action-not-supported-stderr.snap.txt
+++ b/tests/__snapshots__/validation-when-action-not-supported-stderr.snap.txt
@@ -8,3 +8,15 @@ Error: The '.isSupportedWith()' action is not supported.
 
       at ./__typetests__/action-not-supported.tst.ts:7:12
 
+Error: Expression is not callable with the given argument.
+
+Argument of type '"valid"' is not assignable to parameter of type 'never'.
+
+  5 | 
+  6 | // @ts-expect-error
+  7 | when(pipe).isSupportedWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));
+    |                                                                                ~~~~~~~
+  8 | 
+
+      at ./__typetests__/action-not-supported.tst.ts:7:80
+

--- a/tests/__snapshots__/validation-when-action-not-supported-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-action-not-supported-stdout.snap.txt
@@ -4,5 +4,5 @@ fail ./__typetests__/action-not-supported.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Assertions: 1 passed, 1 total
+Assertions: 1 failed, 1 total
 Duration:   <<timestamp>>

--- a/tests/api-toBeCallableWith.test.js
+++ b/tests/api-toBeCallableWith.test.js
@@ -163,4 +163,48 @@ test("handles trailing comma?", () => {
 
     assert.equal(exitCode, 1);
   });
+
+  await t.test("handles '// @ts-expect-error' directive", async (t) => {
+    const toBeCallableWithText = `import { expect, test } from "tstyche";
+
+const concat =
+  (first: string) =>
+  (second: string): string =>
+    first + second;
+
+test("handles '// @ts-expect-error' directive", () => {
+  expect(concat("one")).type.toBeCallableWith("two");
+
+  // @ts-expect-error
+  expect(concat(1)).type.toBeCallableWith("two"); // fail
+
+  // @ts-expect-error
+  expect(concat(3)).type.toBeCallableWith(4); // fail
+});
+`;
+
+    const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+    t.after(async () => {
+      await clearFixture(fixtureUrl);
+    });
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/toBeCallableWith.tst.ts"]: toBeCallableWithText,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-ts-expect-error-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-ts-expect-error-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
 });


### PR DESCRIPTION
The ability layer should always erase the `// @ts-expect-error` directives, because it depends on errors being visible.