### PR TITLE
fix: always respect `// @ts-expect-error` above ability matchers

### DIFF
--- a/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stderr.snap.txt
@@ -1,37 +1,23 @@
 Error: Expression is callable with the given argument.
 
-  13 |   expect(concat(1)).type.toBeCallableWith("two");
-  14 |   // @ts-expect-error!
-  15 |   expect(concat(2)).type.not.toBeCallableWith("two"); // fail
+  15 |   expect(concat(1)).type.toBeCallableWith("two");
+  16 |   // @ts-expect-error!
+  17 |   expect(concat(2)).type.not.toBeCallableWith("two"); // fail
      |                              ~~~~~~~~~~~~~~~~
-  16 | 
-  17 |   // @ts-expect-error!
-  18 |   expect(concat(3)).type.not.toBeCallableWith();
-
-       at ./__typetests__/toBeCallableWith.tst.ts:15:30 ❭ handles '// @ts-expect-error' directive
-
-Error: Expression is not callable without arguments.
-
-Expected 1 arguments, but got 0.
-
-  18 |   expect(concat(3)).type.not.toBeCallableWith();
+  18 | 
   19 |   // @ts-expect-error!
-  20 |   expect(concat(3)).type.toBeCallableWith(); // fail
-     |                          ~~~~~~~~~~~~~~~~
-  21 | });
-  22 | 
+  20 |   concat(3)();
 
-       at ./__typetests__/toBeCallableWith.tst.ts:20:26 ❭ handles '// @ts-expect-error' directive
+       at ./__typetests__/toBeCallableWith.tst.ts:17:30 ❭ respects '// @ts-expect-error' directive
 
-    An argument for 'second' was not provided. ts(6210)
+Error: Expression is callable without arguments.
 
-      3 | const concat =
-      4 |   (first: string) =>
-      5 |   (second: string): string =>
-        |    ~~~~~~~~~~~~~~
-      6 |     first + second;
-      7 | 
-      8 | test("handles '// @ts-expect-error' directive", () => {
+  22 |   expect(concat(3)).type.toBeCallableWith();
+  23 |   // @ts-expect-error!
+  24 |   expect(concat(3)).type.not.toBeCallableWith(); // fail
+     |                              ~~~~~~~~~~~~~~~~
+  25 | });
+  26 | 
 
-          at ./__typetests__/toBeCallableWith.tst.ts:5:4
+       at ./__typetests__/toBeCallableWith.tst.ts:24:30 ❭ respects '// @ts-expect-error' directive
 

--- a/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stdout.snap.txt
@@ -1,7 +1,7 @@
 uses TypeScript <<version>>
 
 fail ./__typetests__/toBeCallableWith.tst.ts
-  × handles '// @ts-expect-error' directive
+  × respects '// @ts-expect-error' directive
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total

--- a/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stderr.snap.txt
@@ -1,37 +1,23 @@
 Error: Expression is constructable with the given argument.
 
-  20 |   expect(getPersonConstructor(true)).type.toBeConstructableWith("abc");
-  21 |   // @ts-expect-error!
-  22 |   expect(getPersonConstructor(true)).type.not.toBeConstructableWith("abc"); // fail
-     |                                               ~~~~~~~~~~~~~~~~~~~~~
-  23 | 
-  24 |   // @ts-expect-error!
-  25 |   expect(getPersonConstructor(true)).type.not.toBeConstructableWith();
-
-       at ./__typetests__/toBeCallableWith.tst.ts:22:47 ❭ handles '// @ts-expect-error' directive
-
-Error: Expression is not constructable without arguments.
-
-Expected 1 arguments, but got 0.
-
-  25 |   expect(getPersonConstructor(true)).type.not.toBeConstructableWith();
+  22 |   expect(getPersonConstructor(false)).type.toBeConstructableWith("abc");
+  23 |   // @ts-expect-error!
+  24 |   expect(getPersonConstructor(false)).type.not.toBeConstructableWith("abc"); // fail
+     |                                                ~~~~~~~~~~~~~~~~~~~~~
+  25 | 
   26 |   // @ts-expect-error!
-  27 |   expect(getPersonConstructor(true)).type.toBeConstructableWith(); // fail
-     |                                           ~~~~~~~~~~~~~~~~~~~~~
-  28 | });
-  29 | 
+  27 |   new (getPersonConstructor(false))();
 
-       at ./__typetests__/toBeCallableWith.tst.ts:27:43 ❭ handles '// @ts-expect-error' directive
+       at ./__typetests__/toBeCallableWith.tst.ts:24:48 ❭ handles '// @ts-expect-error' directive
 
-    An argument for 'name' was not provided. ts(6210)
+Error: Expression is constructable without arguments.
 
-      4 |   _name: string;
-      5 | 
-      6 |   constructor(name: string) {
-        |               ~~~~~~~~~~~~
-      7 |     this._name = name;
-      8 |   }
-      9 | }
+  29 |   expect(getPersonConstructor(false)).type.toBeConstructableWith();
+  30 |   // @ts-expect-error!
+  31 |   expect(getPersonConstructor(false)).type.not.toBeConstructableWith(); // fail
+     |                                                ~~~~~~~~~~~~~~~~~~~~~
+  32 | });
+  33 | 
 
-          at ./__typetests__/toBeCallableWith.tst.ts:6:15
+       at ./__typetests__/toBeCallableWith.tst.ts:31:48 ❭ handles '// @ts-expect-error' directive
 

--- a/tests/__snapshots__/validation-when-action-not-supported-stderr.snap.txt
+++ b/tests/__snapshots__/validation-when-action-not-supported-stderr.snap.txt
@@ -8,15 +8,3 @@ Error: The '.isSupportedWith()' action is not supported.
 
       at ./__typetests__/action-not-supported.tst.ts:7:12
 
-Error: Expression is not callable with the given argument.
-
-Argument of type '"valid"' is not assignable to parameter of type 'never'.
-
-  5 | 
-  6 | // @ts-expect-error!
-  7 | when(pipe).isSupportedWith({ valid: true }, expect(pick).type.toBeCallableWith("valid"));
-    |                                                                                ~~~~~~~
-  8 | 
-
-      at ./__typetests__/action-not-supported.tst.ts:7:80
-

--- a/tests/__snapshots__/validation-when-action-not-supported-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-action-not-supported-stdout.snap.txt
@@ -4,5 +4,5 @@ fail ./__typetests__/action-not-supported.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Assertions: 1 failed, 1 total
+Assertions: 1 passed, 1 total
 Duration:   <<timestamp>>

--- a/tests/api-toBeCallableWith.test.js
+++ b/tests/api-toBeCallableWith.test.js
@@ -180,7 +180,7 @@ test("handles trailing comma?", () => {
     assert.equal(exitCode, 1);
   });
 
-  await t.test("handles '// @ts-expect-error' directive", async (t) => {
+  await t.test("respects '// @ts-expect-error' directive", async (t) => {
     const toBeCallableWithText = `import { expect, test } from "tstyche";
 
 const concat =
@@ -188,19 +188,23 @@ const concat =
   (second: string): string =>
     first + second;
 
-test("handles '// @ts-expect-error' directive", () => {
+test("respects '// @ts-expect-error' directive", () => {
   expect(concat("one")).type.toBeCallableWith("two");
   expect(concat("one")).type.not.toBeCallableWith();
 
+  // @ts-expect-error!
+  concat(1)("two");
   // @ts-expect-error!
   expect(concat(1)).type.toBeCallableWith("two");
   // @ts-expect-error!
   expect(concat(2)).type.not.toBeCallableWith("two"); // fail
 
   // @ts-expect-error!
-  expect(concat(3)).type.not.toBeCallableWith();
+  concat(3)();
   // @ts-expect-error!
-  expect(concat(3)).type.toBeCallableWith(); // fail
+  expect(concat(3)).type.toBeCallableWith();
+  // @ts-expect-error!
+  expect(concat(3)).type.not.toBeCallableWith(); // fail
 });
 `;
 

--- a/tests/api-toBeConstructableWith.test.js
+++ b/tests/api-toBeConstructableWith.test.js
@@ -199,7 +199,7 @@ test("Pair", () => {
     assert.equal(exitCode, 1);
   });
 
-  await t.test("handles '// @ts-expect-error' directive", async (t) => {
+  await t.test("respects '// @ts-expect-error' directive", async (t) => {
     const toBeConstructableWithText = `import { expect, test } from "tstyche";
 
 class Person {
@@ -219,14 +219,18 @@ test("handles '// @ts-expect-error' directive", () => {
   expect(getPersonConstructor()).type.not.toBeConstructableWith();
 
   // @ts-expect-error!
-  expect(getPersonConstructor(true)).type.toBeConstructableWith("abc");
+  new (getPersonConstructor(false))("abc");
   // @ts-expect-error!
-  expect(getPersonConstructor(true)).type.not.toBeConstructableWith("abc"); // fail
+  expect(getPersonConstructor(false)).type.toBeConstructableWith("abc");
+  // @ts-expect-error!
+  expect(getPersonConstructor(false)).type.not.toBeConstructableWith("abc"); // fail
 
   // @ts-expect-error!
-  expect(getPersonConstructor(true)).type.not.toBeConstructableWith();
+  new (getPersonConstructor(false))();
   // @ts-expect-error!
-  expect(getPersonConstructor(true)).type.toBeConstructableWith(); // fail
+  expect(getPersonConstructor(false)).type.toBeConstructableWith();
+  // @ts-expect-error!
+  expect(getPersonConstructor(false)).type.not.toBeConstructableWith(); // fail
 });
 `;
 


### PR DESCRIPTION
This changes ensures `// @ts-expect-error` is always respected above ability matchers.

I think there is no need to handle `// @ts-expect-error` somehow special. Better to follow TypeScript behaviour: add `// @ts-expect-error` above and you can call an expression with any or none arguments.

---

On second thought, users do not see diagnostics of the ability layer in their editors. Reporting these is somewhat misleading. Not clear where they are coming from.