### PR TITLE
refactor!: rename the `ExpectNode`

### DIFF
--- a/examples/exact-optional-properties.tst.ts
+++ b/examples/exact-optional-properties.tst.ts
@@ -1,6 +1,6 @@
 import { expect } from "tstyche";
 
-// all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+// all four assertions pass only when '"exactOptionalPropertyTypes": true' is set
 
 expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
 expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();

--- a/source/collect/AbilityLayer.ts
+++ b/source/collect/AbilityLayer.ts
@@ -3,7 +3,7 @@ import type { ResolvedConfig } from "#config";
 import { diagnosticBelongsToNode, isDiagnosticWithLocation } from "#diagnostic";
 import type { ProjectService } from "#project";
 import { SourceService } from "#source";
-import type { AssertionNode } from "./AssertionNode.js";
+import type { ExpectNode } from "./ExpectNode.js";
 import { nodeIsChildOfExpressionStatement } from "./helpers.js";
 import type { TestTree } from "./TestTree.js";
 import { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
@@ -20,7 +20,7 @@ export class AbilityLayer {
   #compiler: typeof ts;
   #expectErrorRegex = /^(\s*)(\/\/ *@ts-expect-error)(!?)(:? *)(.*)?$/gim;
   #filePath = "";
-  #nodes: Array<AssertionNode | WhenNode> = [];
+  #nodes: Array<ExpectNode | WhenNode> = [];
   #projectService: ProjectService;
   #resolvedConfig: ResolvedConfig;
   #suppressedErrorsMap: Map<number, SuppressedError> | undefined;
@@ -32,7 +32,7 @@ export class AbilityLayer {
     this.#resolvedConfig = resolvedConfig;
   }
 
-  #addRanges(node: AssertionNode | WhenNode, ranges: Array<TextRange>): void {
+  #addRanges(node: ExpectNode | WhenNode, ranges: Array<TextRange>): void {
     this.#nodes.push(node);
 
     for (const range of ranges) {
@@ -45,12 +45,12 @@ export class AbilityLayer {
     }
   }
 
-  #belongsToNode(node: AssertionNode | WhenNode, diagnostic: ts.Diagnostic) {
+  #belongsToNode(node: ExpectNode | WhenNode, diagnostic: ts.Diagnostic) {
     switch (node.brand) {
       case TestTreeNodeBrand.Expect:
         return (
-          diagnosticBelongsToNode(diagnostic, (node as AssertionNode).matcherNode) &&
-          !diagnosticBelongsToNode(diagnostic, (node as AssertionNode).source)
+          diagnosticBelongsToNode(diagnostic, (node as ExpectNode).matcherNode) &&
+          !diagnosticBelongsToNode(diagnostic, (node as ExpectNode).source)
         );
 
       case TestTreeNodeBrand.When:
@@ -164,7 +164,7 @@ export class AbilityLayer {
     this.#text = "";
   }
 
-  #eraseTrailingComma(node: ts.NodeArray<ts.Expression> | ts.NodeArray<ts.TypeNode>, parent: AssertionNode | WhenNode) {
+  #eraseTrailingComma(node: ts.NodeArray<ts.Expression> | ts.NodeArray<ts.TypeNode>, parent: ExpectNode | WhenNode) {
     if (node.hasTrailingComma) {
       this.#addRanges(parent, [{ start: node.end - 1, end: node.end }]);
     }
@@ -194,7 +194,7 @@ export class AbilityLayer {
     return text.join("");
   }
 
-  handleAssertion(assertionNode: AssertionNode): void {
+  handleAssertion(assertionNode: ExpectNode): void {
     const expectStart = assertionNode.node.getStart();
     const expectExpressionEnd = assertionNode.node.expression.getEnd();
     const expectEnd = assertionNode.node.getEnd();

--- a/source/collect/CollectService.ts
+++ b/source/collect/CollectService.ts
@@ -4,8 +4,8 @@ import { Diagnostic, DiagnosticOrigin } from "#diagnostic";
 import { EventEmitter } from "#events";
 import type { ProjectService } from "#project";
 import { AbilityLayer } from "./AbilityLayer.js";
-import { AssertionNode } from "./AssertionNode.js";
 import { CollectDiagnosticText } from "./CollectDiagnosticText.js";
+import { ExpectNode } from "./ExpectNode.js";
 import { IdentifierLookup, type TestTreeNodeMeta } from "./IdentifierLookup.js";
 import { TestTree } from "./TestTree.js";
 import { TestTreeNode } from "./TestTreeNode.js";
@@ -67,7 +67,7 @@ export class CollectService {
             return;
           }
 
-          const assertionNode = new AssertionNode(
+          const assertionNode = new ExpectNode(
             this.#compiler,
             meta.brand,
             node,
@@ -238,7 +238,7 @@ export class CollectService {
     EventEmitter.dispatch(["collect:error", { diagnostics: [diagnostic] }]);
   }
 
-  #onNode(node: TestTreeNode | AssertionNode | WhenNode, parent: TestTree | TestTreeNode, testTree: TestTree) {
+  #onNode(node: TestTreeNode | ExpectNode | WhenNode, parent: TestTree | TestTreeNode, testTree: TestTree) {
     parent.children.push(node);
 
     if (node.flags & TestTreeNodeFlags.Only) {

--- a/source/collect/ExpectNode.ts
+++ b/source/collect/ExpectNode.ts
@@ -5,7 +5,7 @@ import { TestTreeNode } from "./TestTreeNode.js";
 import type { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
 import type { TestTreeNodeFlags } from "./TestTreeNodeFlags.enum.js";
 
-export class AssertionNode extends TestTreeNode {
+export class ExpectNode extends TestTreeNode {
   abilityDiagnostics = new Set<ts.Diagnostic>();
   isNot: boolean;
   matcherNode: ts.CallExpression | ts.Decorator;

--- a/source/collect/TestTree.ts
+++ b/source/collect/TestTree.ts
@@ -1,11 +1,11 @@
 import type ts from "typescript";
-import type { AssertionNode } from "./AssertionNode.js";
+import type { ExpectNode } from "./ExpectNode.js";
 import type { TestTreeNode } from "./TestTreeNode.js";
 import type { SuppressedError } from "./types.js";
 import type { WhenNode } from "./WhenNode.js";
 
 export class TestTree {
-  children: Array<TestTreeNode | AssertionNode | WhenNode> = [];
+  children: Array<TestTreeNode | ExpectNode | WhenNode> = [];
   diagnostics: Set<ts.Diagnostic>;
   hasOnly = false;
   sourceFile: ts.SourceFile;

--- a/source/collect/TestTreeNode.ts
+++ b/source/collect/TestTreeNode.ts
@@ -1,7 +1,7 @@
 import type ts from "typescript";
 import { Directive, type DirectiveRanges } from "#config";
 import { diagnosticBelongsToNode } from "#diagnostic";
-import type { AssertionNode } from "./AssertionNode.js";
+import type { ExpectNode } from "./ExpectNode.js";
 import type { TestTree } from "./TestTree.js";
 import type { TestTreeNodeBrand } from "./TestTreeNodeBrand.enum.js";
 import type { TestTreeNodeFlags } from "./TestTreeNodeFlags.enum.js";
@@ -9,7 +9,7 @@ import type { WhenNode } from "./WhenNode.js";
 
 export class TestTreeNode {
   brand: TestTreeNodeBrand;
-  children: Array<TestTreeNode | AssertionNode | WhenNode> = [];
+  children: Array<TestTreeNode | ExpectNode | WhenNode> = [];
   diagnostics = new Set<ts.Diagnostic>();
   flags: TestTreeNodeFlags;
   name = "";

--- a/source/collect/index.ts
+++ b/source/collect/index.ts
@@ -1,5 +1,5 @@
-export { AssertionNode } from "./AssertionNode.js";
 export { CollectService } from "./CollectService.js";
+export { ExpectNode } from "./ExpectNode.js";
 export { nodeBelongsToArgumentList } from "./helpers.js";
 export { TestTree } from "./TestTree.js";
 export { TestTreeNode } from "./TestTreeNode.js";

--- a/source/diagnostic/DiagnosticOrigin.ts
+++ b/source/diagnostic/DiagnosticOrigin.ts
@@ -1,31 +1,31 @@
 import type ts from "typescript";
-import type { AssertionNode } from "#collect";
+import type { ExpectNode } from "#collect";
 import { type SourceFile, SourceService } from "#source";
 
 export class DiagnosticOrigin {
-  assertion: AssertionNode | undefined;
+  assertionNode: ExpectNode | undefined;
   end: number;
   sourceFile: SourceFile | ts.SourceFile;
   start: number;
 
-  constructor(start: number, end: number, sourceFile: SourceFile | ts.SourceFile, assertion?: AssertionNode) {
+  constructor(start: number, end: number, sourceFile: SourceFile | ts.SourceFile, assertionNode?: ExpectNode) {
     this.start = start;
     this.end = end;
     this.sourceFile = SourceService.get(sourceFile);
-    this.assertion = assertion;
+    this.assertionNode = assertionNode;
   }
 
-  static fromAssertion(assertion: AssertionNode): DiagnosticOrigin {
-    const node = assertion.matcherNameNode.name;
+  static fromAssertion(assertionNode: ExpectNode): DiagnosticOrigin {
+    const node = assertionNode.matcherNameNode.name;
 
-    return new DiagnosticOrigin(node.getStart(), node.getEnd(), node.getSourceFile(), assertion);
+    return new DiagnosticOrigin(node.getStart(), node.getEnd(), node.getSourceFile(), assertionNode);
   }
 
-  static fromNode(node: ts.Node, assertion?: AssertionNode): DiagnosticOrigin {
-    return new DiagnosticOrigin(node.getStart(), node.getEnd(), node.getSourceFile(), assertion);
+  static fromNode(node: ts.Node, assertionNode?: ExpectNode): DiagnosticOrigin {
+    return new DiagnosticOrigin(node.getStart(), node.getEnd(), node.getSourceFile(), assertionNode);
   }
 
-  static fromNodes(nodes: ts.NodeArray<ts.Node>, assertion?: AssertionNode): DiagnosticOrigin {
-    return new DiagnosticOrigin(nodes.pos, nodes.end, (nodes[0] as ts.Node).getSourceFile(), assertion);
+  static fromNodes(nodes: ts.NodeArray<ts.Node>, assertionNode?: ExpectNode): DiagnosticOrigin {
+    return new DiagnosticOrigin(nodes.pos, nodes.end, (nodes[0] as ts.Node).getSourceFile(), assertionNode);
   }
 }

--- a/source/events/types.ts
+++ b/source/events/types.ts
@@ -1,4 +1,4 @@
-import type { AssertionNode, TestTree, TestTreeNode, WhenNode } from "#collect";
+import type { ExpectNode, TestTree, TestTreeNode, WhenNode } from "#collect";
 import type { Diagnostic } from "#diagnostic";
 import type { DescribeResult, ExpectResult, FileResult, Result, TargetResult, TestResult } from "#result";
 
@@ -23,7 +23,7 @@ export type Event =
   | ["directive:error", { diagnostics: Array<Diagnostic> }]
   | ["collect:start", { tree: TestTree }]
   | ["collect:error", { diagnostics: Array<Diagnostic> }]
-  | ["collect:node", { node: TestTreeNode | AssertionNode | WhenNode }]
+  | ["collect:node", { node: TestTreeNode | ExpectNode | WhenNode }]
   | ["collect:end", { tree: TestTree }]
   | ["describe:start", { result: DescribeResult }]
   | ["describe:end", { result: DescribeResult }]

--- a/source/expect/AbilityMatcherBase.ts
+++ b/source/expect/AbilityMatcherBase.ts
@@ -41,8 +41,8 @@ export abstract class AbilityMatcherBase {
 
     const diagnostics: Array<Diagnostic> = [];
 
-    if (matchWorker.assertion.abilityDiagnostics.size > 0) {
-      for (const diagnostic of matchWorker.assertion.abilityDiagnostics) {
+    if (matchWorker.assertionNode.abilityDiagnostics.size > 0) {
+      for (const diagnostic of matchWorker.assertionNode.abilityDiagnostics) {
         const text = [this.explainNotText(isExpression, targetText), getDiagnosticMessageText(diagnostic)];
 
         let origin: DiagnosticOrigin;
@@ -52,10 +52,10 @@ export abstract class AbilityMatcherBase {
             diagnostic.start,
             getTextSpanEnd(diagnostic),
             sourceNode.getSourceFile(),
-            matchWorker.assertion,
+            matchWorker.assertionNode,
           );
         } else {
-          origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+          origin = DiagnosticOrigin.fromAssertion(matchWorker.assertionNode);
         }
 
         let related: Array<Diagnostic> | undefined;
@@ -67,7 +67,7 @@ export abstract class AbilityMatcherBase {
         diagnostics.push(Diagnostic.error(text.flat(), origin).add({ related }));
       }
     } else {
-      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertionNode);
 
       diagnostics.push(Diagnostic.error(this.explainText(isExpression, targetText), origin));
     }

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -1,19 +1,19 @@
 import type ts from "typescript";
-import type { AssertionNode } from "#collect";
+import type { ExpectNode } from "#collect";
 import { DiagnosticOrigin } from "#diagnostic";
 import { Relation } from "./Relation.enum.js";
 import type { TypeChecker } from "./types.js";
 
 export class MatchWorker {
-  assertion: AssertionNode;
+  assertionNode: ExpectNode;
   #compiler: typeof ts;
   #signatureCache = new Map<ts.Node, Array<ts.Signature>>();
   typeChecker: TypeChecker;
 
-  constructor(compiler: typeof ts, typeChecker: TypeChecker, assertion: AssertionNode) {
+  constructor(compiler: typeof ts, typeChecker: TypeChecker, assertionNode: ExpectNode) {
     this.#compiler = compiler;
     this.typeChecker = typeChecker;
-    this.assertion = assertion;
+    this.assertionNode = assertionNode;
   }
 
   checkHasApplicableIndexType(sourceNode: ts.Node, targetNode: ts.Node): boolean {
@@ -119,10 +119,10 @@ export class MatchWorker {
       symbol.valueDeclaration.getStart() >= enclosingNode.getStart() &&
       symbol.valueDeclaration.getEnd() <= enclosingNode.getEnd()
     ) {
-      return DiagnosticOrigin.fromNode(symbol.valueDeclaration.name, this.assertion);
+      return DiagnosticOrigin.fromNode(symbol.valueDeclaration.name, this.assertionNode);
     }
 
-    return DiagnosticOrigin.fromNode(enclosingNode, this.assertion);
+    return DiagnosticOrigin.fromNode(enclosingNode, this.assertionNode);
   }
 
   #simplifyType(type: ts.Type): ts.Type {

--- a/source/expect/RelationMatcherBase.ts
+++ b/source/expect/RelationMatcherBase.ts
@@ -10,11 +10,11 @@ export abstract class RelationMatcherBase {
     const sourceTypeText = matchWorker.getTypeText(sourceNode);
     const targetTypeText = matchWorker.getTypeText(targetNode);
 
-    const text = matchWorker.assertion.isNot
+    const text = matchWorker.assertionNode.isNot
       ? this.explainText(sourceTypeText, targetTypeText)
       : this.explainNotText(sourceTypeText, targetTypeText);
 
-    const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertion);
+    const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertionNode);
 
     return [Diagnostic.error(text, origin)];
   }

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -23,11 +23,11 @@ export class ToAcceptProps {
     return signatures.reduce<Array<Diagnostic>>((accumulator, signature, index) => {
       let diagnostic: Diagnostic | undefined;
 
-      const introText = matchWorker.assertion.isNot
+      const introText = matchWorker.assertionNode.isNot
         ? ExpectDiagnosticText.acceptsProps(isExpression)
         : ExpectDiagnosticText.doesNotAcceptProps(isExpression);
 
-      const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertion);
+      const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertionNode);
 
       if (signatures.length > 1) {
         const signatureText = this.#typeChecker.signatureToString(signature, sourceNode);
@@ -44,7 +44,7 @@ export class ToAcceptProps {
 
       const { diagnostics, isMatch } = this.#explainProperties(matchWorker, signature, targetNode, diagnostic);
 
-      if (matchWorker.assertion.isNot ? isMatch : !isMatch) {
+      if (matchWorker.assertionNode.isNot ? isMatch : !isMatch) {
         accumulator.push(...diagnostics);
       }
 
@@ -202,7 +202,7 @@ export class ToAcceptProps {
       let accumulator: Array<Diagnostic> = [];
 
       const isMatch = sourceType.types.some((sourceType) => {
-        const text = matchWorker.assertion.isNot
+        const text = matchWorker.assertionNode.isNot
           ? ExpectDiagnosticText.isAssignableWith(sourceTypeText, targetTypeText)
           : ExpectDiagnosticText.isNotAssignableWith(sourceTypeText, targetTypeText);
 

--- a/source/expect/ToBeApplicable.ts
+++ b/source/expect/ToBeApplicable.ts
@@ -49,14 +49,14 @@ export class ToBeApplicable {
   }
 
   #explain(matchWorker: MatchWorker) {
-    const targetText = this.#resolveTargetText(matchWorker.assertion.matcherNode.parent);
+    const targetText = this.#resolveTargetText(matchWorker.assertionNode.matcherNode.parent);
 
     const diagnostics: Array<Diagnostic> = [];
 
-    if (matchWorker.assertion.abilityDiagnostics.size > 0) {
-      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+    if (matchWorker.assertionNode.abilityDiagnostics.size > 0) {
+      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertionNode);
 
-      for (const diagnostic of matchWorker.assertion.abilityDiagnostics) {
+      for (const diagnostic of matchWorker.assertionNode.abilityDiagnostics) {
         const text = [ExpectDiagnosticText.cannotBeApplied(targetText), getDiagnosticMessageText(diagnostic)];
 
         let related: Array<Diagnostic> | undefined;
@@ -68,7 +68,7 @@ export class ToBeApplicable {
         diagnostics.push(Diagnostic.error(text.flat(), origin).add({ related }));
       }
     } else {
-      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+      const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertionNode);
 
       diagnostics.push(Diagnostic.error(ExpectDiagnosticText.canBeApplied(targetText), origin));
     }
@@ -99,7 +99,7 @@ export class ToBeApplicable {
 
     return {
       explain: () => this.#explain(matchWorker),
-      isMatch: matchWorker.assertion.abilityDiagnostics.size === 0,
+      isMatch: matchWorker.assertionNode.abilityDiagnostics.size === 0,
     };
   }
 }

--- a/source/expect/ToBeCallableWith.ts
+++ b/source/expect/ToBeCallableWith.ts
@@ -56,7 +56,7 @@ export class ToBeCallableWith extends AbilityMatcherBase {
 
     return {
       explain: () => this.explain(matchWorker, sourceNode, targetNodes),
-      isMatch: matchWorker.assertion.abilityDiagnostics.size === 0,
+      isMatch: matchWorker.assertionNode.abilityDiagnostics.size === 0,
     };
   }
 }

--- a/source/expect/ToBeConstructableWith.ts
+++ b/source/expect/ToBeConstructableWith.ts
@@ -53,7 +53,7 @@ export class ToBeConstructableWith extends AbilityMatcherBase {
 
     return {
       explain: () => this.explain(matchWorker, sourceNode, targetNodes),
-      isMatch: matchWorker.assertion.abilityDiagnostics.size === 0,
+      isMatch: matchWorker.assertionNode.abilityDiagnostics.size === 0,
     };
   }
 }

--- a/source/expect/ToHaveProperty.ts
+++ b/source/expect/ToHaveProperty.ts
@@ -25,9 +25,9 @@ export class ToHaveProperty {
       propertyNameText = `[${this.#compiler.unescapeLeadingUnderscores(targetType.symbol.escapedName)}]`;
     }
 
-    const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertion);
+    const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertionNode);
 
-    return matchWorker.assertion.isNot
+    return matchWorker.assertionNode.isNot
       ? [Diagnostic.error(ExpectDiagnosticText.hasProperty(sourceTypeText, propertyNameText), origin)]
       : [Diagnostic.error(ExpectDiagnosticText.doesNotHaveProperty(sourceTypeText, propertyNameText), origin)];
   }

--- a/source/expect/ToRaiseError.ts
+++ b/source/expect/ToRaiseError.ts
@@ -15,38 +15,38 @@ export class ToRaiseError {
   #explain(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNodes: ts.NodeArray<ArgumentNode>) {
     const isExpression = nodeBelongsToArgumentList(this.#compiler, sourceNode);
 
-    const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertion);
+    const origin = DiagnosticOrigin.fromAssertion(matchWorker.assertionNode);
 
-    if (matchWorker.assertion.diagnostics.size === 0) {
+    if (matchWorker.assertionNode.diagnostics.size === 0) {
       const text = ExpectDiagnosticText.didNotRaiseError(isExpression);
 
       return [Diagnostic.error(text, origin)];
     }
 
-    if (matchWorker.assertion.diagnostics.size !== targetNodes.length) {
-      const count = matchWorker.assertion.diagnostics.size;
+    if (matchWorker.assertionNode.diagnostics.size !== targetNodes.length) {
+      const count = matchWorker.assertionNode.diagnostics.size;
 
       const text = ExpectDiagnosticText.raisedError(isExpression, count, targetNodes.length);
 
       const related = [
         Diagnostic.error(ExpectDiagnosticText.raisedTypeError(count)),
-        ...Diagnostic.fromDiagnostics([...matchWorker.assertion.diagnostics]),
+        ...Diagnostic.fromDiagnostics([...matchWorker.assertionNode.diagnostics]),
       ];
 
       return [Diagnostic.error(text, origin).add({ related })];
     }
 
-    return [...matchWorker.assertion.diagnostics].reduce<Array<Diagnostic>>((accumulator, diagnostic, index) => {
+    return [...matchWorker.assertionNode.diagnostics].reduce<Array<Diagnostic>>((accumulator, diagnostic, index) => {
       const targetNode = targetNodes[index] as ts.StringLiteralLike | ts.NumericLiteral;
 
       const isMatch = this.#matchExpectedError(diagnostic, targetNode);
 
-      if (matchWorker.assertion.isNot ? isMatch : !isMatch) {
-        const text = matchWorker.assertion.isNot
+      if (matchWorker.assertionNode.isNot ? isMatch : !isMatch) {
+        const text = matchWorker.assertionNode.isNot
           ? ExpectDiagnosticText.raisedMatchingError(isExpression)
           : ExpectDiagnosticText.didNotRaiseMatchingError(isExpression);
 
-        const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertion);
+        const origin = DiagnosticOrigin.fromNode(targetNode, matchWorker.assertionNode);
 
         const related = [
           Diagnostic.error(ExpectDiagnosticText.raisedTypeError()),
@@ -94,11 +94,11 @@ export class ToRaiseError {
     let isMatch: boolean | undefined;
 
     if (targetNodes.length === 0) {
-      isMatch = matchWorker.assertion.diagnostics.size > 0;
+      isMatch = matchWorker.assertionNode.diagnostics.size > 0;
     } else {
       isMatch =
-        matchWorker.assertion.diagnostics.size === targetNodes.length &&
-        [...matchWorker.assertion.diagnostics].every((diagnostic, index) =>
+        matchWorker.assertionNode.diagnostics.size === targetNodes.length &&
+        [...matchWorker.assertionNode.diagnostics].every((diagnostic, index) =>
           this.#matchExpectedError(
             diagnostic,
             targetNodes[index] as ts.StringLiteralLike | ts.NumericLiteral | ts.RegularExpressionLiteral,

--- a/source/output/CodeFrameText.tsx
+++ b/source/output/CodeFrameText.tsx
@@ -145,8 +145,8 @@ export function CodeFrameText({ diagnosticCategory, diagnosticOrigin, options }:
 
   let breadcrumbs: ScribblerJsx.Element | undefined;
 
-  if (showBreadcrumbs && diagnosticOrigin.assertion != null) {
-    breadcrumbs = <BreadcrumbsText ancestor={diagnosticOrigin.assertion.parent} />;
+  if (showBreadcrumbs && diagnosticOrigin.assertionNode != null) {
+    breadcrumbs = <BreadcrumbsText ancestor={diagnosticOrigin.assertionNode.parent} />;
   }
 
   const location = (

--- a/source/result/ExpectResult.ts
+++ b/source/result/ExpectResult.ts
@@ -1,18 +1,18 @@
-import type { AssertionNode } from "#collect";
+import type { ExpectNode } from "#collect";
 import type { Diagnostic } from "#diagnostic";
 import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
 export class ExpectResult {
-  assertion: AssertionNode;
+  assertionNode: ExpectNode;
   diagnostics: Array<Diagnostic> = [];
   parent: TestResult | undefined;
   status: ResultStatus = ResultStatus.Runs;
   timing = new ResultTiming();
 
-  constructor(assertion: AssertionNode, parent?: TestResult) {
-    this.assertion = assertion;
+  constructor(assertionNode: ExpectNode, parent?: TestResult) {
+    this.assertionNode = assertionNode;
     this.parent = parent;
   }
 }

--- a/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/toBe.tst.ts
@@ -56,7 +56,7 @@ test("edge cases", () => {
 });
 
 test("exact optional property types", () => {
-  // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  // all four assertions pass only when '"exactOptionalPropertyTypes": true' is set
 
   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
   expect<{ a?: number | undefined }>().type.not.toBe<{ a?: number }>();

--- a/tests/__snapshots__/api-toBe-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-stderr.snap.txt
@@ -144,7 +144,7 @@ Error: Type '{ a: string; }' is not the same as type '(({ a: string; } & { a: st
 
 Error: Type '{ a?: number | undefined; }' is the same as type '{ a?: number | undefined; }'.
 
-  59 |   // all four assertion pass only when '"exactOptionalPropertyTypes": true' is set
+  59 |   // all four assertions pass only when '"exactOptionalPropertyTypes": true' is set
   60 | 
   61 |   expect<{ a?: number }>().type.not.toBe<{ a?: number | undefined }>();
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Renaming the `AssertionNode` to the `ExpectNode`.

This change makes the internal namings more clear and paves the road for #467.
