### PR TITLE
refactor!: export `ResultCounts` and `ResultTiming` as types only

### DIFF
--- a/source/output/summaryText.tsx
+++ b/source/output/summaryText.tsx
@@ -29,19 +29,19 @@ function CountsText({ counts, total }: CountsTextProps) {
           <Text>{", "}</Text>
         </Text>
       ) : undefined}
-      {counts.fixme > 0 ? (
+      {"fixme" in counts && counts.fixme > 0 ? (
         <Text>
           <Text color={Color.Yellow}>{counts.fixme} fixme</Text>
           <Text>{", "}</Text>
         </Text>
       ) : undefined}
-      {counts.skipped > 0 ? (
+      {"skipped" in counts && counts.skipped > 0 ? (
         <Text>
           <Text color={Color.Yellow}>{counts.skipped} skipped</Text>
           <Text>{", "}</Text>
         </Text>
       ) : undefined}
-      {counts.todo > 0 ? (
+      {"todo" in counts && counts.todo > 0 ? (
         <Text>
           <Text color={Color.Magenta}>{counts.todo} todo</Text>
           <Text>{", "}</Text>

--- a/source/result/DescribeResult.ts
+++ b/source/result/DescribeResult.ts
@@ -1,12 +1,12 @@
 import type { TestTreeNode } from "#collect";
-import { ResultTiming } from "./ResultTiming.js";
+import { createResultTiming } from "./helpers.js";
 import type { TestResult } from "./TestResult.js";
 
 export class DescribeResult {
   describe: TestTreeNode;
   parent: DescribeResult | undefined;
   results: Array<DescribeResult | TestResult> = [];
-  timing = new ResultTiming();
+  timing = createResultTiming();
 
   constructor(describe: TestTreeNode, parent?: DescribeResult) {
     this.describe = describe;

--- a/source/result/ExpectResult.ts
+++ b/source/result/ExpectResult.ts
@@ -1,13 +1,13 @@
 import type { ExpectNode } from "#collect";
+import { createResultTiming } from "./helpers.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
-import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
 
 export class ExpectResult {
   expect: ExpectNode;
   parent: TestResult | undefined;
   status: ResultStatus = ResultStatus.Runs;
-  timing = new ResultTiming();
+  timing = createResultTiming();
 
   constructor(expect: ExpectNode, parent?: TestResult) {
     this.expect = expect;

--- a/source/result/FileResult.ts
+++ b/source/result/FileResult.ts
@@ -1,20 +1,18 @@
 import type { FileLocation } from "#file";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
-import { ResultCounts } from "./ResultCounts.js";
+import { createAssertionCounts, createResultTiming, createTestCounts } from "./helpers.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
-import { ResultTiming } from "./ResultTiming.js";
 import type { TestResult } from "./TestResult.js";
-
-export type FileResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
+import type { FileResultStatus } from "./types.js";
 
 export class FileResult {
-  assertionCounts = new ResultCounts();
+  assertionCounts = createAssertionCounts();
   file: FileLocation;
   results: Array<DescribeResult | TestResult | ExpectResult> = [];
   status: FileResultStatus = ResultStatus.Runs;
-  testCounts = new ResultCounts();
-  timing = new ResultTiming();
+  testCounts = createTestCounts();
+  timing = createResultTiming();
 
   constructor(file: FileLocation) {
     this.file = file;

--- a/source/result/Result.ts
+++ b/source/result/Result.ts
@@ -1,16 +1,21 @@
 import type { FileLocation } from "#file";
-import { ResultCounts } from "./ResultCounts.js";
-import { ResultTiming } from "./ResultTiming.js";
+import {
+  createAssertionCounts,
+  createFileCounts,
+  createResultTiming,
+  createTargetCounts,
+  createTestCounts,
+} from "./helpers.js";
 import type { TargetResult } from "./TargetResult.js";
 
 export class Result {
-  assertionCounts = new ResultCounts();
-  fileCounts = new ResultCounts();
+  assertionCounts = createAssertionCounts();
+  fileCounts = createFileCounts();
   files: Array<FileLocation>;
   results: Array<TargetResult> = [];
-  targetCounts = new ResultCounts();
-  testCounts = new ResultCounts();
-  timing = new ResultTiming();
+  targetCounts = createTargetCounts();
+  testCounts = createTestCounts();
+  timing = createResultTiming();
 
   constructor(files: Array<FileLocation>) {
     this.files = files;

--- a/source/result/ResultCounts.ts
+++ b/source/result/ResultCounts.ts
@@ -1,7 +1,0 @@
-export class ResultCounts {
-  failed = 0;
-  passed = 0;
-  skipped = 0;
-  fixme = 0;
-  todo = 0;
-}

--- a/source/result/ResultTiming.ts
+++ b/source/result/ResultTiming.ts
@@ -1,4 +1,0 @@
-export class ResultTiming {
-  end = Number.NaN;
-  start = Number.NaN;
-}

--- a/source/result/TargetResult.ts
+++ b/source/result/TargetResult.ts
@@ -1,16 +1,15 @@
 import type { FileLocation } from "#file";
+import { createResultTiming } from "./helpers.js";
 import type { ProjectResult } from "./ProjectResult.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
-import { ResultTiming } from "./ResultTiming.js";
-
-export type TargetResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
+import type { TargetResultStatus } from "./types.js";
 
 export class TargetResult {
   files: Array<FileLocation>;
   results = new Map<string | undefined, ProjectResult>();
   status: TargetResultStatus = ResultStatus.Runs;
   target: string;
-  timing = new ResultTiming();
+  timing = createResultTiming();
 
   constructor(target: string, files: Array<FileLocation>) {
     this.target = target;

--- a/source/result/TestResult.ts
+++ b/source/result/TestResult.ts
@@ -1,17 +1,16 @@
 import type { TestTreeNode } from "#collect";
 import type { DescribeResult } from "./DescribeResult.js";
 import type { ExpectResult } from "./ExpectResult.js";
-import { ResultCounts } from "./ResultCounts.js";
+import { createAssertionCounts, createResultTiming } from "./helpers.js";
 import { ResultStatus } from "./ResultStatus.enum.js";
-import { ResultTiming } from "./ResultTiming.js";
 
 export class TestResult {
-  assertionCounts = new ResultCounts();
+  assertionCounts = createAssertionCounts();
   parent: DescribeResult | undefined;
   results: Array<ExpectResult> = [];
   status: ResultStatus = ResultStatus.Runs;
   test: TestTreeNode;
-  timing = new ResultTiming();
+  timing = createResultTiming();
 
   constructor(test: TestTreeNode, parent?: DescribeResult) {
     this.test = test;

--- a/source/result/helpers.ts
+++ b/source/result/helpers.ts
@@ -1,5 +1,28 @@
-import type { ResultCounts } from "./ResultCounts.js";
-import type { ResultTiming } from "./ResultTiming.js";
+import type { AssertionCounts, FileCounts, ResultCounts, ResultTiming, TargetCounts, TestCounts } from "./types.js";
+
+function createObjectFromKeys<T extends string, U>(keys: Array<T>, defaultValue: U): Record<T, U> {
+  return Object.fromEntries(keys.map((key) => [key, defaultValue])) as Record<T, U>;
+}
+
+export function createTargetCounts(): TargetCounts {
+  return createObjectFromKeys(["failed", "passed"], 0);
+}
+
+export function createFileCounts(): FileCounts {
+  return createObjectFromKeys(["failed", "passed"], 0);
+}
+
+export function createTestCounts(): TestCounts {
+  return createObjectFromKeys(["failed", "passed", "skipped", "fixme", "todo"], 0);
+}
+
+export function createAssertionCounts(): AssertionCounts {
+  return createObjectFromKeys(["failed", "passed", "skipped", "fixme", "todo"], 0);
+}
+
+export function createResultTiming(): ResultTiming {
+  return createObjectFromKeys(["start", "end"], Number.NaN);
+}
 
 export function duration(timing: ResultTiming) {
   return timing.end - timing.start;

--- a/source/result/index.ts
+++ b/source/result/index.ts
@@ -1,11 +1,19 @@
 export { DescribeResult } from "./DescribeResult.js";
 export { ExpectResult } from "./ExpectResult.js";
-export { FileResult, type FileResultStatus } from "./FileResult.js";
+export { FileResult } from "./FileResult.js";
 export { duration, total } from "./helpers.js";
 export { ProjectResult } from "./ProjectResult.js";
 export { Result } from "./Result.js";
-export { ResultCounts } from "./ResultCounts.js";
 export { ResultStatus } from "./ResultStatus.enum.js";
-export { ResultTiming } from "./ResultTiming.js";
-export { TargetResult, type TargetResultStatus } from "./TargetResult.js";
+export { TargetResult } from "./TargetResult.js";
 export { TestResult } from "./TestResult.js";
+export type {
+  AssertionCounts,
+  FileCounts,
+  FileResultStatus,
+  ResultCounts,
+  ResultTiming,
+  TargetCounts,
+  TargetResultStatus,
+  TestCounts,
+} from "./types.js";

--- a/source/result/types.ts
+++ b/source/result/types.ts
@@ -1,0 +1,37 @@
+import type { ResultStatus } from "./ResultStatus.enum.js";
+
+export type FileResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
+export type TargetResultStatus = ResultStatus.Runs | ResultStatus.Passed | ResultStatus.Failed;
+
+export interface TargetCounts {
+  passed: number;
+  failed: number;
+}
+
+export interface FileCounts {
+  passed: number;
+  failed: number;
+}
+
+export interface TestCounts {
+  passed: number;
+  failed: number;
+  skipped: number;
+  fixme: number;
+  todo: number;
+}
+
+export interface AssertionCounts {
+  passed: number;
+  failed: number;
+  skipped: number;
+  fixme: number;
+  todo: number;
+}
+
+export type ResultCounts = AssertionCounts | TestCounts | FileCounts | TargetCounts;
+
+export interface ResultTiming {
+  start: number;
+  end: number;
+}

--- a/tests/integration-Runner.test.js
+++ b/tests/integration-Runner.test.js
@@ -80,9 +80,9 @@ await test("Runner", async (t) => {
       await t.test(testCase, async () => {
         await runner.run(testFiles);
 
-        assert.deepEqual(result?.assertionCounts, { failed: 2, passed: 3, skipped: 3, fixme: 0, todo: 0 });
-        assert.deepEqual(result?.fileCounts, { failed: 2, passed: 0, skipped: 0, fixme: 0, todo: 0 });
+        assert.deepEqual(result?.fileCounts, { failed: 2, passed: 0 });
         assert.deepEqual(result?.testCounts, { failed: 2, passed: 2, skipped: 1, fixme: 0, todo: 1 });
+        assert.deepEqual(result?.assertionCounts, { failed: 2, passed: 3, skipped: 3, fixme: 0, todo: 0 });
       });
     }
   });
@@ -120,9 +120,9 @@ await test("Runner", async (t) => {
 
         await runner.run(files);
 
-        assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 2, skipped: 3, fixme: 0, todo: 0 });
-        assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
+        assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0 });
         assert.deepEqual(result?.testCounts, { failed: 1, passed: 1, skipped: 1, fixme: 0, todo: 1 });
+        assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 2, skipped: 3, fixme: 0, todo: 0 });
       });
     }
 
@@ -133,9 +133,9 @@ await test("Runner", async (t) => {
 
         await runner.run([file]);
 
-        assert.deepEqual(result?.assertionCounts, { failed: 0, passed: 1, skipped: 5, fixme: 0, todo: 0 });
-        assert.deepEqual(result?.fileCounts, { failed: 0, passed: 1, skipped: 0, fixme: 0, todo: 0 });
+        assert.deepEqual(result?.fileCounts, { failed: 0, passed: 1 });
         assert.deepEqual(result?.testCounts, { failed: 0, passed: 0, skipped: 3, fixme: 0, todo: 1 });
+        assert.deepEqual(result?.assertionCounts, { failed: 0, passed: 1, skipped: 5, fixme: 0, todo: 0 });
       });
     }
 
@@ -146,9 +146,9 @@ await test("Runner", async (t) => {
 
         await runner.run([file]);
 
-        assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 0, skipped: 5, fixme: 0, todo: 0 });
-        assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
+        assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0 });
         assert.deepEqual(result?.testCounts, { failed: 0, passed: 0, skipped: 3, fixme: 0, todo: 1 });
+        assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 0, skipped: 5, fixme: 0, todo: 0 });
       });
     }
 
@@ -159,9 +159,9 @@ await test("Runner", async (t) => {
 
         await runner.run([file]);
 
-        assert.deepEqual(result?.assertionCounts, { failed: 0, passed: 1, skipped: 5, fixme: 0, todo: 0 });
-        assert.deepEqual(result?.fileCounts, { failed: 0, passed: 1, skipped: 0, fixme: 0, todo: 0 });
+        assert.deepEqual(result?.fileCounts, { failed: 0, passed: 1 });
         assert.deepEqual(result?.testCounts, { failed: 0, passed: 1, skipped: 2, fixme: 0, todo: 1 });
+        assert.deepEqual(result?.assertionCounts, { failed: 0, passed: 1, skipped: 5, fixme: 0, todo: 0 });
       });
     }
 
@@ -172,9 +172,9 @@ await test("Runner", async (t) => {
 
         await runner.run([file]);
 
-        assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 1, skipped: 4, fixme: 0, todo: 0 });
-        assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
+        assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0 });
         assert.deepEqual(result?.testCounts, { failed: 1, passed: 0, skipped: 2, fixme: 0, todo: 1 });
+        assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 1, skipped: 4, fixme: 0, todo: 0 });
       });
     }
   });
@@ -201,9 +201,9 @@ await test("Runner", async (t) => {
 
       await runner.run(testFiles);
 
-      assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
-      assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
+      assert.deepEqual(result?.fileCounts, { failed: 1, passed: 0 });
       assert.deepEqual(result?.testCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
+      assert.deepEqual(result?.assertionCounts, { failed: 1, passed: 0, skipped: 0, fixme: 0, todo: 0 });
     });
   });
 });


### PR DESCRIPTION
Exporting `ResultCounts` and `ResultTiming` as types only.

Also `AssertionCounts`, `TestCounts`, `FileCounts`, `TargetCounts` are added to make typings more precise.