### PR TITLE
refactor!: remove `allowJs` and `checkJs` from default compiler options

### DIFF
--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -65,8 +65,6 @@ export class ProjectService {
 
   #getDefaultCompilerOptions() {
     const defaultCompilerOptions: ts.server.protocol.CompilerOptions = {
-      allowJs: true,
-      checkJs: true,
       exactOptionalPropertyTypes: true,
       jsx: this.#compiler.JsxEmit.Preserve,
       module: this.#compiler.ModuleKind.NodeNext,


### PR DESCRIPTION
Removing `allowJs` and `checkJs` from default compiler options. Seems like they are not really useful. 