### PR TITLE
fix: provide correct declaration file for TypeScript `4.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "type": "module",
   "exports": {
     ".": {
+      "types@4.x": {
+        "import": "./build/4.x/index.d.ts",
+        "require": "./build/4.x/index.d.cts"
+      },
       "import": "./build/index.js",
       "require": "./build/index.cjs"
     },
@@ -30,6 +34,13 @@
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "typesVersions": {
+    "4.x": {
+      "build/*": [
+        "./build/4.x/*"
+      ]
+    }
+  },
   "bin": "./build/bin.js",
   "files": [
     "build/*"

--- a/scripts/rollup.ts
+++ b/scripts/rollup.ts
@@ -77,6 +77,27 @@ function tidyDts(): Plugin {
   };
 }
 
+// TODO remove this plugin and 'package.json' entries after dropping support for TypeScript 4.x
+function ts4Dts(): Plugin {
+  return {
+    name: "ts4-dts",
+
+    async renderChunk(code, chunkInfo) {
+      if (chunkInfo.fileName.startsWith("index")) {
+        const updatedCode = code.replace(
+          / {4}\/\*\*\n {5}\* Checks if the decorator[\s\S]*DecoratorContext\) => void;\n/,
+          "",
+        );
+
+        await fs.mkdir(path.resolve(output.dir, "4.x"), { recursive: true });
+        await fs.writeFile(path.resolve(output.dir, "4.x", chunkInfo.fileName), updatedCode);
+      }
+
+      return null;
+    },
+  };
+}
+
 const config: Array<RollupOptions> = [
   {
     external: [/^node:/],
@@ -91,6 +112,7 @@ const config: Array<RollupOptions> = [
       typescript({ tsconfig }),
       dts({ tsconfig }),
       tidyDts(),
+      ts4Dts(),
     ],
   },
 
@@ -104,6 +126,7 @@ const config: Array<RollupOptions> = [
       // @ts-expect-error TODO: https://github.com/rollup/plugins/issues/1541
       typescript({ tsconfig }),
       dts({ tsconfig }),
+      ts4Dts(),
     ],
   },
 


### PR DESCRIPTION
Close #585

This provides declaration file with `DecoratorContext` type omitted for TypeScript `4.x`.