### PR TITLE
refactor!: rename `*ResultStatusFlags` enums and turn them into flagged enums

### DIFF
--- a/source/handlers/ResultHandler.ts
+++ b/source/handlers/ResultHandler.ts
@@ -6,7 +6,7 @@ import {
   type FileResult,
   ProjectResult,
   type Result,
-  ResultStatus,
+  ResultStatusFlags,
   type TargetResult,
   type TestResult,
 } from "#result";
@@ -40,11 +40,11 @@ export class ResultHandler implements EventHandler {
         break;
 
       case "target:end":
-        if (this.#targetResult!.status === ResultStatus.Failed) {
+        if (this.#targetResult!.status === ResultStatusFlags.Failed) {
           this.#result!.targetCount.failed++;
         } else {
           this.#result!.targetCount.passed++;
-          this.#targetResult!.status = ResultStatus.Passed;
+          this.#targetResult!.status = ResultStatusFlags.Passed;
         }
 
         this.#targetResult!.timing.end = Date.now();
@@ -53,7 +53,7 @@ export class ResultHandler implements EventHandler {
 
       case "store:error":
         if (payload.diagnostics.some(({ category }) => category === DiagnosticCategory.Error)) {
-          this.#targetResult!.status = ResultStatus.Failed;
+          this.#targetResult!.status = ResultStatusFlags.Failed;
         }
         break;
 
@@ -71,7 +71,7 @@ export class ResultHandler implements EventHandler {
       }
 
       case "project:error":
-        this.#targetResult!.status = ResultStatus.Failed;
+        this.#targetResult!.status = ResultStatusFlags.Failed;
         this.#projectResult!.diagnostics.push(...payload.diagnostics);
         break;
 
@@ -85,23 +85,23 @@ export class ResultHandler implements EventHandler {
       case "file:error":
       case "directive:error":
       case "collect:error":
-        this.#targetResult!.status = ResultStatus.Failed;
-        this.#fileResult!.status = ResultStatus.Failed;
+        this.#targetResult!.status = ResultStatusFlags.Failed;
+        this.#fileResult!.status = ResultStatusFlags.Failed;
         this.#fileResult!.diagnostics.push(...payload.diagnostics);
         break;
 
       case "file:end":
         if (
-          this.#fileResult!.status === ResultStatus.Failed ||
+          this.#fileResult!.status === ResultStatusFlags.Failed ||
           this.#fileResult!.expectCount.failed > 0 ||
           this.#fileResult!.testCount.failed > 0
         ) {
           this.#result!.fileCount.failed++;
-          this.#targetResult!.status = ResultStatus.Failed;
-          this.#fileResult!.status = ResultStatus.Failed;
+          this.#targetResult!.status = ResultStatusFlags.Failed;
+          this.#fileResult!.status = ResultStatusFlags.Failed;
         } else {
           this.#result!.fileCount.passed++;
-          this.#fileResult!.status = ResultStatus.Passed;
+          this.#fileResult!.status = ResultStatusFlags.Passed;
         }
 
         this.#fileResult!.timing.end = Date.now();
@@ -139,7 +139,7 @@ export class ResultHandler implements EventHandler {
         this.#result!.testCount.failed++;
         this.#fileResult!.testCount.failed++;
 
-        this.#testResult!.status = ResultStatus.Failed;
+        this.#testResult!.status = ResultStatusFlags.Failed;
         this.#testResult!.diagnostics.push(...payload.diagnostics);
         this.#testResult!.timing.end = Date.now();
         this.#testResult = undefined;
@@ -149,7 +149,7 @@ export class ResultHandler implements EventHandler {
         this.#result!.testCount.failed++;
         this.#fileResult!.testCount.failed++;
 
-        this.#testResult!.status = ResultStatus.Failed;
+        this.#testResult!.status = ResultStatusFlags.Failed;
         this.#testResult!.timing.end = Date.now();
         this.#testResult = undefined;
         break;
@@ -158,7 +158,7 @@ export class ResultHandler implements EventHandler {
         this.#result!.testCount.passed++;
         this.#fileResult!.testCount.passed++;
 
-        this.#testResult!.status = ResultStatus.Passed;
+        this.#testResult!.status = ResultStatusFlags.Passed;
         this.#testResult!.timing.end = Date.now();
         this.#testResult = undefined;
         break;
@@ -167,7 +167,7 @@ export class ResultHandler implements EventHandler {
         this.#result!.testCount.skipped++;
         this.#fileResult!.testCount.skipped++;
 
-        this.#testResult!.status = ResultStatus.Skipped;
+        this.#testResult!.status = ResultStatusFlags.Skipped;
         this.#testResult!.timing.end = Date.now();
         this.#testResult = undefined;
         break;
@@ -176,7 +176,7 @@ export class ResultHandler implements EventHandler {
         this.#result!.testCount.todo++;
         this.#fileResult!.testCount.todo++;
 
-        this.#testResult!.status = ResultStatus.Todo;
+        this.#testResult!.status = ResultStatusFlags.Todo;
         this.#testResult!.timing.end = Date.now();
         this.#testResult = undefined;
         break;
@@ -200,7 +200,7 @@ export class ResultHandler implements EventHandler {
           this.#testResult.expectCount.failed++;
         }
 
-        this.#expectResult!.status = ResultStatus.Failed;
+        this.#expectResult!.status = ResultStatusFlags.Failed;
         this.#expectResult!.diagnostics.push(...payload.diagnostics);
         this.#expectResult!.timing.end = Date.now();
         this.#expectResult = undefined;
@@ -214,7 +214,7 @@ export class ResultHandler implements EventHandler {
           this.#testResult.expectCount.failed++;
         }
 
-        this.#expectResult!.status = ResultStatus.Failed;
+        this.#expectResult!.status = ResultStatusFlags.Failed;
         this.#expectResult!.timing.end = Date.now();
         this.#expectResult = undefined;
         break;
@@ -227,7 +227,7 @@ export class ResultHandler implements EventHandler {
           this.#testResult.expectCount.passed++;
         }
 
-        this.#expectResult!.status = ResultStatus.Passed;
+        this.#expectResult!.status = ResultStatusFlags.Passed;
         this.#expectResult!.timing.end = Date.now();
         this.#expectResult = undefined;
         break;
@@ -240,7 +240,7 @@ export class ResultHandler implements EventHandler {
           this.#testResult.expectCount.skipped++;
         }
 
-        this.#expectResult!.status = ResultStatus.Skipped;
+        this.#expectResult!.status = ResultStatusFlags.Skipped;
         this.#expectResult!.timing.end = Date.now();
         this.#expectResult = undefined;
         break;

--- a/source/output/__tests__/fileStatusText.test.js
+++ b/source/output/__tests__/fileStatusText.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import test from "node:test";
 import prettyAnsi from "pretty-ansi";
-import { FileLocation, fileStatusText, ResultStatus, Scribbler } from "tstyche/tstyche";
+import { FileLocation, fileStatusText, ResultStatusFlags, Scribbler } from "tstyche/tstyche";
 
 const sampleFileUrl = new URL("../../../path/to/sample.test.ts", import.meta.url);
 const sampleFile = new FileLocation(sampleFileUrl);
@@ -10,19 +10,19 @@ const scribbler = new Scribbler();
 
 test("fileStatusText", async (t) => {
   await t.test("formats failing file status text", () => {
-    const text = scribbler.render(fileStatusText(ResultStatus.Failed, sampleFile));
+    const text = scribbler.render(fileStatusText(ResultStatusFlags.Failed, sampleFile));
 
     assert.strictEqual(prettyAnsi(text), ["<red>fail</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
   });
 
   await t.test("formats passing file status text", () => {
-    const text = scribbler.render(fileStatusText(ResultStatus.Passed, sampleFile));
+    const text = scribbler.render(fileStatusText(ResultStatusFlags.Passed, sampleFile));
 
     assert.strictEqual(prettyAnsi(text), ["<green>pass</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
   });
 
   await t.test("formats running file status text", () => {
-    const text = scribbler.render(fileStatusText(ResultStatus.Runs, sampleFile));
+    const text = scribbler.render(fileStatusText(ResultStatusFlags.Runs, sampleFile));
 
     assert.strictEqual(prettyAnsi(text), ["<yellow>runs</> <gray>./path/to/</>sample.test.ts", ""].join("\n"));
   });

--- a/source/output/__tests__/testNameText.test.js
+++ b/source/output/__tests__/testNameText.test.js
@@ -1,55 +1,55 @@
 import assert from "node:assert";
 import test from "node:test";
 import prettyAnsi from "pretty-ansi";
-import { Scribbler, testNameText } from "tstyche/tstyche";
+import { ResultStatusFlags, Scribbler, testNameText } from "tstyche/tstyche";
 
 const scribbler = new Scribbler();
 
 test("testNameText", async (t) => {
   await t.test("formats failing test name text", () => {
-    const text = scribbler.render(testNameText("fail", "sample test name"));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Failed, "sample test name"));
 
     assert.strictEqual(prettyAnsi(text), ["  <red>×</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats failing test name text with indent", () => {
-    const text = scribbler.render(testNameText("fail", "sample test name", 2));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Failed, "sample test name", 2));
 
     assert.strictEqual(prettyAnsi(text), ["      <red>×</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats passing test name text", () => {
-    const text = scribbler.render(testNameText("pass", "sample test name"));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Passed, "sample test name"));
 
     assert.strictEqual(prettyAnsi(text), ["  <green>+</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats passing test name text with indent", () => {
-    const text = scribbler.render(testNameText("pass", "sample test name", 2));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Passed, "sample test name", 2));
 
     assert.strictEqual(prettyAnsi(text), ["      <green>+</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats skipped test name text", () => {
-    const text = scribbler.render(testNameText("skip", "sample test name"));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Skipped, "sample test name"));
 
     assert.strictEqual(prettyAnsi(text), ["  <yellow>- skip</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats skipped test name text with indent", () => {
-    const text = scribbler.render(testNameText("skip", "sample test name", 2));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Skipped, "sample test name", 2));
 
     assert.strictEqual(prettyAnsi(text), ["      <yellow>- skip</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats todo test name text", () => {
-    const text = scribbler.render(testNameText("todo", "sample test name"));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Todo, "sample test name"));
 
     assert.strictEqual(prettyAnsi(text), ["  <magenta>- todo</> <gray>sample test name</>", ""].join("\n"));
   });
 
   await t.test("formats todo test name text with indent", () => {
-    const text = scribbler.render(testNameText("todo", "sample test name", 2));
+    const text = scribbler.render(testNameText(ResultStatusFlags.Todo, "sample test name", 2));
 
     assert.strictEqual(prettyAnsi(text), ["      <magenta>- todo</> <gray>sample test name</>", ""].join("\n"));
   });

--- a/source/output/fileStatusText.tsx
+++ b/source/output/fileStatusText.tsx
@@ -1,6 +1,6 @@
 import type { FileLocation } from "#file";
 import { Path } from "#path";
-import { type FileResultStatus, ResultStatus } from "#result";
+import { type FileResultStatusFlags, ResultStatusFlags } from "#result";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 
 interface FileNameTextProps {
@@ -22,22 +22,22 @@ function FileNameText({ filePath }: FileNameTextProps) {
   );
 }
 
-export function fileStatusText(status: FileResultStatus, file: FileLocation): ScribblerJsx.Element {
+export function fileStatusText(status: FileResultStatusFlags, file: FileLocation): ScribblerJsx.Element {
   let statusColor: Color;
   let statusText: string;
 
   switch (status) {
-    case ResultStatus.Runs:
+    case ResultStatusFlags.Runs:
       statusColor = Color.Yellow;
       statusText = "runs";
       break;
 
-    case ResultStatus.Passed:
+    case ResultStatusFlags.Passed:
       statusColor = Color.Green;
       statusText = "pass";
       break;
 
-    case ResultStatus.Failed:
+    case ResultStatusFlags.Failed:
       statusColor = Color.Red;
       statusText = "fail";
       break;

--- a/source/output/testNameText.tsx
+++ b/source/output/testNameText.tsx
@@ -1,30 +1,49 @@
+import { ResultStatusFlags } from "#result";
 import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
 
-interface StatusTextProps {
-  status: "fail" | "pass" | "skip" | "todo";
-}
-
-function StatusText({ status }: StatusTextProps) {
-  switch (status) {
-    case "fail":
-      return <Text color={Color.Red}>×</Text>;
-    case "pass":
-      return <Text color={Color.Green}>+</Text>;
-    case "skip":
-      return <Text color={Color.Yellow}>- skip</Text>;
-    case "todo":
-      return <Text color={Color.Magenta}>- todo</Text>;
-  }
-}
-
 export function testNameText(
-  status: "fail" | "pass" | "skip" | "todo",
+  status: Exclude<ResultStatusFlags, ResultStatusFlags.Runs>,
   name: string,
   indent = 0,
 ): ScribblerJsx.Element {
+  let statusColor: Color;
+  let statusText: string;
+
+  // TODO
+
+  // // ResultStatusFlags.Passed | ResultStatusFlags.Fixme
+  // statusColor = Color.Red;
+  // statusText = "× fixme"; // it passed, consider removing '@tstyche fixme'
+
+  // // ResultStatusFlags.Failed | ResultStatusFlags.Fixme
+  // statusColor = Color.Yellow;
+  // statusText = "- fixme"; // it failed, but should be working at some point
+
+  switch (status) {
+    case ResultStatusFlags.Passed:
+      statusColor = Color.Green;
+      statusText = "+";
+      break;
+
+    case ResultStatusFlags.Failed:
+      statusColor = Color.Red;
+      statusText = "×";
+      break;
+
+    case ResultStatusFlags.Skipped:
+      statusColor = Color.Yellow;
+      statusText = "- skip";
+      break;
+
+    case ResultStatusFlags.Todo:
+      statusColor = Color.Magenta;
+      statusText = "- todo";
+      break;
+  }
+
   return (
     <Line indent={indent + 1}>
-      <StatusText status={status} /> <Text color={Color.Gray}>{name}</Text>
+      <Text color={statusColor}>{statusText}</Text> <Text color={Color.Gray}>{name}</Text>
     </Line>
   );
 }

--- a/source/reporters/FileView.ts
+++ b/source/reporters/FileView.ts
@@ -1,4 +1,5 @@
 import { describeNameText, fileViewText, testNameText } from "#output";
+import type { ResultStatusFlags } from "#result";
 import type { ScribblerJsx } from "#scribbler";
 
 export class FileView {
@@ -14,7 +15,7 @@ export class FileView {
     this.#messages.push(message);
   }
 
-  addTest(status: "fail" | "pass" | "skip" | "todo", name: string): void {
+  addTest(status: Exclude<ResultStatusFlags, ResultStatusFlags.Runs>, name: string): void {
     this.#lines.push(testNameText(status, name, this.#indent));
   }
 

--- a/source/reporters/ListReporter.ts
+++ b/source/reporters/ListReporter.ts
@@ -1,5 +1,6 @@
 import { environmentOptions } from "#environment";
 import { addsPackageText, diagnosticText, fileStatusText, OutputService, usesCompilerText } from "#output";
+import { ResultStatusFlags } from "#result";
 import { BaseReporter } from "./BaseReporter.js";
 import { FileView } from "./FileView.js";
 import type { ReporterEvent } from "./types.js";
@@ -104,19 +105,19 @@ export class ListReporter extends BaseReporter {
 
       case "test:skip":
         if (this.#isFileViewExpanded) {
-          this.#fileView.addTest("skip", payload.result.test.name);
+          this.#fileView.addTest(ResultStatusFlags.Skipped, payload.result.test.name);
         }
         break;
 
       case "test:todo":
         if (this.#isFileViewExpanded) {
-          this.#fileView.addTest("todo", payload.result.test.name);
+          this.#fileView.addTest(ResultStatusFlags.Todo, payload.result.test.name);
         }
         break;
 
       case "test:error":
         if (this.#isFileViewExpanded) {
-          this.#fileView.addTest("fail", payload.result.test.name);
+          this.#fileView.addTest(ResultStatusFlags.Failed, payload.result.test.name);
         }
 
         for (const diagnostic of payload.diagnostics) {
@@ -126,13 +127,13 @@ export class ListReporter extends BaseReporter {
 
       case "test:fail":
         if (this.#isFileViewExpanded) {
-          this.#fileView.addTest("fail", payload.result.test.name);
+          this.#fileView.addTest(ResultStatusFlags.Failed, payload.result.test.name);
         }
         break;
 
       case "test:pass":
         if (this.#isFileViewExpanded) {
-          this.#fileView.addTest("pass", payload.result.test.name);
+          this.#fileView.addTest(ResultStatusFlags.Passed, payload.result.test.name);
         }
         break;
 

--- a/source/result/ExpectResult.ts
+++ b/source/result/ExpectResult.ts
@@ -1,6 +1,6 @@
 import type { ExpectNode } from "#collect";
 import type { Diagnostic } from "#diagnostic";
-import { ResultStatus } from "./ResultStatus.enum.js";
+import { ResultStatusFlags } from "./ResultStatusFlags.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
@@ -8,7 +8,7 @@ export class ExpectResult {
   assertionNode: ExpectNode;
   diagnostics: Array<Diagnostic> = [];
   parent: TestResult | undefined;
-  status: ResultStatus = ResultStatus.Runs;
+  status: ResultStatusFlags = ResultStatusFlags.Runs;
   timing = new ResultTiming();
 
   constructor(assertionNode: ExpectNode, parent?: TestResult) {

--- a/source/result/FileResult.ts
+++ b/source/result/FileResult.ts
@@ -3,18 +3,18 @@ import type { FileLocation } from "#file";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
 import { ResultCount } from "./ResultCount.js";
-import { ResultStatus } from "./ResultStatus.enum.js";
+import { ResultStatusFlags } from "./ResultStatusFlags.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
-export type FileResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
+export type FileResultStatusFlags = ResultStatusFlags.Runs | ResultStatusFlags.Passed | ResultStatusFlags.Failed;
 
 export class FileResult {
   diagnostics: Array<Diagnostic> = [];
   expectCount = new ResultCount();
   file: FileLocation;
   results: Array<DescribeResult | TestResult | ExpectResult> = [];
-  status: FileResultStatus = ResultStatus.Runs;
+  status: FileResultStatusFlags = ResultStatusFlags.Runs;
   testCount = new ResultCount();
   timing = new ResultTiming();
 

--- a/source/result/ResultStatus.enum.ts
+++ b/source/result/ResultStatus.enum.ts
@@ -1,7 +1,0 @@
-export const enum ResultStatus {
-  Runs = "runs",
-  Passed = "passed",
-  Failed = "failed",
-  Skipped = "skipped",
-  Todo = "todo",
-}

--- a/source/result/ResultStatusFlags.enum.ts
+++ b/source/result/ResultStatusFlags.enum.ts
@@ -1,0 +1,7 @@
+export const enum ResultStatusFlags {
+  Runs = 1 << 0,
+  Passed = 1 << 1,
+  Failed = 1 << 2,
+  Skipped = 1 << 3,
+  Todo = 1 << 4,
+}

--- a/source/result/TargetResult.ts
+++ b/source/result/TargetResult.ts
@@ -1,14 +1,14 @@
 import type { FileLocation } from "#file";
 import type { ProjectResult } from "./ProjectResult.js";
-import { ResultStatus } from "./ResultStatus.enum.js";
+import { ResultStatusFlags } from "./ResultStatusFlags.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 
-export type TargetResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
+export type TargetResultStatusFlags = ResultStatusFlags.Runs | ResultStatusFlags.Passed | ResultStatusFlags.Failed;
 
 export class TargetResult {
   files: Array<FileLocation>;
   results = new Map<string | undefined, ProjectResult>();
-  status: TargetResultStatus = ResultStatus.Runs;
+  status: TargetResultStatusFlags = ResultStatusFlags.Runs;
   target: string;
   timing = new ResultTiming();
 

--- a/source/result/TestResult.ts
+++ b/source/result/TestResult.ts
@@ -3,7 +3,7 @@ import type { Diagnostic } from "#diagnostic";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
 import { ResultCount } from "./ResultCount.js";
-import { ResultStatus } from "./ResultStatus.enum.js";
+import { ResultStatusFlags } from "./ResultStatusFlags.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 
 export class TestResult {
@@ -11,7 +11,7 @@ export class TestResult {
   expectCount = new ResultCount();
   parent: DescribeResult | undefined;
   results: Array<ExpectResult> = [];
-  status: ResultStatus = ResultStatus.Runs;
+  status: ResultStatusFlags = ResultStatusFlags.Runs;
   test: TestTreeNode;
   timing = new ResultTiming();
 

--- a/source/result/index.ts
+++ b/source/result/index.ts
@@ -1,10 +1,10 @@
 export { DescribeResult } from "./DescribeResult.js";
 export { ExpectResult } from "./ExpectResult.js";
-export { FileResult, type FileResultStatus } from "./FileResult.js";
+export { FileResult, type FileResultStatusFlags } from "./FileResult.js";
 export { ProjectResult } from "./ProjectResult.js";
 export { Result } from "./Result.js";
 export { ResultCount } from "./ResultCount.js";
-export { ResultStatus } from "./ResultStatus.enum.js";
+export { ResultStatusFlags } from "./ResultStatusFlags.enum.js";
 export { ResultTiming } from "./ResultTiming.js";
-export { TargetResult, type TargetResultStatus } from "./TargetResult.js";
+export { TargetResult, type TargetResultStatusFlags } from "./TargetResult.js";
 export { TestResult } from "./TestResult.js";


### PR DESCRIPTION
Part of #497

Renaming and reworking `ResultStatusFlags`, `FileResultStatusFlags` and `FileResultStatusFlags` enums. From now these will be flagged enums.
