### PR TITLE
feat: add support for glob brace expansion

### DIFF
--- a/source/select/GlobService.ts
+++ b/source/select/GlobService.ts
@@ -1,6 +1,30 @@
-export class GlobPattern {
+export class GlobService {
   // escaping any non-word and non-whitespace character sounds inefficient, but this is future proof
   static #reservedCharacterRegex = /[^\w\s/]/g;
+
+  static #expandBraces(text: string, start?: number) {
+    start = start ?? text.indexOf("{");
+
+    if (start !== -1) {
+      let position = start + 1;
+
+      while (position < text.length) {
+        switch (text[position]) {
+          case "}":
+            text = `${text.slice(0, start - 1)}(${text.slice(start + 1, position - 1).replaceAll("\\,", "|")})${text.slice(position + 1)}`;
+            break;
+
+          case "{":
+            text = GlobService.#expandBraces(text, position);
+            break;
+        }
+
+        position++;
+      }
+    }
+
+    return text;
+  }
 
   // all wildcards must not match path segments that start with a dot '[^./]'
   // as well as the 'node_modules' directories '(?!(node_modules)(\\/|$))'
@@ -28,8 +52,8 @@ export class GlobPattern {
       resultPattern += "\\/";
 
       const segmentPattern = segment.replace(
-        GlobPattern.#reservedCharacterRegex,
-        GlobPattern.#replaceReservedCharacter,
+        GlobService.#reservedCharacterRegex,
+        GlobService.#replaceReservedCharacter,
       );
 
       // no need to exclude 'node_modules' when a segment has no wildcards
@@ -41,6 +65,8 @@ export class GlobPattern {
     }
 
     resultPattern += ")?".repeat(optionalSegmentCount);
+
+    resultPattern = GlobService.#expandBraces(resultPattern);
 
     return resultPattern;
   }
@@ -59,7 +85,7 @@ export class GlobPattern {
   }
 
   static toRegex(patterns: Array<string>, target: "directories" | "files"): RegExp {
-    const patternText = patterns.map((pattern) => `(${GlobPattern.#parse(pattern, target)})`).join("|");
+    const patternText = patterns.map((pattern) => `(${GlobService.#parse(pattern, target)})`).join("|");
 
     return new RegExp(`^(${patternText})$`);
   }

--- a/source/select/Select.ts
+++ b/source/select/Select.ts
@@ -3,7 +3,7 @@ import type { ResolvedConfig } from "#config";
 import { Diagnostic } from "#diagnostic";
 import { EventEmitter } from "#events";
 import { Path } from "#path";
-import { GlobPattern } from "./GlobPattern.js";
+import { GlobService } from "./GlobService.js";
 import { SelectDiagnosticText } from "./SelectDiagnosticText.js";
 
 interface FileSystemEntryMeta {
@@ -52,8 +52,8 @@ export class Select {
 
     if (!matchPatterns) {
       matchPatterns = {
-        includedDirectory: GlobPattern.toRegex(globPatterns, "directories"),
-        includedFile: GlobPattern.toRegex(globPatterns, "files"),
+        includedDirectory: GlobService.toRegex(globPatterns, "directories"),
+        includedFile: GlobService.toRegex(globPatterns, "files"),
       };
 
       Select.#patternsCache.set(globPatterns, matchPatterns);

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,5 +1,5 @@
 {
   "$schema": "./schemas/config.json",
   "checkSuppressedErrors": true,
-  "testFileMatch": ["examples/*.t*st.*", "tests/*.test.*", "typetests/*.tst.*"]
+  "testFileMatch": ["examples/*.{js,ts,tsx}", "tests/*.test.*", "typetests/*.tst.*"]
 }


### PR DESCRIPTION
Closes #522

This implements glob brace expansion for patterns like `examples/*.{ts,tsx}` or `examples/*.{js,ts{,x}}`.