### PR TITLE
feat: add the `fixtureFileMatch` configuration option

### DIFF
--- a/schemas/__tests__/__fixtures__/invalid-fixtureFileMatch-1.json
+++ b/schemas/__tests__/__fixtures__/invalid-fixtureFileMatch-1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config.json",
+  "fixtureFileMatch": [true]
+}

--- a/schemas/__tests__/__fixtures__/invalid-fixtureFileMatch-2.json
+++ b/schemas/__tests__/__fixtures__/invalid-fixtureFileMatch-2.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config.json",
+  "fixtureFileMatch": ["fixtures/*.ts", "fixtures/*.ts"]
+}

--- a/schemas/__tests__/__fixtures__/invalid-fixtureFileMatch-3.json
+++ b/schemas/__tests__/__fixtures__/invalid-fixtureFileMatch-3.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config.json",
+  "fixtureFileMatch": true
+}

--- a/schemas/__tests__/__fixtures__/valid-all-options.json
+++ b/schemas/__tests__/__fixtures__/valid-all-options.json
@@ -3,6 +3,7 @@
   "checkSourceFiles": true,
   "checkSuppressedErrors": true,
   "failFast": true,
+  "fixtureFileMatch": ["fixtures/*.ts", "**/__fixtures__/**/*"],
   "plugins": ["./tstyche-plugin.js"],
   "rejectAnyType": true,
   "rejectNeverType": true,

--- a/schemas/__tests__/__fixtures__/valid-fixtureFileMatch.json
+++ b/schemas/__tests__/__fixtures__/valid-fixtureFileMatch.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../config.json",
+  "fixtureFileMatch": ["fixtures/*.ts", "**/__fixtures__/**/*"]
+}

--- a/schemas/__tests__/config-schema.test.js
+++ b/schemas/__tests__/config-schema.test.js
@@ -48,6 +48,10 @@ test("config schema", async (t) => {
         testCase: "'failFast' option",
       },
       {
+        fixtureFileName: "valid-fixtureFileMatch.json",
+        testCase: "'fixtureFileMatch' option",
+      },
+      {
         fixtureFileName: "valid-plugins.json",
         testCase: "'plugins' option",
       },
@@ -103,6 +107,18 @@ test("config schema", async (t) => {
       {
         fixtureFileName: "invalid-failFast.json",
         testCase: "value of 'failFast' option must be of type boolean",
+      },
+      {
+        fixtureFileName: "invalid-fixtureFileMatch-1.json",
+        testCase: "item of 'fixtureFileMatch' option must be of type string",
+      },
+      {
+        fixtureFileName: "invalid-fixtureFileMatch-2.json",
+        testCase: "items of 'fixtureFileMatch' option must NOT be identical",
+      },
+      {
+        fixtureFileName: "invalid-fixtureFileMatch-3.json",
+        testCase: "value of 'fixtureFileMatch' option must be of type Array",
       },
       {
         fixtureFileName: "invalid-plugins-1.json",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -16,6 +16,18 @@
       "description": "Stop running tests after the first failed assertion.",
       "type": "boolean"
     },
+    "fixtureFileMatch": {
+      "default": [
+        "**/__fixtures__/*.{ts,tsx}",
+        "**/fixtures/*.{ts,tsx}"
+      ],
+      "description": "The list of glob patterns matching the fixture files.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
     "plugins": {
       "default": [],
       "description": "The list of plugins to use.",

--- a/source/config/ConfigDiagnosticText.ts
+++ b/source/config/ConfigDiagnosticText.ts
@@ -17,6 +17,13 @@ export class ConfigDiagnosticText {
     return `The specified path '${filePath}' does not exist.`;
   }
 
+  static fileMatchPatternCannotStartWith(optionName: string, segment: string): Array<string> {
+    return [
+      `A '${optionName}' pattern cannot start with '${segment}'.`,
+      "The files are only collected within the 'rootPath' directory.",
+    ];
+  }
+
   static inspectSupportedVersions(): string {
     return "Use the '--list' command line option to inspect the list of supported versions.";
   }
@@ -43,13 +50,6 @@ export class ConfigDiagnosticText {
 
   static seen(element: string): string {
     return `The ${element} was seen here.`;
-  }
-
-  static testFileMatchCannotStartWith(segment: string): Array<string> {
-    return [
-      `A test file match pattern cannot start with '${segment}'.`,
-      "The test files are only collected within the 'rootPath' directory.",
-    ];
   }
 
   static unexpected(element: string): string {

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -360,10 +360,16 @@ export class Options {
         break;
       }
 
+      case "fixtureFileMatch":
       case "testFileMatch":
         for (const segment of ["/", "../"]) {
           if (optionValue.startsWith(segment)) {
-            onDiagnostics(Diagnostic.error(ConfigDiagnosticText.testFileMatchCannotStartWith(segment), origin));
+            onDiagnostics(
+              Diagnostic.error(
+                ConfigDiagnosticText.fileMatchPatternCannotStartWith(canonicalOptionName, segment),
+                origin,
+              ),
+            );
           }
         }
         break;

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -77,6 +77,17 @@ export class Options {
     },
 
     {
+      brand: OptionBrand.List,
+      description: "The list of glob patterns matching the fixture files.",
+      group: OptionGroup.ConfigFile,
+      items: {
+        brand: OptionBrand.String,
+        name: "fixtureFileMatch",
+      },
+      name: "fixtureFileMatch",
+    },
+
+    {
       brand: OptionBrand.BareTrue,
       description: "Print the list of command line options with brief descriptions and exit.",
       group: OptionGroup.CommandLine,

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -6,6 +6,7 @@ export const defaultOptions: Required<ConfigFileOptions> = {
   checkSourceFiles: true,
   checkSuppressedErrors: false,
   failFast: false,
+  fixtureFileMatch: ["**/__fixtures__/*.{ts,tsx}", "**/fixtures/*.{ts,tsx}"],
   plugins: [],
   rejectAnyType: true,
   rejectNeverType: true,

--- a/source/config/types.ts
+++ b/source/config/types.ts
@@ -24,6 +24,7 @@ export interface ConfigFileOptions {
   checkSourceFiles?: boolean;
   checkSuppressedErrors?: boolean;
   failFast?: boolean;
+  fixtureFileMatch?: Array<string>;
   plugins?: Array<string>;
   rejectAnyType?: boolean;
   rejectNeverType?: boolean;

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -167,7 +167,7 @@ export class ProjectService {
       ]);
     }
 
-    if (this.#resolvedConfig.checkSourceFiles && !this.#seenTestFiles.has(filePath)) {
+    if (!this.#seenTestFiles.has(filePath)) {
       this.#seenTestFiles.add(filePath);
 
       const languageService = this.getLanguageService(filePath);
@@ -185,11 +185,15 @@ export class ProjectService {
           return false;
         }
 
+        if (Select.isFixtureFile(sourceFile.fileName, { ...this.#resolvedConfig, pathMatch: [] })) {
+          return true;
+        }
+
         if (Select.isTestFile(sourceFile.fileName, { ...this.#resolvedConfig, pathMatch: [] })) {
           return false;
         }
 
-        return true;
+        return this.#resolvedConfig.checkSourceFiles;
       });
 
       const diagnostics: Array<ts.Diagnostic> = [];

--- a/source/select/Select.ts
+++ b/source/select/Select.ts
@@ -77,6 +77,12 @@ export class Select {
     return matchPatterns.includedFile.test(filePath);
   }
 
+  static isFixtureFile(filePath: string, resolvedConfig: ResolvedConfig): boolean {
+    const matchPatterns = Select.#getMatchPatterns(resolvedConfig.fixtureFileMatch);
+
+    return Select.#isFileIncluded(Path.relative(resolvedConfig.rootPath, filePath), matchPatterns, resolvedConfig);
+  }
+
   static isTestFile(filePath: string, resolvedConfig: ResolvedConfig): boolean {
     const matchPatterns = Select.#getMatchPatterns(resolvedConfig.testFileMatch);
 

--- a/tests/__snapshots__/config-fixtureFileMatch-default-patterns-typetests-stderr.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-default-patterns-typetests-stderr.snap.txt
@@ -1,0 +1,32 @@
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/fixtures/b.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/fixtures/b.ts:1:14
+

--- a/tests/__snapshots__/config-fixtureFileMatch-default-patterns-typetests-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-default-patterns-typetests-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/isString.test.ts
+pass ./typetests/isString.test.ts
+
+Targets:    1 failed, 1 total
+Test files: 2 passed, 2 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-empty-list-stderr.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-empty-list-stderr.snap.txt
@@ -1,0 +1,32 @@
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/fixtures/b.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/fixtures/b.ts:1:14
+

--- a/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-empty-list-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-empty-list-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/isString.test.ts
+pass ./typetests/isString.test.ts
+
+Targets:    1 failed, 1 total
+Test files: 2 passed, 2 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-stderr.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-stderr.snap.txt
@@ -1,0 +1,48 @@
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/fixtures/b.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./type-tests/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./type-tests/fixtures/b.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/fixtures/b.ts:1:14
+

--- a/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/isString.test.ts
+pass ./typetests/isString.test.ts
+
+Targets:    1 failed, 1 total
+Test files: 2 passed, 2 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/config-fixtureFileMatch-when-checkSourceFiles-disabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-when-checkSourceFiles-disabled-stderr.snap.txt
@@ -1,0 +1,32 @@
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./__typetests__/fixtures/b.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/__fixtures__/a.ts:1:14
+
+Error: Type 'number' is not assignable to type 'string'. ts(2322)
+
+  1 | export const x: string = 10;
+    |              ~
+  2 | 
+
+      at ./typetests/fixtures/b.ts:1:14
+

--- a/tests/__snapshots__/config-fixtureFileMatch-when-checkSourceFiles-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-when-checkSourceFiles-disabled-stdout.snap.txt
@@ -1,0 +1,10 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/isString.test.ts
+pass ./typetests/isString.test.ts
+
+Targets:    1 failed, 1 total
+Test files: 2 passed, 2 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-fixtureFileMatch-cannot-start-with-dot-dot-slash.snap.txt
+++ b/tests/__snapshots__/validation-fixtureFileMatch-cannot-start-with-dot-dot-slash.snap.txt
@@ -1,0 +1,14 @@
+Error: A 'fixtureFileMatch' pattern cannot start with '../'.
+
+The files are only collected within the 'rootPath' directory.
+
+  1 | {
+  2 |   "fixtureFileMatch": [
+  3 |     "../fixtures"
+    |     ~~~~~~~~~~~~~
+  4 |   ]
+  5 | }
+  6 | 
+
+      at ./tstyche.config.json:3:5
+

--- a/tests/__snapshots__/validation-fixtureFileMatch-cannot-start-with-slash.snap.txt
+++ b/tests/__snapshots__/validation-fixtureFileMatch-cannot-start-with-slash.snap.txt
@@ -1,11 +1,11 @@
-Error: A 'testFileMatch' pattern cannot start with '/'.
+Error: A 'fixtureFileMatch' pattern cannot start with '/'.
 
 The files are only collected within the 'rootPath' directory.
 
   1 | {
-  2 |   "testFileMatch": [
-  3 |     "/feature"
-    |     ~~~~~~~~~~
+  2 |   "fixtureFileMatch": [
+  3 |     "/fixtures"
+    |     ~~~~~~~~~~~
   4 |   ]
   5 | }
   6 | 

--- a/tests/__snapshots__/validation-fixtureFileMatch-wrong-list-item-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-fixtureFileMatch-wrong-list-item-type-stderr.snap.txt
@@ -1,0 +1,12 @@
+Error: Item of the 'fixtureFileMatch' list must be of type string.
+
+  2 |   "fixtureFileMatch": [
+  3 |     "fixtures/*",
+  4 |     false,
+    |     ~~~~~
+  5 |     "**/__fixtures__/*.ts"
+  6 |   ]
+  7 | }
+
+      at ./tstyche.config.json:4:5
+

--- a/tests/__snapshots__/validation-fixtureFileMatch-wrong-option-value-type-stderr.snap.txt
+++ b/tests/__snapshots__/validation-fixtureFileMatch-wrong-option-value-type-stderr.snap.txt
@@ -1,0 +1,11 @@
+Error: Option 'fixtureFileMatch' requires a value of type list.
+
+  1 | {
+  2 |   "fixtureFileMatch": "fixtures",
+    |                       ~~~~~~~~~~
+  3 |   "failFast": true
+  4 | }
+  5 | 
+
+      at ./tstyche.config.json:2:23
+

--- a/tests/__snapshots__/validation-testFileMatch-cannot-start-with-dot-dot-slash.snap.txt
+++ b/tests/__snapshots__/validation-testFileMatch-cannot-start-with-dot-dot-slash.snap.txt
@@ -1,6 +1,6 @@
-Error: A test file match pattern cannot start with '../'.
+Error: A 'testFileMatch' pattern cannot start with '../'.
 
-The test files are only collected within the 'rootPath' directory.
+The files are only collected within the 'rootPath' directory.
 
   1 | {
   2 |   "testFileMatch": [

--- a/tests/config-fixtureFileMatch.test.js
+++ b/tests/config-fixtureFileMatch.test.js
@@ -119,5 +119,36 @@ await test("'fixtureFileMatch' configuration file option", async (t) => {
 
       assert.equal(exitCode, 1);
     });
+
+    await t.test("when 'checkSourceFiles' is disabled", async () => {
+      const config = {
+        checkSourceFiles: false,
+      };
+
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/isString.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+        ["typetests/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["typetests/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["typetests/isString.test.ts"]: isStringTestText,
+      });
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+      await assert.matchSnapshot(normalizeOutput(stderr), {
+        fileName: `${testFileName}-when-checkSourceFiles-disabled-stderr`,
+        testFileUrl: import.meta.url,
+      });
+
+      await assert.matchSnapshot(normalizeOutput(stdout), {
+        fileName: `${testFileName}-when-checkSourceFiles-disabled-stdout`,
+        testFileUrl: import.meta.url,
+      });
+
+      assert.equal(exitCode, 1);
+    });
   });
 });

--- a/tests/config-fixtureFileMatch.test.js
+++ b/tests/config-fixtureFileMatch.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const fixtureWithAnErrorText = `export const x: string = 10;
+`;
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBe<string>();
+});
+`;
+
+const tsconfig = {
+  extends: "../../tsconfig.json",
+  include: ["**/*"],
+};
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'fixtureFileMatch' configuration file option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("default patterns", async (t) => {
+    await t.test("selects files in 'fixtures' directories", async () => {
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/isString.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["typetests/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["typetests/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["typetests/isString.test.ts"]: isStringTestText,
+      });
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+      await assert.matchSnapshot(normalizeOutput(stderr), {
+        fileName: `${testFileName}-default-patterns-typetests-stderr`,
+        testFileUrl: import.meta.url,
+      });
+
+      await assert.matchSnapshot(normalizeOutput(stdout), {
+        fileName: `${testFileName}-default-patterns-typetests-stdout`,
+        testFileUrl: import.meta.url,
+      });
+
+      assert.equal(exitCode, 1);
+    });
+  });
+
+  await t.test("specified pattern", async (t) => {
+    await t.test("select only matching files", async () => {
+      const config = {
+        fixtureFileMatch: ["**/type-tests/fixtures/**/*"],
+      };
+
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/isString.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+        ["type-tests/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["type-tests/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["type-tests/isString.test.ts"]: isStringTestText,
+        ["typetests/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["typetests/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["typetests/isString.test.ts"]: isStringTestText,
+      });
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+      await assert.matchSnapshot(normalizeOutput(stderr), {
+        fileName: `${testFileName}-specified-patterns-stderr`,
+        testFileUrl: import.meta.url,
+      });
+
+      await assert.matchSnapshot(normalizeOutput(stdout), {
+        fileName: `${testFileName}-specified-patterns-stdout`,
+        testFileUrl: import.meta.url,
+      });
+
+      assert.equal(exitCode, 1);
+    });
+
+    await t.test("when list is empty", async () => {
+      const config = {
+        fixtureFileMatch: [],
+      };
+
+      await writeFixture(fixtureUrl, {
+        ["__typetests__/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["__typetests__/isString.test.ts"]: isStringTestText,
+        ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+        ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+        ["typetests/__fixtures__/a.ts"]: fixtureWithAnErrorText,
+        ["typetests/fixtures/b.ts"]: fixtureWithAnErrorText,
+        ["typetests/isString.test.ts"]: isStringTestText,
+      });
+
+      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+      await assert.matchSnapshot(normalizeOutput(stderr), {
+        fileName: `${testFileName}-specified-patterns-empty-list-stderr`,
+        testFileUrl: import.meta.url,
+      });
+
+      await assert.matchSnapshot(normalizeOutput(stdout), {
+        fileName: `${testFileName}-specified-patterns-empty-list-stdout`,
+        testFileUrl: import.meta.url,
+      });
+
+      assert.equal(exitCode, 1);
+    });
+  });
+});

--- a/tests/validation-fixtureFileMatch.test.js
+++ b/tests/validation-fixtureFileMatch.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBe<string>();
+});
+`;
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'fixtureFileMatch' configuration file option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when a pattern starts with '/'", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify({ fixtureFileMatch: ["/fixtures"] }, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-cannot-start-with-slash`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stdout, "");
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when a pattern starts with '../'", async () => {
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify({ fixtureFileMatch: ["../fixtures"] }, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-cannot-start-with-dot-dot-slash`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stdout, "");
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when option value is not a list", async () => {
+    const config = {
+      fixtureFileMatch: "fixtures",
+      failFast: true,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-wrong-option-value-type-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stdout, "");
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when item of the list is not a string", async () => {
+    const config = {
+      fixtureFileMatch: ["fixtures/*", false, "**/__fixtures__/*.ts"],
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/dummy.test.ts"]: isStringTestText,
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-wrong-list-item-type-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(stdout, "");
+    assert.equal(exitCode, 1);
+  });
+});

--- a/typetests/ConfigFileOptions.tst.ts
+++ b/typetests/ConfigFileOptions.tst.ts
@@ -7,6 +7,7 @@ describe("ConfigFileOptions", () => {
       checkSourceFiles: true,
       checkSuppressedErrors: true,
       failFast: true,
+      fixtureFileMatch: ["**/tests/types/fixtures/**/*"],
       plugins: ["./tstyche-plugin.js"],
       rejectAnyType: true,
       rejectNeverType: true,
@@ -37,6 +38,12 @@ describe("ConfigFileOptions", () => {
   test("'failFast' option", () => {
     expect<Pick<tstyche.ConfigFileOptions, "failFast">>().type.toBe<{
       failFast?: boolean;
+    }>();
+  });
+
+  test("'fixtureFileMatch' option", () => {
+    expect<Pick<tstyche.ConfigFileOptions, "fixtureFileMatch">>().type.toBe<{
+      fixtureFileMatch?: Array<string>;
     }>();
   });
 


### PR DESCRIPTION
Closes #532

Add the `fixtureFileMatch` configuration option. It will allow checking fixture files without `checkSourceFiles` enabled.