### PR TITLE
feat: enable `noUncheckedSideEffectImports` in default compiler options

### DIFF
--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -82,6 +82,10 @@ export class ProjectService {
       defaultCompilerOptions.verbatimModuleSyntax = true;
     }
 
+    if (Version.isSatisfiedWith(this.#compiler.version, "5.6")) {
+      defaultCompilerOptions.noUncheckedSideEffectImports = true;
+    }
+
     return defaultCompilerOptions;
   }
 


### PR DESCRIPTION
Enabling `noUncheckedSideEffectImports` in default compiler options for TypeScript 5.6 and above.