### PR TITLE
refactor: move suppressed error ignore logic to service

### DIFF
--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -65,7 +65,7 @@ export class AbilityLayer {
       const argumentSeparatorText = match?.[4];
       const argumentText = match?.[5]?.split(/--+/)[0]?.trimEnd();
 
-      if (typeof offsetText !== "string" || !directiveText || ignoreText === "!") {
+      if (typeof offsetText !== "string" || !directiveText) {
         continue;
       }
 
@@ -73,6 +73,7 @@ export class AbilityLayer {
 
       const range: SuppressedError = {
         directive: { start, end: start + directiveText.length, text: directiveText },
+        ignore: ignoreText === "!",
         diagnostics: [],
       };
 

--- a/source/collect/types.ts
+++ b/source/collect/types.ts
@@ -3,6 +3,7 @@ import type { TextRange } from "#config";
 
 export interface SuppressedError {
   directive: TextRange;
+  ignore: boolean;
   argument?: TextRange;
   diagnostics: Array<ts.Diagnostic>;
 }

--- a/source/diagnostic/Diagnostic.ts
+++ b/source/diagnostic/Diagnostic.ts
@@ -48,7 +48,7 @@ export class Diagnostic {
       let related: Array<Diagnostic> | undefined;
 
       if (diagnostic.relatedInformation != null) {
-        related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation, sourceFile);
+        related = Diagnostic.fromDiagnostics(diagnostic.relatedInformation);
       }
 
       const text = getDiagnosticMessageText(diagnostic);

--- a/source/suppressed/SuppressedService.ts
+++ b/source/suppressed/SuppressedService.ts
@@ -5,8 +5,8 @@ import { SuppressedDiagnosticText } from "./SuppressedDiagnosticText.js";
 export class SuppressedService {
   match(suppressedErrors: SuppressedErrors, onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>): void {
     for (const suppressedError of suppressedErrors) {
-      if (suppressedError.diagnostics.length === 0) {
-        // must be already reported by the compiler
+      if (suppressedError.diagnostics.length === 0 || suppressedError.ignore) {
+        // directive is unused or ignored
         continue;
       }
 

--- a/tests/__fixtures__/validation-expect/__typetests__/matcher-not-supported.tst.ts
+++ b/tests/__fixtures__/validation-expect/__typetests__/matcher-not-supported.tst.ts
@@ -6,8 +6,8 @@ test("is string?", () => {
 });
 
 test("is not supported?", () => {
-  // @ts-expect-error
+  // @ts-expect-error!
   expect<string>().type.toBeSupported();
-  // @ts-expect-error
+  // @ts-expect-error!
   expect<number>().type.not.toBeSupported();
 });

--- a/tests/__fixtures__/validation-toHaveProperty/__typetests__/toHaveProperty.tst.ts
+++ b/tests/__fixtures__/validation-toHaveProperty/__typetests__/toHaveProperty.tst.ts
@@ -23,12 +23,12 @@ describe("type argument for 'Source'", () => {
 
 describe("argument for 'key'", () => {
   test("must be provided", () => {
-    // @ts-expect-error testing purpose
+    // @ts-expect-error!
     expect<{ test: () => void }>().type.toHaveProperty();
   });
 
   test("must be of type 'string | number | symbol'", () => {
-    // @ts-expect-error testing purpose
+    // @ts-expect-error!
     expect<{ test: () => void }>().type.toHaveProperty(["test"]);
   });
 });

--- a/tests/__fixtures__/validation-toRaiseError/__typetests__/toRaiseError.tst.ts
+++ b/tests/__fixtures__/validation-toRaiseError/__typetests__/toRaiseError.tst.ts
@@ -12,7 +12,7 @@ describe("argument for 'target'", () => {
   }
 
   test("must be of type 'string | number'", () => {
-    // @ts-expect-error testing purpose
+    // @ts-expect-error!
     expect(check(123)).type.toRaiseError(true, [2345]);
   });
 });

--- a/tests/__fixtures__/validation-when/__typetests__/action-not-supported.tst.ts
+++ b/tests/__fixtures__/validation-when/__typetests__/action-not-supported.tst.ts
@@ -3,5 +3,5 @@ import { expect, when } from "tstyche";
 declare function pipe<T>(source: T, ...target: Array<(source: T) => T>): void;
 declare function pick<T, K extends keyof T>(key: K): <K extends keyof T>(object: T) => Pick<T, K>;
 
-// @ts-expect-error
+// @ts-expect-error!
 when(pipe).isSupportedWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));

--- a/tests/__snapshots__/config-rejectAnyType-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-enabled-stderr.snap.txt
@@ -4,10 +4,10 @@ The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
   4 |   test("rejects the 'any' type", () => {
-  5 |     // @ts-expect-error missing import test
+  5 |     // @ts-expect-error! Missing import
   6 |     expect(getResult("sample")).type.toBe<Result<string>>(); // rejected
     |            ~~~~~~~~~~~~~~~~~~~
-  7 |     // @ts-expect-error missing import test
+  7 |     // @ts-expect-error! Missing import
   8 |     expect(getResult(123)).type.toBeAssignableWith<Result<number>>(); // rejected
   9 |   });
 
@@ -19,7 +19,7 @@ The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
    6 |     expect(getResult("sample")).type.toBe<Result<string>>(); // rejected
-   7 |     // @ts-expect-error missing import test
+   7 |     // @ts-expect-error! Missing import
    8 |     expect(getResult(123)).type.toBeAssignableWith<Result<number>>(); // rejected
      |            ~~~~~~~~~~~~~~
    9 |   });
@@ -79,10 +79,10 @@ The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
   46 |   test("rejects the 'any' type", () => {
-  47 |     // @ts-expect-error missing import test
+  47 |     // @ts-expect-error! Missing import
   48 |     expect<string>().type.toBeAssignableWith(getResult("sample")); // rejected
      |                                              ~~~~~~~~~~~~~~~~~~~
-  49 |     // @ts-expect-error missing import test
+  49 |     // @ts-expect-error! Missing import
   50 |     expect<number>().type.not.toBe(getResult(123)); // rejected
   51 |   });
 
@@ -94,7 +94,7 @@ The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
   48 |     expect<string>().type.toBeAssignableWith(getResult("sample")); // rejected
-  49 |     // @ts-expect-error missing import test
+  49 |     // @ts-expect-error! Missing import
   50 |     expect<number>().type.not.toBe(getResult(123)); // rejected
      |                                    ~~~~~~~~~~~~~~
   51 |   });

--- a/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stderr.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-not-supported-matcher-stderr.snap.txt
@@ -1,10 +1,10 @@
 Error: The '.toBeSupported()' matcher is not supported.
 
    8 | test("is not supported?", () => {
-   9 |   // @ts-expect-error
+   9 |   // @ts-expect-error!
   10 |   expect<string>().type.toBeSupported();
      |                         ~~~~~~~~~~~~~
-  11 |   // @ts-expect-error
+  11 |   // @ts-expect-error!
   12 |   expect<number>().type.not.toBeSupported();
   13 | });
 
@@ -13,7 +13,7 @@ Error: The '.toBeSupported()' matcher is not supported.
 Error: The '.toBeSupported()' matcher is not supported.
 
   10 |   expect<string>().type.toBeSupported();
-  11 |   // @ts-expect-error
+  11 |   // @ts-expect-error!
   12 |   expect<number>().type.not.toBeSupported();
      |                             ~~~~~~~~~~~~~
   13 | });

--- a/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toHaveProperty-stderr.snap.txt
@@ -73,7 +73,7 @@ Error: A type argument for 'Source' must be of an object type.
 Error: An argument for 'key' must be provided.
 
   25 |   test("must be provided", () => {
-  26 |     // @ts-expect-error testing purpose
+  26 |     // @ts-expect-error!
   27 |     expect<{ test: () => void }>().type.toHaveProperty();
      |                                         ~~~~~~~~~~~~~~
   28 |   });
@@ -85,7 +85,7 @@ Error: An argument for 'key' must be provided.
 Error: An argument for 'key' must be of type 'string | number | symbol'.
 
   30 |   test("must be of type 'string | number | symbol'", () => {
-  31 |     // @ts-expect-error testing purpose
+  31 |     // @ts-expect-error!
   32 |     expect<{ test: () => void }>().type.toHaveProperty(["test"]);
      |                                                        ~~~~~~~~
   33 |   });

--- a/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toRaiseError-stderr.snap.txt
@@ -13,7 +13,7 @@ Error: An argument for 'source' or type argument for 'Source' must be provided.
 Error: An argument for 'target' must be a string, number or regular expression literal.
 
   14 |   test("must be of type 'string | number'", () => {
-  15 |     // @ts-expect-error testing purpose
+  15 |     // @ts-expect-error!
   16 |     expect(check(123)).type.toRaiseError(true, [2345]);
      |                                          ~~~~
   17 |   });
@@ -25,7 +25,7 @@ Error: An argument for 'target' must be a string, number or regular expression l
 Error: An argument for 'target' must be a string, number or regular expression literal.
 
   14 |   test("must be of type 'string | number'", () => {
-  15 |     // @ts-expect-error testing purpose
+  15 |     // @ts-expect-error!
   16 |     expect(check(123)).type.toRaiseError(true, [2345]);
      |                                                ~~~~~~
   17 |   });

--- a/tests/__snapshots__/validation-when-action-not-supported-stderr.snap.txt
+++ b/tests/__snapshots__/validation-when-action-not-supported-stderr.snap.txt
@@ -1,7 +1,7 @@
 Error: The '.isSupportedWith()' action is not supported.
 
   5 | 
-  6 | // @ts-expect-error
+  6 | // @ts-expect-error!
   7 | when(pipe).isSupportedWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));
     |            ~~~~~~~~~~~~~~~
   8 | 
@@ -13,7 +13,7 @@ Error: Expression is not callable with the given argument.
 Argument of type '"valid"' is not assignable to parameter of type 'never'.
 
   5 | 
-  6 | // @ts-expect-error
+  6 | // @ts-expect-error!
   7 | when(pipe).isSupportedWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));
     |                                                                                ~~~~~~~
   8 | 

--- a/tests/config-rejectAnyType.test.js
+++ b/tests/config-rejectAnyType.test.js
@@ -8,9 +8,9 @@ const isRejectedText = `import { describe, expect, test } from "tstyche";
 
 describe("argument for 'source'", () => {
   test("rejects the 'any' type", () => {
-    // @ts-expect-error missing import test
+    // @ts-expect-error! Missing import
     expect(getResult("sample")).type.toBe<Result<string>>(); // rejected
-    // @ts-expect-error missing import test
+    // @ts-expect-error! Missing import
     expect(getResult(123)).type.toBeAssignableWith<Result<number>>(); // rejected
   });
 
@@ -50,9 +50,9 @@ describe("type argument for 'Source'", () => {
 
 describe("argument for 'target'", () => {
   test("rejects the 'any' type", () => {
-    // @ts-expect-error missing import test
+    // @ts-expect-error! Missing import
     expect<string>().type.toBeAssignableWith(getResult("sample")); // rejected
-    // @ts-expect-error missing import test
+    // @ts-expect-error! Missing import
     expect<number>().type.not.toBe(getResult(123)); // rejected
   });
 


### PR DESCRIPTION
The ignored `// @ts-expect-error` directives must be filtered out later. Otherwise they are not erased.