### PR TITLE
chore(ci): use Yarn from npm

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -136,14 +136,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2
-        # TODO remove this override after Windows support is added to the 'mise-yarn' plugin
-        with:
-          mise_toml: |
-            [settings]
-            disable_tools = ['yarn']
-            experimental = true
-            [hooks]
-            postinstall = 'corepack enable'
       - run: yarn install
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -166,14 +158,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2
-        # TODO remove after Windows support is added to the 'mise-yarn' plugin
-        with:
-          mise_toml: |
-            [settings]
-            disable_tools = ['yarn']
-            experimental = true
-            [hooks]
-            postinstall = 'corepack enable'
       - run: yarn install
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
 hyperfine = "1.19.0"
 jsonschema = "10.0.0"
-node = "lts"
-yarn = "latest"
+node = "22.17.1"
+"npm:@yarnpkg/cli-dist" = "4.9.2"
 
 [tasks."test:schemas"]
 run = "jsonschema test schemas/__tests__/*.test.json --resolve ./schemas/config.json"


### PR DESCRIPTION
Let’s use Yarn from npm instead of the `mise-yarn` plugin. (If Windows allows.)