### PR TITLE
fix: handle leading tabs when collecting directives

### DIFF
--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -16,7 +16,7 @@ interface TextRange {
 
 export class AbilityLayer {
   #compiler: typeof ts;
-  #expectErrorRegex = /^(\s*)(\/\/\s*@ts-expect-error)(!?)(:?\s*)(.*)?$/gim;
+  #expectErrorRegex = /^(\s*)(\/\/ *@ts-expect-error)(!?)(:? *)(.*)?$/gim;
   #filePath = "";
   #nodes: Array<AssertionNode | WhenNode> = [];
   #projectService: ProjectService;

--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -16,7 +16,7 @@ interface TextRange {
 
 export class AbilityLayer {
   #compiler: typeof ts;
-  #expectErrorRegex = /^( *)(\/\/ *@ts-expect-error)(!?)(:? *)(.*)?$/gim;
+  #expectErrorRegex = /^(\s*)(\/\/\s*@ts-expect-error)(!?)(:?\s*)(.*)?$/gim;
   #filePath = "";
   #nodes: Array<AssertionNode | WhenNode> = [];
   #projectService: ProjectService;

--- a/source/config/Directive.ts
+++ b/source/config/Directive.ts
@@ -23,7 +23,7 @@ export interface DirectiveRange {
 export type DirectiveRanges = Array<DirectiveRange> & { sourceFile: ts.SourceFile };
 
 export class Directive {
-  static #directiveRegex = /^(\/\/ *@tstyche)( *|-)?(\S*)?( *)?(.*)?/i;
+  static #directiveRegex = /^(\/\/\s*@tstyche)(\s*|-)?(\S*)?(\s*)?(.*)?/i;
 
   static getDirectiveRanges(compiler: typeof ts, sourceFile: ts.SourceFile, position = 0): DirectiveRanges | undefined {
     const comments = compiler.getLeadingCommentRanges(sourceFile.text, position);

--- a/source/config/Directive.ts
+++ b/source/config/Directive.ts
@@ -23,7 +23,7 @@ export interface DirectiveRange {
 export type DirectiveRanges = Array<DirectiveRange> & { sourceFile: ts.SourceFile };
 
 export class Directive {
-  static #directiveRegex = /^(\/\/\s*@tstyche)(\s*|-)?(\S*)?(\s*)?(.*)?/i;
+  static #directiveRegex = /^(\/\/ *@tstyche)( *|-)?(\S*)?( *)?(.*)?/i;
 
   static getDirectiveRanges(compiler: typeof ts, sourceFile: ts.SourceFile, position = 0): DirectiveRanges | undefined {
     const comments = compiler.getLeadingCommentRanges(sourceFile.text, position);

--- a/tests/__snapshots__/config-checkSuppressedErrors-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-checkSuppressedErrors-enabled-stderr.snap.txt
@@ -3,6 +3,8 @@ Error: The diagnostic message did not match.
   1 | // @ts-expect-error Does not work
     |                     ~~~~~~~~~~~~~
   2 | console.log(add);
+  3 | 
+  4 |   // @ts-expect-error Should handle leading spaces
 
       at ./__typetests__/sample.tst.ts:1:21
 
@@ -13,6 +15,56 @@ Error: The diagnostic message did not match.
       1 | // @ts-expect-error Does not work
       2 | console.log(add);
         |             ~~~
+      3 | 
+      4 |   // @ts-expect-error Should handle leading spaces
+      5 |   console.log(spaces);
 
           at ./__typetests__/sample.tst.ts:2:13
+
+Error: The diagnostic message did not match.
+
+  2 | console.log(add);
+  3 | 
+  4 |   // @ts-expect-error Should handle leading spaces
+    |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  5 |   console.log(spaces);
+  6 | 
+  7 |  // @ts-expect-error Should handle leading tabs
+
+      at ./__typetests__/sample.tst.ts:4:23
+
+    The suppressed error:
+
+    Cannot find name 'spaces'. ts(2304)
+
+      3 | 
+      4 |   // @ts-expect-error Should handle leading spaces
+      5 |   console.log(spaces);
+        |               ~~~~~~
+      6 | 
+      7 |  // @ts-expect-error Should handle leading tabs
+      8 |  console.log(tabs);
+
+          at ./__typetests__/sample.tst.ts:5:15
+
+Error: The diagnostic message did not match.
+
+  5 |   console.log(spaces);
+  6 | 
+  7 |  // @ts-expect-error Should handle leading tabs
+    |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  8 |  console.log(tabs);
+
+      at ./__typetests__/sample.tst.ts:7:22
+
+    The suppressed error:
+
+    Cannot find name 'tabs'. ts(2304)
+
+      6 | 
+      7 |  // @ts-expect-error Should handle leading tabs
+      8 |  console.log(tabs);
+        |              ~~~~
+
+          at ./__typetests__/sample.tst.ts:8:14
 

--- a/tests/config-checkSuppressedErrors.test.js
+++ b/tests/config-checkSuppressedErrors.test.js
@@ -5,7 +5,13 @@ import { normalizeOutput } from "./__utilities__/output.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
 
 const testFileText = `// @ts-expect-error Does not work
-console.log(add);`;
+console.log(add);
+
+  // @ts-expect-error Should handle leading spaces
+  console.log(spaces);
+
+\t// @ts-expect-error Should handle leading tabs
+\tconsole.log(tabs);`;
 
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });


### PR DESCRIPTION
Leading tabs must be taken into account when collecting directives.