### PR TITLE
feat: add `TestTreeNodeBrand.It` member

### DIFF
--- a/source/collect/IdentifierLookup.ts
+++ b/source/collect/IdentifierLookup.ts
@@ -10,7 +10,6 @@ export interface Identifiers {
 export interface TestTreeNodeMeta {
   brand: TestTreeNodeBrand;
   flags: TestTreeNodeFlags;
-  identifier: string;
 }
 
 export class IdentifierLookup {
@@ -113,17 +112,19 @@ export class IdentifierLookup {
 
     switch (identifier) {
       case "describe":
-        return { brand: TestTreeNodeBrand.Describe, flags, identifier };
+        return { brand: TestTreeNodeBrand.Describe, flags };
 
       case "it":
+        return { brand: TestTreeNodeBrand.It, flags };
+
       case "test":
-        return { brand: TestTreeNodeBrand.Test, flags, identifier };
+        return { brand: TestTreeNodeBrand.Test, flags };
 
       case "expect":
-        return { brand: TestTreeNodeBrand.Expect, flags, identifier };
+        return { brand: TestTreeNodeBrand.Expect, flags };
 
       case "when":
-        return { brand: TestTreeNodeBrand.When, flags, identifier };
+        return { brand: TestTreeNodeBrand.When, flags };
     }
 
     return;

--- a/source/collect/TestTreeNodeBrand.enum.ts
+++ b/source/collect/TestTreeNodeBrand.enum.ts
@@ -1,6 +1,7 @@
 export const enum TestTreeNodeBrand {
   Describe = "describe",
   Test = "test",
+  It = "it",
   Expect = "expect",
   When = "when",
 }

--- a/source/runner/FixmeService.ts
+++ b/source/runner/FixmeService.ts
@@ -70,9 +70,7 @@ export class FixmeService {
     }
 
     if (isFail === false) {
-      const targetText = owner.node.expression.getText();
-
-      const text = [FixmeDiagnosticText.wasSupposedToFail(targetText), FixmeDiagnosticText.considerRemoving()];
+      const text = [FixmeDiagnosticText.wasSupposedToFail(owner.brand), FixmeDiagnosticText.considerRemoving()];
 
       const origin = new DiagnosticOrigin(
         directive.namespace.start,

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -105,6 +105,7 @@ export class TestTreeWalker {
           await this.#visitDescribe(node, runModeFlags, parentResult as DescribeResult | undefined);
           break;
 
+        case TestTreeNodeBrand.It:
         case TestTreeNodeBrand.Test:
           await this.#visitTest(node, runModeFlags, parentResult as DescribeResult | undefined);
           break;

--- a/source/types.ts
+++ b/source/types.ts
@@ -229,11 +229,11 @@ export declare const describe: Describe;
 /**
  * Defines a single test.
  */
-export declare const test: Test;
+export declare const it: Test;
 /**
  * Defines a single test.
  */
-export declare const it: Test;
+export declare const test: Test;
 
 interface Actions {
   /**

--- a/tests/__snapshots__/directive-fixme-only-stderr.snap.txt
+++ b/tests/__snapshots__/directive-fixme-only-stderr.snap.txt
@@ -1,4 +1,4 @@
-Error: The 'expect.only()' was supposed to fail, but it passed.
+Error: The 'expect()' was supposed to fail, but it passed.
 
 Consider removing the '// @tstyche fixme' directive.
 
@@ -12,7 +12,7 @@ Consider removing the '// @tstyche fixme' directive.
 
        at ./__typetests__/directive-fixme-only.tst.ts:9:1
 
-Error: The 'expect.only()' was supposed to fail, but it passed.
+Error: The 'expect()' was supposed to fail, but it passed.
 
 Consider removing the '// @tstyche fixme' directive.
 
@@ -40,7 +40,7 @@ Consider removing the '// @tstyche fixme' directive.
 
        at ./__typetests__/directive-fixme-only.tst.ts:32:3
 
-Error: The 'expect.only()' was supposed to fail, but it passed.
+Error: The 'expect()' was supposed to fail, but it passed.
 
 Consider removing the '// @tstyche fixme' directive.
 
@@ -68,7 +68,7 @@ Consider removing the '// @tstyche fixme' directive.
 
        at ./__typetests__/directive-fixme-only.tst.ts:51:3
 
-Error: The 'test.only()' was supposed to fail, but it passed.
+Error: The 'test()' was supposed to fail, but it passed.
 
 Consider removing the '// @tstyche fixme' directive.
 
@@ -138,7 +138,7 @@ Consider removing the '// @tstyche fixme' directive.
 
         at ./__typetests__/directive-fixme-only.tst.ts:163:3
 
-Error: The 'describe.only()' was supposed to fail, but it passed.
+Error: The 'describe()' was supposed to fail, but it passed.
 
 Consider removing the '// @tstyche fixme' directive.
 


### PR DESCRIPTION
Adding the `TestTreeNodeBrand.It` member. After this change it becomes straight forward to get the name of a test node.