### PR TITLE
feat: allow suppressed error messages to be truncated

### DIFF
--- a/tests/__snapshots__/config-checkSuppressedErrors-enabled-stderr.snap.txt
+++ b/tests/__snapshots__/config-checkSuppressedErrors-enabled-stderr.snap.txt
@@ -1,70 +1,102 @@
-Error: The diagnostic message did not match.
+Error: Directive requires an argument.
 
-  1 | // @ts-expect-error Does not work
-    |                     ~~~~~~~~~~~~~
-  2 | console.log(add);
-  3 | 
-  4 |   // @ts-expect-error Should handle leading spaces
+Add a fragment of the expected error message after the directive.
+To ignore the directive, append the '!' character after it.
 
-      at ./__typetests__/sample.tst.ts:1:21
+   6 | a = true;
+   7 | 
+   8 | // @ts-expect-error
+     | ~~~~~~~~~~~~~~~~~~~
+   9 | console.log(add);
+  10 | 
+  11 | // @ts-expect-error Does not work
+
+       at ./__typetests__/sample.tst.ts:8:1
 
     The suppressed error:
 
     Cannot find name 'add'. ts(2304)
 
-      1 | // @ts-expect-error Does not work
-      2 | console.log(add);
-        |             ~~~
-      3 | 
-      4 |   // @ts-expect-error Should handle leading spaces
-      5 |   console.log(spaces);
+       7 | 
+       8 | // @ts-expect-error
+       9 | console.log(add);
+         |             ~~~
+      10 | 
+      11 | // @ts-expect-error Does not work
+      12 | console.log(add);
 
-          at ./__typetests__/sample.tst.ts:2:13
+           at ./__typetests__/sample.tst.ts:9:13
 
 Error: The diagnostic message did not match.
 
-  2 | console.log(add);
-  3 | 
-  4 |   // @ts-expect-error Should handle leading spaces
-    |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  5 |   console.log(spaces);
-  6 | 
-  7 |  // @ts-expect-error Should handle leading tabs
+   9 | console.log(add);
+  10 | 
+  11 | // @ts-expect-error Does not work
+     |                     ~~~~~~~~~~~~~
+  12 | console.log(add);
+  13 | 
+  14 |   // @ts-expect-error Should handle leading spaces
 
-      at ./__typetests__/sample.tst.ts:4:23
+       at ./__typetests__/sample.tst.ts:11:21
+
+    The suppressed error:
+
+    Cannot find name 'add'. ts(2304)
+
+      10 | 
+      11 | // @ts-expect-error Does not work
+      12 | console.log(add);
+         |             ~~~
+      13 | 
+      14 |   // @ts-expect-error Should handle leading spaces
+      15 |   console.log(spaces);
+
+           at ./__typetests__/sample.tst.ts:12:13
+
+Error: The diagnostic message did not match.
+
+  12 | console.log(add);
+  13 | 
+  14 |   // @ts-expect-error Should handle leading spaces
+     |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  15 |   console.log(spaces);
+  16 | 
+  17 |  // @ts-expect-error Should handle leading tabs
+
+       at ./__typetests__/sample.tst.ts:14:23
 
     The suppressed error:
 
     Cannot find name 'spaces'. ts(2304)
 
-      3 | 
-      4 |   // @ts-expect-error Should handle leading spaces
-      5 |   console.log(spaces);
-        |               ~~~~~~
-      6 | 
-      7 |  // @ts-expect-error Should handle leading tabs
-      8 |  console.log(tabs);
+      13 | 
+      14 |   // @ts-expect-error Should handle leading spaces
+      15 |   console.log(spaces);
+         |               ~~~~~~
+      16 | 
+      17 |  // @ts-expect-error Should handle leading tabs
+      18 |  console.log(tabs);
 
-          at ./__typetests__/sample.tst.ts:5:15
+           at ./__typetests__/sample.tst.ts:15:15
 
 Error: The diagnostic message did not match.
 
-  5 |   console.log(spaces);
-  6 | 
-  7 |  // @ts-expect-error Should handle leading tabs
-    |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
-  8 |  console.log(tabs);
+  15 |   console.log(spaces);
+  16 | 
+  17 |  // @ts-expect-error Should handle leading tabs
+     |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  18 |  console.log(tabs);
 
-      at ./__typetests__/sample.tst.ts:7:22
+       at ./__typetests__/sample.tst.ts:17:22
 
     The suppressed error:
 
     Cannot find name 'tabs'. ts(2304)
 
-      6 | 
-      7 |  // @ts-expect-error Should handle leading tabs
-      8 |  console.log(tabs);
-        |              ~~~~
+      16 | 
+      17 |  // @ts-expect-error Should handle leading tabs
+      18 |  console.log(tabs);
+         |              ~~~~
 
-          at ./__typetests__/sample.tst.ts:8:14
+           at ./__typetests__/sample.tst.ts:18:14
 

--- a/tests/config-checkSuppressedErrors.test.js
+++ b/tests/config-checkSuppressedErrors.test.js
@@ -4,7 +4,17 @@ import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "
 import { normalizeOutput } from "./__utilities__/output.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
 
-const testFileText = `// @ts-expect-error Does not work
+const testFileText = `let a: Promise<string>;
+
+// @ts-expect-error Type 'number' is not assignable to type 'Promise<string>'.
+a = 123;
+// @ts-expect-error Type 'boolean' is not assignable to type 'Promise<...>' -- Allows messages to be truncated
+a = true;
+
+// @ts-expect-error
+console.log(add);
+
+// @ts-expect-error Does not work
 console.log(add);
 
   // @ts-expect-error Should handle leading spaces


### PR DESCRIPTION
Long error messages get truncated by TypeScript:

> Argument of type 'VariableRegistry<EnvironmentRegistry<Environment<"env1", { env: Record<string, string>; }, Resolution<"hardcoded", { env: Record<string, string>; }, string, "sync"> | Resolution<"from-env", { ...; }, string | undefined, "sync"> | Resolution<...>> | Environment<...>>, Variable<...>>' is not assignable to parameter of type 'never'.

This PR allow suppressed error messages to be shortened using `...`. The above can be checked like this:

```ts
// @ts-expect-error Argument of type 'VariableRegistry<...>' is not assignable to parameter of type 'never'.
```