### PR TITLE
chore!: drop support for older Node.js 20 versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.9', '20', '22', '24']
+        node-version: ['20.12', '20', '22', '24']
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
   },
   "packageManager": "yarn@4.9.2",
   "engines": {
-    "node": ">=20.9"
+    "node": ">=20.12"
   }
 }


### PR DESCRIPTION
This drops support for older Node.js 20 versions (to stay in parity with [`create-tstyche`](https://github.com/tstyche/create-tstyche)).