### PR TITLE
feat!: pass `testTree` to `SuppressedService#match()`

### DIFF
--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -221,8 +221,7 @@ export class AbilityLayer {
     const suppressedErrors = this.#collectSuppressedErrors();
 
     if (this.#resolvedConfig.checkSuppressedErrors) {
-      testTree.suppressedErrors = Object.assign(suppressedErrors, { sourceFile: testTree.sourceFile });
-
+      testTree.suppressedErrors = suppressedErrors;
       this.#suppressedErrorsMap = new Map();
     }
 

--- a/source/collect/TestTree.ts
+++ b/source/collect/TestTree.ts
@@ -2,7 +2,7 @@ import type ts from "typescript";
 import { Directive, type DirectiveRanges } from "#config";
 import type { AssertionNode } from "./AssertionNode.js";
 import type { TestTreeNode } from "./TestTreeNode.js";
-import type { SuppressedErrors } from "./types.js";
+import type { SuppressedError } from "./types.js";
 import type { WhenNode } from "./WhenNode.js";
 
 export class TestTree {
@@ -10,7 +10,7 @@ export class TestTree {
   diagnostics: Set<ts.Diagnostic>;
   hasOnly = false;
   sourceFile: ts.SourceFile;
-  suppressedErrors: SuppressedErrors | undefined;
+  suppressedErrors: Array<SuppressedError> | undefined;
 
   constructor(diagnostics: Set<ts.Diagnostic>, sourceFile: ts.SourceFile) {
     this.diagnostics = diagnostics;

--- a/source/collect/index.ts
+++ b/source/collect/index.ts
@@ -5,5 +5,5 @@ export { TestTree } from "./TestTree.js";
 export { TestTreeNode } from "./TestTreeNode.js";
 export { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
 export { TestTreeNodeFlags } from "./TestTreeNodeFlags.enum.js";
-export type { SuppressedError, SuppressedErrors } from "./types.js";
+export type { SuppressedError } from "./types.js";
 export { WhenNode } from "./WhenNode.js";

--- a/source/collect/types.ts
+++ b/source/collect/types.ts
@@ -7,5 +7,3 @@ export interface SuppressedError {
   argument?: TextRange;
   diagnostics: Array<ts.Diagnostic>;
 }
-
-export type SuppressedErrors = Array<SuppressedError> & { sourceFile: ts.SourceFile };

--- a/source/runner/TaskRunner.ts
+++ b/source/runner/TaskRunner.ts
@@ -87,11 +87,9 @@ export class TaskRunner {
       runMode |= RunMode.Skip;
     }
 
-    if (testTree.suppressedErrors != null) {
-      this.#suppressedService.match(testTree.suppressedErrors, (diagnostics) => {
-        this.#onDiagnostics(diagnostics, taskResult);
-      });
-    }
+    this.#suppressedService.match(testTree, (diagnostics) => {
+      this.#onDiagnostics(diagnostics, taskResult);
+    });
 
     if (inlineConfig?.template) {
       // TODO testTree.children must be not allowed in template files

--- a/source/suppressed/SuppressedService.ts
+++ b/source/suppressed/SuppressedService.ts
@@ -1,10 +1,14 @@
-import type { SuppressedErrors } from "#collect";
+import type { TestTree } from "#collect";
 import { Diagnostic, DiagnosticOrigin, type DiagnosticsHandler, getDiagnosticMessageText } from "#diagnostic";
 import { SuppressedDiagnosticText } from "./SuppressedDiagnosticText.js";
 
 export class SuppressedService {
-  match(suppressedErrors: SuppressedErrors, onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>): void {
-    for (const suppressedError of suppressedErrors) {
+  match(testTree: TestTree, onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>): void {
+    if (!testTree.suppressedErrors) {
+      return;
+    }
+
+    for (const suppressedError of testTree.suppressedErrors) {
       if (suppressedError.diagnostics.length === 0 || suppressedError.ignore) {
         // directive is unused or ignored
         continue;
@@ -16,7 +20,7 @@ export class SuppressedService {
         const origin = new DiagnosticOrigin(
           suppressedError.directive.start,
           suppressedError.directive.end,
-          suppressedErrors.sourceFile,
+          testTree.sourceFile,
         );
 
         onDiagnostics([Diagnostic.error(text, origin)]);
@@ -26,7 +30,7 @@ export class SuppressedService {
 
       const related = [
         Diagnostic.error(SuppressedDiagnosticText.suppressedError(suppressedError.diagnostics.length)),
-        ...Diagnostic.fromDiagnostics(suppressedError.diagnostics, suppressedErrors.sourceFile),
+        ...Diagnostic.fromDiagnostics(suppressedError.diagnostics, testTree.sourceFile),
       ];
 
       if (suppressedError.diagnostics.length > 1) {
@@ -35,7 +39,7 @@ export class SuppressedService {
         const origin = new DiagnosticOrigin(
           suppressedError.directive.start,
           suppressedError.directive.end,
-          suppressedErrors.sourceFile,
+          testTree.sourceFile,
         );
 
         onDiagnostics([Diagnostic.error(text, origin).add({ related })]);
@@ -56,7 +60,7 @@ export class SuppressedService {
         const origin = new DiagnosticOrigin(
           suppressedError.argument.start,
           suppressedError.argument.end,
-          suppressedErrors.sourceFile,
+          testTree.sourceFile,
         );
 
         onDiagnostics([Diagnostic.error(text, origin).add({ related })]);


### PR DESCRIPTION
This change requires to pass `testTree` to `SuppressedService#match()`.