### PR TITLE
feat: add the `checkDeclarationFiles` configuration option

### DIFF
--- a/schema/__tests__/all-options.test.json
+++ b/schema/__tests__/all-options.test.json
@@ -5,6 +5,7 @@
       "description": "all options",
       "valid": true,
       "data": {
+        "checkDeclarationFiles": true,
         "checkSourceFiles": true,
         "checkSuppressedErrors": true,
         "failFast": true,

--- a/schema/__tests__/checkDeclarationFiles.test.json
+++ b/schema/__tests__/checkDeclarationFiles.test.json
@@ -1,0 +1,19 @@
+{
+  "target": "../config.json",
+  "tests": [
+    {
+      "description": "'checkDeclarationFiles' option",
+      "valid": true,
+      "data": {
+        "checkDeclarationFiles": true
+      }
+    },
+    {
+      "description": "value of the 'checkDeclarationFiles' option must be of type boolean",
+      "valid": false,
+      "data": {
+        "checkDeclarationFiles": "skip"
+      }
+    }
+  ]
+}

--- a/schema/config.json
+++ b/schema/config.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "checkDeclarationFiles": {
+      "description": "Check declaration files for type errors.",
+      "default": true,
+      "type": "boolean"
+    },
     "checkSourceFiles": {
       "description": "Enable type error reporting for source files.",
       "default": true,

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -43,6 +43,13 @@ export class Options {
 
     {
       brand: OptionBrand.Boolean,
+      description: "Check declaration files for type errors.",
+      group: OptionGroup.ConfigFile,
+      name: "checkDeclarationFiles",
+    },
+
+    {
+      brand: OptionBrand.Boolean,
       description: "Enable type error reporting for source files.",
       group: OptionGroup.ConfigFile,
       name: "checkSourceFiles",

--- a/source/config/defaultOptions.ts
+++ b/source/config/defaultOptions.ts
@@ -3,6 +3,7 @@ import type { ConfigFileOptions } from "./types.js";
 
 export const defaultOptions: Required<ConfigFileOptions> = {
   checkSourceFiles: true,
+  checkDeclarationFiles: true,
   checkSuppressedErrors: true,
   failFast: false,
   fixtureFileMatch: ["**/__fixtures__/*.{ts,tsx}", "**/fixtures/*.{ts,tsx}"],

--- a/source/config/types.ts
+++ b/source/config/types.ts
@@ -21,6 +21,7 @@ export interface CommandLineOptions {
 }
 
 export interface ConfigFileOptions {
+  checkDeclarationFiles?: boolean;
   checkSourceFiles?: boolean;
   checkSuppressedErrors?: boolean;
   failFast?: boolean;

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -97,6 +97,10 @@ export class ProjectService {
 
     const compilerOptions = project?.getCompilerOptions();
 
+    if (this.#resolvedConfig.checkDeclarationFiles && compilerOptions?.skipLibCheck) {
+      project?.setCompilerOptions({ ...compilerOptions, skipLibCheck: false });
+    }
+
     if (this.#resolvedConfig.checkSourceFiles && compilerOptions?.skipLibCheck) {
       project?.setCompilerOptions({ ...compilerOptions, skipLibCheck: false });
     }
@@ -183,6 +187,10 @@ export class ProjectService {
       const sourceFilesToCheck = program.getSourceFiles().filter((sourceFile) => {
         if (program.isSourceFileFromExternalLibrary(sourceFile) || program.isSourceFileDefaultLibrary(sourceFile)) {
           return false;
+        }
+
+        if (this.#resolvedConfig.checkDeclarationFiles && sourceFile.isDeclarationFile) {
+          return true;
         }
 
         if (Select.isFixtureFile(sourceFile.fileName, { ...this.#resolvedConfig, pathMatch: [] })) {

--- a/tests/__snapshots__/config-checkDeclarationFiles-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-checkDeclarationFiles-disabled-stdout.snap.txt
@@ -1,0 +1,11 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/isNumber.test.ts
+pass ./__typetests__/isSample.test.ts
+pass ./__typetests__/isString.test.ts
+
+Targets:    1 passed, 1 total
+Test files: 3 passed, 3 total
+Tests:      2 passed, 2 total
+Assertions: 4 passed, 4 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/config-checkDeclarationFiles-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-checkDeclarationFiles-enabled-stderr.snap.txt
@@ -1,0 +1,56 @@
+Error: 'const' modifier can only appear on a type parameter of a function, method or class ts(1277)
+
+   5 | }
+   6 | 
+   7 | export type ParseKeys<const Context extends {}> = Context;
+     |                       ~~~~~
+   8 | 
+   9 | false();
+  10 | 
+
+       at ./__typetests__/ambient.d.ts:7:23
+
+Error: Statements are not allowed in ambient contexts. ts(1036)
+
+   7 | export type ParseKeys<const Context extends {}> = Context;
+   8 | 
+   9 | false();
+     | ~~~~~
+  10 | 
+
+       at ./__typetests__/ambient.d.ts:9:1
+
+Error: This expression is not callable. ts(2349)
+
+Type 'Boolean' has no call signatures.
+
+   7 | export type ParseKeys<const Context extends {}> = Context;
+   8 | 
+   9 | false();
+     | ~~~~~
+  10 | 
+
+       at ./__typetests__/ambient.d.ts:9:1
+
+Error: Statements are not allowed in ambient contexts. ts(1036)
+
+  1 | export declare function concat(a: string, b: string): string;
+  2 | 
+  3 | false();
+    | ~~~~~
+  4 | 
+
+      at ./__typetests__/concat.d.ts:3:1
+
+Error: This expression is not callable. ts(2349)
+
+Type 'Boolean' has no call signatures.
+
+  1 | export declare function concat(a: string, b: string): string;
+  2 | 
+  3 | false();
+    | ~~~~~
+  4 | 
+
+      at ./__typetests__/concat.d.ts:3:1
+

--- a/tests/__snapshots__/config-checkDeclarationFiles-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-checkDeclarationFiles-enabled-stdout.snap.txt
@@ -1,0 +1,11 @@
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/isNumber.test.ts
+pass ./__typetests__/isSample.test.ts
+pass ./__typetests__/isString.test.ts
+
+Targets:    1 failed, 1 total
+Test files: 3 passed, 3 total
+Tests:      2 passed, 2 total
+Assertions: 4 passed, 4 total
+Duration:   <<timestamp>>

--- a/tests/config-checkDeclarationFiles.test.js
+++ b/tests/config-checkDeclarationFiles.test.js
@@ -1,0 +1,124 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const ambientFileText = `declare module "ambient-example" {
+  interface CustomOptions {
+    test: boolean;
+  }
+}
+
+export type ParseKeys<const Context extends {}> = Context;
+
+false();
+`;
+
+const declarationFileText = `export declare function concat(a: string, b: string): string;
+
+false();
+`;
+
+const sourceFileText = `export type Sample = { a: string };
+
+false();
+`;
+
+const isSampleTestText = `import { expect } from "tstyche";
+import { concat } from "./concat.js";
+import { type Sample } from "./Sample.js";
+
+expect(concat("a", "b")).type.toBe<string>();
+expect<Sample>().type.toBe<{ a: string }>();
+`;
+
+const isStringTestText = `import { expect, test } from "tstyche";
+test("is string?", () => {
+  expect<string>().type.toBe<string>();
+});
+`;
+
+const isNumberTestText = `import { expect, test } from "tstyche";
+test("is number?", () => {
+  expect<number>().type.toBe<number>();
+});
+`;
+
+const tsconfig = {
+  extends: "../../tsconfig.json",
+  compilerOptions: {
+    skipLibCheck: true, // must be ignored, if 'checkDeclarationFiles' is enabled
+  },
+  include: ["**/*"],
+};
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'checkDeclarationFiles' config file option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when enabled", async () => {
+    const config = {
+      checkDeclarationFiles: true,
+      checkSourceFiles: false,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/ambient.d.ts"]: ambientFileText,
+      ["__typetests__/concat.d.ts"]: declarationFileText,
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isSample.test.ts"]: isSampleTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["__typetests__/Sample.ts"]: sourceFileText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-enabled-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-enabled-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when disabled", async () => {
+    const config = {
+      checkDeclarationFiles: false,
+      checkSourceFiles: false,
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/ambient.d.ts"]: ambientFileText,
+      ["__typetests__/concat.d.ts"]: declarationFileText,
+      ["__typetests__/isNumber.test.ts"]: isNumberTestText,
+      ["__typetests__/isSample.test.ts"]: isSampleTestText,
+      ["__typetests__/isString.test.ts"]: isStringTestText,
+      ["__typetests__/Sample.ts"]: sourceFileText,
+      ["tsconfig.json"]: JSON.stringify(tsconfig, null, 2),
+      ["tstyche.config.json"]: JSON.stringify(config, null, 2),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    assert.equal(stderr, "");
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-disabled-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+});

--- a/typetests/ConfigFileOptions.tst.ts
+++ b/typetests/ConfigFileOptions.tst.ts
@@ -4,6 +4,7 @@ import type * as tstyche from "tstyche/tstyche";
 describe("ConfigFileOptions", () => {
   test("all options", () => {
     expect<tstyche.ConfigFileOptions>().type.toBeAssignableWith({
+      checkDeclarationFiles: true,
       checkSourceFiles: true,
       checkSuppressedErrors: true,
       failFast: true,
@@ -21,6 +22,12 @@ describe("ConfigFileOptions", () => {
 
   test("all options are optional", () => {
     expect<tstyche.ConfigFileOptions>().type.toBeAssignableWith({});
+  });
+
+  test("'checkDeclarationFiles' option", () => {
+    expect<Pick<tstyche.ConfigFileOptions, "checkDeclarationFiles">>().type.toBe<{
+      checkDeclarationFiles?: boolean;
+    }>();
   });
 
   test("'checkSourceFiles' option", () => {


### PR DESCRIPTION
Adding the `checkDeclarationFiles` configuration option. This is useful for libraries with handcrafted declaration files.

Differently from `checkSourceFiles` it will only check `.d.ts` files. 