### PR TITLE
refactor!: remove the `*Result.diagnostics` property

### DIFF
--- a/source/handlers/ResultHandler.ts
+++ b/source/handlers/ResultHandler.ts
@@ -72,7 +72,6 @@ export class ResultHandler implements EventHandler {
 
       case "project:error":
         this.#targetResult!.status = ResultStatus.Failed;
-        this.#projectResult!.diagnostics.push(...payload.diagnostics);
         break;
 
       case "file:start":
@@ -87,7 +86,6 @@ export class ResultHandler implements EventHandler {
       case "collect:error":
         this.#targetResult!.status = ResultStatus.Failed;
         this.#fileResult!.status = ResultStatus.Failed;
-        this.#fileResult!.diagnostics.push(...payload.diagnostics);
         break;
 
       case "file:end":
@@ -140,7 +138,6 @@ export class ResultHandler implements EventHandler {
         this.#fileResult!.testCount.failed++;
 
         this.#testResult!.status = ResultStatus.Failed;
-        this.#testResult!.diagnostics.push(...payload.diagnostics);
         this.#testResult!.timing.end = Date.now();
         this.#testResult = undefined;
         break;
@@ -210,7 +207,6 @@ export class ResultHandler implements EventHandler {
         }
 
         this.#expectResult!.status = ResultStatus.Failed;
-        this.#expectResult!.diagnostics.push(...payload.diagnostics);
         this.#expectResult!.timing.end = Date.now();
         this.#expectResult = undefined;
         break;

--- a/source/result/ExpectResult.ts
+++ b/source/result/ExpectResult.ts
@@ -1,12 +1,10 @@
 import type { ExpectNode } from "#collect";
-import type { Diagnostic } from "#diagnostic";
 import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
 export class ExpectResult {
   expect: ExpectNode;
-  diagnostics: Array<Diagnostic> = [];
   parent: TestResult | undefined;
   status: ResultStatus = ResultStatus.Runs;
   timing = new ResultTiming();

--- a/source/result/FileResult.ts
+++ b/source/result/FileResult.ts
@@ -1,4 +1,3 @@
-import type { Diagnostic } from "#diagnostic";
 import type { FileLocation } from "#file";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
@@ -10,7 +9,6 @@ import type { TestResult } from "./TestResult.js";
 export type FileResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
 
 export class FileResult {
-  diagnostics: Array<Diagnostic> = [];
   assertionCount = new ResultCount();
   file: FileLocation;
   results: Array<DescribeResult | TestResult | ExpectResult> = [];

--- a/source/result/ProjectResult.ts
+++ b/source/result/ProjectResult.ts
@@ -1,9 +1,7 @@
-import type { Diagnostic } from "#diagnostic";
 import type { FileResult } from "./FileResult.js";
 
 export class ProjectResult {
   compilerVersion: string;
-  diagnostics: Array<Diagnostic> = [];
   projectConfigFilePath: string | undefined;
   results: Array<FileResult> = [];
 

--- a/source/result/TestResult.ts
+++ b/source/result/TestResult.ts
@@ -1,5 +1,4 @@
 import type { TestTreeNode } from "#collect";
-import type { Diagnostic } from "#diagnostic";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
 import { ResultCount } from "./ResultCount.js";
@@ -7,7 +6,6 @@ import { ResultStatus } from "./ResultStatus.enum.js";
 import { ResultTiming } from "./ResultTiming.js";
 
 export class TestResult {
-  diagnostics: Array<Diagnostic> = [];
   assertionCount = new ResultCount();
   parent: DescribeResult | undefined;
   results: Array<ExpectResult> = [];


### PR DESCRIPTION
Removing the `*Result.diagnostics` property. It is not constantly implemented on all `Result` objects and does not seem to be useful. `diagnostics` is always available in event’s payload.