### PR TITLE
feat: print test runner version and root path

### DIFF
--- a/source/output/index.ts
+++ b/source/output/index.ts
@@ -5,6 +5,7 @@ export { fileStatusText } from "./fileStatusText.js";
 export { fileViewText } from "./fileViewText.js";
 export { formattedText } from "./formattedText.js";
 export { helpText } from "./helpText.js";
+export { introText } from "./introText.js";
 export { OutputService } from "./OutputService.js";
 export { summaryText } from "./summaryText.js";
 export { testNameText } from "./testNameText.js";

--- a/source/output/introText.tsx
+++ b/source/output/introText.tsx
@@ -1,0 +1,18 @@
+import { Color, Line, type ScribblerJsx, Text } from "#scribbler";
+
+export function introText(runnerVersion: string, rootPath: string): ScribblerJsx.Element {
+  return (
+    <Text>
+      <Line>
+        <Text color={Color.Gray}>{"····"}</Text>
+        {" TSTyche "}
+        {runnerVersion}
+        <Text color={Color.Gray}>
+          {" from "}
+          {rootPath}
+        </Text>
+      </Line>
+      <Line />
+    </Text>
+  );
+}

--- a/source/runner/Runner.ts
+++ b/source/runner/Runner.ts
@@ -3,6 +3,7 @@ import { environmentOptions } from "#environment";
 import { EventEmitter } from "#events";
 import { FileLocation } from "#file";
 import { CancellationHandler, ResultHandler } from "#handlers";
+import { introText, OutputService } from "#output";
 import { ListReporter, type Reporter, SummaryReporter, WatchReporter } from "#reporters";
 import { Result, TargetResult } from "#result";
 import { Store } from "#store";
@@ -61,6 +62,10 @@ export class Runner {
   }
 
   async run(files: Array<string | URL | FileLocation>, cancellationToken = new CancellationToken()): Promise<void> {
+    if (!this.#resolvedConfig.watch) {
+      OutputService.writeMessage(introText(Runner.version, this.#resolvedConfig.rootPath));
+    }
+
     const fileLocations = files.map((file) => (file instanceof FileLocation ? file : new FileLocation(file)));
 
     this.#addHandlers(cancellationToken);

--- a/tests/__snapshots__/api-describe-nested-stdout.snap.txt
+++ b/tests/__snapshots__/api-describe-nested-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-describe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/describe-nested.tst.ts

--- a/tests/__snapshots__/api-describe-only-stdout.snap.txt
+++ b/tests/__snapshots__/api-describe-only-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-describe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/describe-only.tst.ts

--- a/tests/__snapshots__/api-describe-skip-stdout.snap.txt
+++ b/tests/__snapshots__/api-describe-skip-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-describe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/describe-skip.tst.ts

--- a/tests/__snapshots__/api-describe-todo-stdout.snap.txt
+++ b/tests/__snapshots__/api-describe-todo-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-describe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/describe-todo.tst.ts

--- a/tests/__snapshots__/api-expect-only-stdout.snap.txt
+++ b/tests/__snapshots__/api-expect-only-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-expect
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/expect-only.tst.ts

--- a/tests/__snapshots__/api-expect-skip-stdout.snap.txt
+++ b/tests/__snapshots__/api-expect-skip-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-expect
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/expect-skip.tst.ts

--- a/tests/__snapshots__/api-it-only-stdout.snap.txt
+++ b/tests/__snapshots__/api-it-only-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-it
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/it-only.tst.ts

--- a/tests/__snapshots__/api-it-skip-stdout.snap.txt
+++ b/tests/__snapshots__/api-it-skip-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-it
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/it-skip.tst.ts

--- a/tests/__snapshots__/api-it-todo-stdout.snap.txt
+++ b/tests/__snapshots__/api-it-todo-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-it
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/it-todo.tst.ts

--- a/tests/__snapshots__/api-omit-stdout.snap.txt
+++ b/tests/__snapshots__/api-omit-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-omit
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/omit.tst.ts

--- a/tests/__snapshots__/api-pick-stdout.snap.txt
+++ b/tests/__snapshots__/api-pick-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-pick
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/pick.tst.ts

--- a/tests/__snapshots__/api-test-only-stdout.snap.txt
+++ b/tests/__snapshots__/api-test-only-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-test
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/test-only.tst.ts

--- a/tests/__snapshots__/api-test-skip-stdout.snap.txt
+++ b/tests/__snapshots__/api-test-skip-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-test
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/test-skip.tst.ts

--- a/tests/__snapshots__/api-test-todo-stdout.snap.txt
+++ b/tests/__snapshots__/api-test-todo-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-test
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/test-todo.tst.ts

--- a/tests/__snapshots__/api-toAcceptProps-class-components-stdout.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-class-components-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toAcceptProps
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/class-components.tst.tsx

--- a/tests/__snapshots__/api-toAcceptProps-function-components-stdout.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-function-components-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toAcceptProps
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/function-components.tst.tsx

--- a/tests/__snapshots__/api-toAcceptProps-overloaded-components-stdout.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-overloaded-components-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toAcceptProps
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/overloaded-components.tst.tsx

--- a/tests/__snapshots__/api-toAcceptProps-special-cases-stdout.snap.txt
+++ b/tests/__snapshots__/api-toAcceptProps-special-cases-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toAcceptProps
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/special-cases.tst.tsx

--- a/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-exact-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBe
+
 uses TypeScript <<version>> with ./tsconfig-exact.json
 
 pass ./__typetests__/toBe.tst.ts

--- a/tests/__snapshots__/api-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBe.tst.ts

--- a/tests/__snapshots__/api-toBeApplicable-stdout-line-endings.snap.txt
+++ b/tests/__snapshots__/api-toBeApplicable-stdout-line-endings.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeApplicable
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/toBeApplicable.tst.ts

--- a/tests/__snapshots__/api-toBeApplicable-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeApplicable-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeApplicable
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeApplicable.tst.ts

--- a/tests/__snapshots__/api-toBeAssignableFrom-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableFrom-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeAssignableFrom
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeAssignableFrom.tst.ts

--- a/tests/__snapshots__/api-toBeAssignableTo-stdout-line-endings.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableTo-stdout-line-endings.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeAssignableTo
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/unrelated.tst.ts

--- a/tests/__snapshots__/api-toBeAssignableTo-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeAssignableTo-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeAssignableTo
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeAssignableTo.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-generic-functions-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-generic-functions-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeCallableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/generic-functions.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-missing-semicolons-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-missing-semicolons-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeCallableWith
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/toBeCallableWith.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-overload-signatures-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-overload-signatures-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeCallableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/overload-signatures.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-parameter-arity-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-parameter-arity-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeCallableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/parameter-arity.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-related-diagnostics-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-related-diagnostics-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeCallableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/related-diagnostics.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-rest-parameters-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-rest-parameters-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeCallableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/rest-parameters.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-trailing-comma-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-trailing-comma-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeCallableWith
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/toBeCallableWith.tst.ts

--- a/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeCallableWith-ts-expect-error-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeCallableWith
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/toBeCallableWith.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeConstructableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/generic-classes.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-missing-semicolons-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-missing-semicolons-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeConstructableWith
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/toBeConstructableWith.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeConstructableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/overload-signatures.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeConstructableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/parameter-arity.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-related-diagnostics-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-related-diagnostics-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeConstructableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/related-diagnostics.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toBeConstructableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/rest-parameters.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-trailing-comma-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-trailing-comma-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeConstructableWith
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/toBeConstructableWith.tst.ts

--- a/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-ts-expect-error-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-toBeConstructableWith
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/toBeCallableWith.tst.ts

--- a/tests/__snapshots__/api-toHaveProperty-index-signatures-stdout.snap.txt
+++ b/tests/__snapshots__/api-toHaveProperty-index-signatures-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toHaveProperty
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/index-signatures.tst.ts

--- a/tests/__snapshots__/api-toHaveProperty-stdout.snap.txt
+++ b/tests/__snapshots__/api-toHaveProperty-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toHaveProperty
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toHaveProperty.tst.ts

--- a/tests/__snapshots__/api-toRaiseError-multiline-stdout.snap.txt
+++ b/tests/__snapshots__/api-toRaiseError-multiline-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toRaiseError
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toRaiseError-multiline.tst.ts

--- a/tests/__snapshots__/api-toRaiseError-regex-stdout.snap.txt
+++ b/tests/__snapshots__/api-toRaiseError-regex-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toRaiseError
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toRaiseError-regex.tst.ts

--- a/tests/__snapshots__/api-toRaiseError-stdout.snap.txt
+++ b/tests/__snapshots__/api-toRaiseError-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-toRaiseError
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toRaiseError.tst.ts

--- a/tests/__snapshots__/api-when-missing-semicolons-stdout.snap.txt
+++ b/tests/__snapshots__/api-when-missing-semicolons-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-when
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/when.tst.ts

--- a/tests/__snapshots__/api-when-stdout.snap.txt
+++ b/tests/__snapshots__/api-when-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/api-when
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/when.tst.ts

--- a/tests/__snapshots__/api-when-trailing-comma-stdout.snap.txt
+++ b/tests/__snapshots__/api-when-trailing-comma-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/api-when
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/when.tst.ts

--- a/tests/__snapshots__/config-checkDeclarationFiles-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-checkDeclarationFiles-disabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-checkDeclarationFiles
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isNumber.test.ts

--- a/tests/__snapshots__/config-checkDeclarationFiles-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-checkDeclarationFiles-enabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-checkDeclarationFiles
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isNumber.test.ts

--- a/tests/__snapshots__/config-checkSuppressedErrors-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-checkSuppressedErrors-disabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-checkSuppressedErrors
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/config-checkSuppressedErrors-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-checkSuppressedErrors-enabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-checkSuppressedErrors
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/config-commandLine-multiple-search-stdout.snap.txt
+++ b/tests/__snapshots__/config-commandLine-multiple-search-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-commandLine
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isString.test.ts

--- a/tests/__snapshots__/config-commandLine-relative-search-stdout.snap.txt
+++ b/tests/__snapshots__/config-commandLine-relative-search-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-commandLine
+
 uses TypeScript <<version>>
 
 pass ./feature/__tests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-commandLine-single-search-stdout.snap.txt
+++ b/tests/__snapshots__/config-commandLine-single-search-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-commandLine
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.test.ts

--- a/tests/__snapshots__/config-commandLine-testFileMatch-stdout.snap.txt
+++ b/tests/__snapshots__/config-commandLine-testFileMatch-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-commandLine
+
 uses TypeScript <<version>> with ./feature/__tests__/tsconfig.json
 
 pass ./feature/__tests__/isNumber.test.ts

--- a/tests/__snapshots__/config-commandLine-without-arguments-stdout.snap.txt
+++ b/tests/__snapshots__/config-commandLine-without-arguments-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-commandLine
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.test.ts

--- a/tests/__snapshots__/config-failFast---failFast-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast---failFast-isNumber---failFast-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-isNumber---failFast-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast---failFast-isString-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-isString-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isString.tst.ts

--- a/tests/__snapshots__/config-failFast---failFast-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast---failFast-true-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast---failFast-true-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast-failFast-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast-failFast-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast-failFast-true-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast-failFast-true-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast-isNumber---failFast-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast-isNumber---failFast-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast-overrides-failFast-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast-overrides-failFast-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-failFast-overrides-failFast-true-stdout.snap.txt
+++ b/tests/__snapshots__/config-failFast-overrides-failFast-true-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-failFast
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-fixtureFileMatch-default-patterns-typetests-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-default-patterns-typetests-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-fixtureFileMatch
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isString.test.ts

--- a/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-empty-list-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-empty-list-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-fixtureFileMatch
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isString.test.ts

--- a/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-stdout.snap.txt
+++ b/tests/__snapshots__/config-fixtureFileMatch-specified-patterns-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-fixtureFileMatch
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isString.test.ts

--- a/tests/__snapshots__/config-noColor-noColors-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-noColor-noColors-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+<gray>····</> TSTyche <<version>><gray> from <<basePath>>/tests/__fixtures__/.generated/config-noColor</>
+
 <blue>uses</> TypeScript <<version>>
 
 <green>pass</> <gray>./__typetests__/</>dummy.test.ts

--- a/tests/__snapshots__/config-noColor-noColors-true-stdout.snap.txt
+++ b/tests/__snapshots__/config-noColor-noColors-true-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-noColor
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-noColor-tstycheNoColor-false-overrides-stdout.snap.txt
+++ b/tests/__snapshots__/config-noColor-tstycheNoColor-false-overrides-stdout.snap.txt
@@ -1,3 +1,5 @@
+<gray>····</> TSTyche <<version>><gray> from <<basePath>>/tests/__fixtures__/.generated/config-noColor</>
+
 <blue>uses</> TypeScript <<version>>
 
 <green>pass</> <gray>./__typetests__/</>dummy.test.ts

--- a/tests/__snapshots__/config-noColor-tstycheNoColor-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-noColor-tstycheNoColor-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+<gray>····</> TSTyche <<version>><gray> from <<basePath>>/tests/__fixtures__/.generated/config-noColor</>
+
 <blue>uses</> TypeScript <<version>>
 
 <green>pass</> <gray>./__typetests__/</>dummy.test.ts

--- a/tests/__snapshots__/config-noColor-tstycheNoColor-true-overrides-stdout.snap.txt
+++ b/tests/__snapshots__/config-noColor-tstycheNoColor-true-overrides-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-noColor
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-noColor-tstycheNoColor-true-stdout.snap.txt
+++ b/tests/__snapshots__/config-noColor-tstycheNoColor-true-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-noColor
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-noInteractive-tstycheNoInteractive-false-stdout.snap.txt
+++ b/tests/__snapshots__/config-noInteractive-tstycheNoInteractive-false-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-noInteractive
+
 uses TypeScript <<version>>
 
 runs ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-noInteractive-tstycheNoInteractive-true-stdout.snap.txt
+++ b/tests/__snapshots__/config-noInteractive-tstycheNoInteractive-true-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-noInteractive
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-only---only-external---skip-number-stdout.snap.txt
+++ b/tests/__snapshots__/config-only---only-external---skip-number-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-only
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-only---only-external-dummy-stdout.snap.txt
+++ b/tests/__snapshots__/config-only---only-external-dummy-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-only
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-only-describe---only-external-stdout.snap.txt
+++ b/tests/__snapshots__/config-only-describe---only-external-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-only
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-only-dummy---only-external-stdout.snap.txt
+++ b/tests/__snapshots__/config-only-dummy---only-external-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-only
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-only-test---only-external-stdout.snap.txt
+++ b/tests/__snapshots__/config-only-test---only-external-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-only
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-only-test-skip---only-external-stdout.snap.txt
+++ b/tests/__snapshots__/config-only-test-skip---only-external-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-only
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-rejectAnyType-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-disabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-rejectAnyType
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isRejected.test.ts

--- a/tests/__snapshots__/config-rejectAnyType-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectAnyType-enabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-rejectAnyType
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/isRejected.test.ts

--- a/tests/__snapshots__/config-rejectNeverType-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-disabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-rejectNeverType
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isRejected.test.ts

--- a/tests/__snapshots__/config-rejectNeverType-enabled-stdout.snap.txt
+++ b/tests/__snapshots__/config-rejectNeverType-enabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-rejectNeverType
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/isRejected.test.ts

--- a/tests/__snapshots__/config-reporters-custom-reporter-stdout.snap.txt
+++ b/tests/__snapshots__/config-reporters-custom-reporter-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-reporters
+
 Hello from custom reporter one!
 
 <<basePath>>/tests/__fixtures__/.generated/config-reporters/__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-reporters-list-stdout.snap.txt
+++ b/tests/__snapshots__/config-reporters-list-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-reporters
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-reporters-list-with-summary-stdout.snap.txt
+++ b/tests/__snapshots__/config-reporters-list-with-summary-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-reporters
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-reporters-summary-stdout.snap.txt
+++ b/tests/__snapshots__/config-reporters-summary-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-reporters
+
 Targets:    1 passed, 1 total
 Test files: 2 passed, 2 total
 Tests:      2 passed, 2 total

--- a/tests/__snapshots__/config-reporters-summary-with-custom-stdout.snap.txt
+++ b/tests/__snapshots__/config-reporters-summary-with-custom-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-reporters
+
 Hello from custom reporter one!
 
 <<basePath>>/tests/__fixtures__/.generated/config-reporters/__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-skip---only-number---skip-internal-stdout.snap.txt
+++ b/tests/__snapshots__/config-skip---only-number---skip-internal-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-skip
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-skip---skip-internal-dummy-stdout.snap.txt
+++ b/tests/__snapshots__/config-skip---skip-internal-dummy-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-skip
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-skip-describe---skip-internal-stdout.snap.txt
+++ b/tests/__snapshots__/config-skip-describe---skip-internal-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-skip
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-skip-dummy---skip-internal-stdout.snap.txt
+++ b/tests/__snapshots__/config-skip-dummy---skip-internal-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-skip
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-skip-test---skip-internal-stdout.snap.txt
+++ b/tests/__snapshots__/config-skip-test---skip-internal-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-skip
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-skip-test-only---skip-internal-stdout.snap.txt
+++ b/tests/__snapshots__/config-skip-test-only---skip-internal-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-skip
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/config-target---target-5.2-stdout.snap.txt
+++ b/tests/__snapshots__/config-target---target-5.2-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.2.2 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.2.2
 uses TypeScript 5.2.2 with ./tsconfig.json
 

--- a/tests/__snapshots__/config-target---target-5.6-isString-stdout.snap.txt
+++ b/tests/__snapshots__/config-target---target-5.6-isString-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.6.3 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.6.3
 uses TypeScript 5.6.3
 

--- a/tests/__snapshots__/config-target-isNumber---target-5.8-stdout.snap.txt
+++ b/tests/__snapshots__/config-target-isNumber---target-5.8-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.8.3 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.8.3
 uses TypeScript 5.8.3
 

--- a/tests/__snapshots__/config-target-overrides-target-stdout.snap.txt
+++ b/tests/__snapshots__/config-target-overrides-target-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.8.3 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.8.3
 uses TypeScript 5.8.3 with ./tsconfig.json
 

--- a/tests/__snapshots__/config-target-target-5.3.2-5.8-stdout.snap.txt
+++ b/tests/__snapshots__/config-target-target-5.3.2-5.8-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.3.2 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.3.2
 uses TypeScript 5.3.2 with ./tsconfig.json
 

--- a/tests/__snapshots__/config-target-target-5.4-stdout.snap.txt
+++ b/tests/__snapshots__/config-target-target-5.4-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.4.5 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.4.5
 uses TypeScript 5.4.5 with ./tsconfig.json
 

--- a/tests/__snapshots__/config-target-target-asterisk-stdout.snap.txt
+++ b/tests/__snapshots__/config-target-target-asterisk-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isString.tst.ts

--- a/tests/__snapshots__/config-target-upper-bound-version-range-stdout.snap.txt
+++ b/tests/__snapshots__/config-target-upper-bound-version-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-target
+
 adds TypeScript 5.3.3 to <<basePath>>/tests/__fixtures__/.generated/config-target/.store/typescript@5.3.3
 uses TypeScript 5.3.3 with ./tsconfig.json
 

--- a/tests/__snapshots__/config-testFileMatch-braces-span-several-segments-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-braces-span-several-segments-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./one/isString.ts

--- a/tests/__snapshots__/config-testFileMatch-default-patterns-tst-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-default-patterns-tst-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./__tests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-default-patterns-typetests-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-default-patterns-typetests-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.test.ts

--- a/tests/__snapshots__/config-testFileMatch-double-asterisk-does-not-select-dot-paths.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-double-asterisk-does-not-select-dot-paths.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./_generated/_nested/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-double-asterisk-does-not-select-node_modules-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-double-asterisk-does-not-select-node_modules-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-double-asterisk-matches-zero-or-more-characters.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-double-asterisk-matches-zero-or-more-characters.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./packages/core/typetests/awaitable.test.ts

--- a/tests/__snapshots__/config-testFileMatch-multiple-braces-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-multiple-braces-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./one/isNumber.tsx

--- a/tests/__snapshots__/config-testFileMatch-nested-braces-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-nested-braces-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./tests/isNumber.tsx

--- a/tests/__snapshots__/config-testFileMatch-question-mark-does-not-match-path-separators.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-question-mark-does-not-match-path-separators.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./tests/call.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-question-mark-does-not-select-dot-paths.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-question-mark-does-not-select-dot-paths.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./_generated/_isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-question-mark-does-not-select-node_modules-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-question-mark-does-not-select-node_modules-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./_ode_modules/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-question-mark-matches-any-single-character.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-question-mark-matches-any-single-character.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/bat.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-single-asterisk-does-not-match-path-separators.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-single-asterisk-does-not-match-path-separators.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./packages/typetests/core.test.ts

--- a/tests/__snapshots__/config-testFileMatch-single-asterisk-does-not-select-dot-paths.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-single-asterisk-does-not-select-dot-paths.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./_generated/_isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-single-asterisk-does-not-select-node_modules-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-single-asterisk-does-not-select-node_modules-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-single-asterisk-matches-zero-or-more-characters.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-single-asterisk-matches-zero-or-more-characters.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./Options.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-single-braces-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-single-braces-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./tests/isNumber.ts

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-dot-paths-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-dot-paths-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./.generated/isString.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-empty-list-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-empty-list-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 Targets:    1 passed, 1 total
 Test files: 0 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-node_modules-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-node_modules-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./local/node_modules/isString.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-start-with-dot-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-start-with-dot-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./tests/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./type-tests/isNumber.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-symbolic-links.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-symbolic-links.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>>
 
 pass ./isNumber-link.tst.ts

--- a/tests/__snapshots__/config-testFileMatch-specified-patterns-with-all-extensions-stdout.snap.txt
+++ b/tests/__snapshots__/config-testFileMatch-specified-patterns-with-all-extensions-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-testFileMatch
+
 uses TypeScript <<version>> with ./__typetests__/tsconfig.json
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-tsconfig-findup-stdout.snap.txt
+++ b/tests/__snapshots__/config-tsconfig-findup-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-tsconfig
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-tsconfig-ignore-stdout.snap.txt
+++ b/tests/__snapshots__/config-tsconfig-ignore-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-tsconfig
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-tsconfig-not-include-stdout.snap.txt
+++ b/tests/__snapshots__/config-tsconfig-not-include-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-tsconfig
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-tsconfig-overrides-stdout.snap.txt
+++ b/tests/__snapshots__/config-tsconfig-overrides-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-tsconfig
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/config-tsconfig-specified-stdout.snap.txt
+++ b/tests/__snapshots__/config-tsconfig-specified-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/config-tsconfig
+
 uses TypeScript <<version>> with ./tsconfig.test.json
 
 pass ./__typetests__/isNumber.tst.ts

--- a/tests/__snapshots__/directive-fixme-only-stdout.snap.txt
+++ b/tests/__snapshots__/directive-fixme-only-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/directive-fixme
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/directive-fixme-only.tst.ts

--- a/tests/__snapshots__/directive-fixme-skip-stdout.snap.txt
+++ b/tests/__snapshots__/directive-fixme-skip-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/directive-fixme
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/directive-fixme-skip.tst.ts

--- a/tests/__snapshots__/directive-fixme-stdout.snap.txt
+++ b/tests/__snapshots__/directive-fixme-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/directive-fixme
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/directive-fixme.tst.ts

--- a/tests/__snapshots__/directive-if-target-describe-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.2.2 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.2.2
 uses TypeScript 5.2.2 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-kebab-case-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-multiple-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-multiple-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-partly-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-partly-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-single-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-single-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-describe-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-describe-level-with-note-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.2.2 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.2.2
 uses TypeScript 5.2.2 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-kebab-case-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-multiple-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-multiple-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-partly-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-partly-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-single-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-single-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-expect-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-expect-level-with-note-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.2.2 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.2.2
 uses TypeScript 5.2.2 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-kebab-case-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-multiple-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-multiple-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-partly-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-partly-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-single-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-single-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-file-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-file-level-with-note-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-combination-of-ranges-and-versions-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-combination-of-ranges-and-versions-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.2.2 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.2.2
 uses TypeScript 5.2.2 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-kebab-case-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-kebab-case-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-multiple-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-multiple-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-multiple-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-multiple-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-not-matching-range-with-upper-bound-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-not-matching-range-with-upper-bound-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-partly-matching-range-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-partly-matching-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-single-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-single-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-single-not-matching-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-single-not-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-if-target-test-level-with-note-stdout.snap.txt
+++ b/tests/__snapshots__/directive-if-target-test-level-with-note-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-if-target
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-if-target/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-template-stdout.snap.txt
+++ b/tests/__snapshots__/directive-template-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-template
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/template.tst.ts

--- a/tests/__snapshots__/directive-template-test-text-with-tstyche-if-stdout.snap.txt
+++ b/tests/__snapshots__/directive-template-test-text-with-tstyche-if-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-template
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-template/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-template-used-with-tstyche-if-stdout.snap.txt
+++ b/tests/__snapshots__/directive-template-used-with-tstyche-if-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-template
+
 adds TypeScript 5.5.4 to <<basePath>>/tests/__fixtures__/.generated/directive-template/.store/typescript@5.5.4
 uses TypeScript 5.5.4 with ./tsconfig.json
 

--- a/tests/__snapshots__/directive-ts-expect-error-blank-line-in-between-stdout.snap.txt
+++ b/tests/__snapshots__/directive-ts-expect-error-blank-line-in-between-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-ts-expect-error
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/directive-ts-expect-error-disabled-stdout.snap.txt
+++ b/tests/__snapshots__/directive-ts-expect-error-disabled-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-ts-expect-error
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/directive-ts-expect-error-does-not-match-stdout.snap.txt
+++ b/tests/__snapshots__/directive-ts-expect-error-does-not-match-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-ts-expect-error
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/directive-ts-expect-error-matches-stdout.snap.txt
+++ b/tests/__snapshots__/directive-ts-expect-error-matches-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-ts-expect-error
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/directive-ts-expect-error-multiple-errors-stdout.snap.txt
+++ b/tests/__snapshots__/directive-ts-expect-error-multiple-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/directive-ts-expect-error
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/hooks-select-multiple-plugins-stdout.snap.txt
+++ b/tests/__snapshots__/hooks-select-multiple-plugins-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/hooks-select
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./ts-tests/toBeNumber.test.ts

--- a/tests/__snapshots__/hooks-selectsingle-plugin-stdout.snap.txt
+++ b/tests/__snapshots__/hooks-selectsingle-plugin-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/hooks-select
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/toBeBoolean.tst.ts

--- a/tests/__snapshots__/project-cjs-support-cjs-syntax-stdout.snap.txt
+++ b/tests/__snapshots__/project-cjs-support-cjs-syntax-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/project-cjs-support
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/cjs-syntax.tst.cts

--- a/tests/__snapshots__/project-cjs-support-esm-syntax-stdout.snap.txt
+++ b/tests/__snapshots__/project-cjs-support-esm-syntax-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/project-cjs-support
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/esm-syntax.tst.ts

--- a/tests/__snapshots__/project-imports-aliased-imports.snap.txt
+++ b/tests/__snapshots__/project-imports-aliased-imports.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/project-imports
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/aliased-import.tst.ts

--- a/tests/__snapshots__/project-imports-names-imports.snap.txt
+++ b/tests/__snapshots__/project-imports-names-imports.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/project-imports
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/named-import.tst.ts

--- a/tests/__snapshots__/project-imports-namespace-imports.snap.txt
+++ b/tests/__snapshots__/project-imports-namespace-imports.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/project-imports
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/namespace-import.tst.ts

--- a/tests/__snapshots__/project-test-files-empty-describe.snap.txt
+++ b/tests/__snapshots__/project-test-files-empty-describe.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-empty-file.snap.txt
+++ b/tests/__snapshots__/project-test-files-empty-file.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-empty-test.snap.txt
+++ b/tests/__snapshots__/project-test-files-empty-test.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-only-expect.snap.txt
+++ b/tests/__snapshots__/project-test-files-only-expect.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-skipped-describe.snap.txt
+++ b/tests/__snapshots__/project-test-files-skipped-describe.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-skipped-test.snap.txt
+++ b/tests/__snapshots__/project-test-files-skipped-test.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-todo-describe.snap.txt
+++ b/tests/__snapshots__/project-test-files-todo-describe.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-test-files-todo-test.snap.txt
+++ b/tests/__snapshots__/project-test-files-todo-test.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-test-files
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/project-tsconfig-sets-default-compiler-options.snap.txt
+++ b/tests/__snapshots__/project-tsconfig-sets-default-compiler-options.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/project-tsconfig
+
 uses TypeScript <<version>>
 
 pass ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/validation-describe-handles-expect-stdout.snap.txt
+++ b/tests/__snapshots__/validation-describe-handles-expect-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-describe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-expect.tst.ts

--- a/tests/__snapshots__/validation-directive-handles-not-supported-stdout.snap.txt
+++ b/tests/__snapshots__/validation-directive-handles-not-supported-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-directive
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/directive-not-supported.tst.ts

--- a/tests/__snapshots__/validation-expect-assertion-chain-stdout.snap.txt
+++ b/tests/__snapshots__/validation-expect-assertion-chain-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-expect
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/assertion-chain.tst.ts

--- a/tests/__snapshots__/validation-expect-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-expect-handles-nested-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-expect
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts

--- a/tests/__snapshots__/validation-expect-not-supported-matcher-stdout.snap.txt
+++ b/tests/__snapshots__/validation-expect-not-supported-matcher-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-expect
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/not-supported-matcher.tst.ts

--- a/tests/__snapshots__/validation-fixme-does-not-take-argument-stdout.snap.txt
+++ b/tests/__snapshots__/validation-fixme-does-not-take-argument-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-fixme
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-argument-is-missing-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-argument-is-missing-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-argument-is-not-object-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-argument-is-not-object-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-closing-brace-missing-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-closing-brace-missing-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-target-no-supported-versions-matching-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-target-no-supported-versions-matching-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if-target
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-target-not-supported-version-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-target-not-supported-version-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if-target
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-target-not-supported-version-within-union-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-target-not-supported-version-within-union-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if-target
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-target-not-valid-range-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-target-not-valid-range-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if-target
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-target-not-valid-range-within-union-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-target-not-valid-range-within-union-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if-target
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-target-wrong-option-value-type-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-target-wrong-option-value-type-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if-target
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-if-unexpected-trailing-token-stdout.snap.txt
+++ b/tests/__snapshots__/validation-if-unexpected-trailing-token-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-if
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-it-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-it-handles-nested-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-it
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts

--- a/tests/__snapshots__/validation-project-tsconfig-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-project-tsconfig-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-project
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 pass ./__typetests__/dummy.tst.ts

--- a/tests/__snapshots__/validation-select-stdout.snap.txt
+++ b/tests/__snapshots__/validation-select-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-select
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/toBeNotfound.test.ts

--- a/tests/__snapshots__/validation-syntax-errors-syntax-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-syntax-errors-syntax-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-syntax-errors
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/dummy.test.ts

--- a/tests/__snapshots__/validation-template-does-not-take-argument-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-does-not-take-argument-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-template-missing-export-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-missing-export-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-template-must-export-a-string-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-must-export-a-string-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-template-test-file-syntax-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-test-file-syntax-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-template-test-file-type-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-test-file-type-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-template-test-text-syntax-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-test-text-syntax-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-template-test-text-type-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-template-test-text-type-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-template
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-test-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-test-handles-nested-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-test
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts

--- a/tests/__snapshots__/validation-toAcceptProps-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toAcceptProps
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toAcceptProps.tst.tsx

--- a/tests/__snapshots__/validation-toBe-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBe-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toBe
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBe.tst.ts

--- a/tests/__snapshots__/validation-toBeApplicable-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeApplicable-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toBeApplicable
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeApplicable.tst.ts

--- a/tests/__snapshots__/validation-toBeAssignableFrom-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableFrom-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toBeAssignableFrom
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeAssignableFrom.tst.ts

--- a/tests/__snapshots__/validation-toBeAssignableTo-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeAssignableTo-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toBeAssignableTo
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeAssignableTo.tst.ts

--- a/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeCallableWith-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toBeCallableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeCallableWith.tst.ts

--- a/tests/__snapshots__/validation-toBeConstructableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeConstructableWith-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toBeConstructableWith
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toBeConstructableWith.tst.ts

--- a/tests/__snapshots__/validation-toHaveProperty-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toHaveProperty-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toHaveProperty
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toHaveProperty.tst.ts

--- a/tests/__snapshots__/validation-toRaiseError-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toRaiseError-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-toRaiseError
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/toRaiseError.tst.ts

--- a/tests/__snapshots__/validation-ts-expect-error-argument-is-missing-stdout.snap.txt
+++ b/tests/__snapshots__/validation-ts-expect-error-argument-is-missing-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/.generated/validation-ts-expect-error
+
 uses TypeScript <<version>>
 
 fail ./__typetests__/sample.tst.ts

--- a/tests/__snapshots__/validation-type-errors-describe-level-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-describe-level-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-type-errors
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/describe-level.tst.ts

--- a/tests/__snapshots__/validation-type-errors-matcher-level-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-matcher-level-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-type-errors
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/matcher-level.tst.ts

--- a/tests/__snapshots__/validation-type-errors-test-level-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-test-level-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-type-errors
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/test-level.tst.ts

--- a/tests/__snapshots__/validation-type-errors-top-level-errors-stdout.snap.txt
+++ b/tests/__snapshots__/validation-type-errors-top-level-errors-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-type-errors
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/top-level.tst.ts

--- a/tests/__snapshots__/validation-when-action-chain-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-action-chain-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-when
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/action-chain.tst.ts

--- a/tests/__snapshots__/validation-when-argument-validation-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-argument-validation-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-when
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/when.tst.ts

--- a/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-handles-nested-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-when
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/handles-nested.tst.ts

--- a/tests/__snapshots__/validation-when-not-supported-action-stdout.snap.txt
+++ b/tests/__snapshots__/validation-when-not-supported-action-stdout.snap.txt
@@ -1,3 +1,5 @@
+···· TSTyche <<version>> from <<basePath>>/tests/__fixtures__/validation-when
+
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/not-supported-action.tst.ts

--- a/tests/__utilities__/output.js
+++ b/tests/__utilities__/output.js
@@ -1,6 +1,7 @@
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import ts from "typescript";
+import packageConfig from "../../package.json" with { type: "json" };
 
 const basePath = process.cwd().replace(/\\/g, "/");
 const baseUrl = pathToFileURL(process.cwd()).toString();
@@ -13,5 +14,6 @@ export function normalizeOutput(output) {
     .replace(new RegExp(baseUrl, "g"), "<<baseUrl>>")
     .replace(new RegExp(basePath, "g"), "<<basePath>>")
     .replace(/(Duration:\s{2})\s((?:\d\.?)+s)/g, "$1 <<timestamp>>")
-    .replace(new RegExp(`TypeScript ${ts.version}`, "g"), "TypeScript <<version>>");
+    .replace(new RegExp(`TypeScript ${ts.version}`, "g"), "TypeScript <<version>>")
+    .replace(new RegExp(`TSTyche ${packageConfig.version}`, "g"), "TSTyche <<version>>");
 }

--- a/tests/config-npmRegistry.test.js
+++ b/tests/config-npmRegistry.test.js
@@ -45,7 +45,7 @@ await test("'TSTYCHE_NPM_REGISTRY' environment variable", async (t) => {
     });
 
     assert.equal(stderr, "");
-    assert.match(stdout, /^adds TypeScript 5.4.5/);
+    assert.match(stdout, /adds TypeScript 5.4.5/);
     assert.equal(exitCode, 0);
   });
 });

--- a/tests/config-target.test.js
+++ b/tests/config-target.test.js
@@ -153,7 +153,7 @@ await test("'--target' command line option", async (t) => {
     });
 
     assert.equal(stderr, "");
-    assert.match(stdout, /^adds TypeScript/);
+    assert.match(stdout, /adds TypeScript/);
 
     assert.equal(exitCode, 0);
   });
@@ -387,7 +387,7 @@ await test("'target' configuration file option", async (t) => {
     });
 
     assert.equal(stderr, "");
-    assert.match(stdout, /^adds TypeScript/);
+    assert.match(stdout, /adds TypeScript/);
 
     assert.equal(exitCode, 0);
   });

--- a/tests/config-typescriptModule.test.js
+++ b/tests/config-typescriptModule.test.js
@@ -48,7 +48,7 @@ await test("'TSTYCHE_TYPESCRIPT_MODULE' environment variable", async (t) => {
     });
 
     assert.equal(stderr, "");
-    assert.match(stdout, /^uses TypeScript 5.2.2/);
+    assert.match(stdout, /uses TypeScript 5.2.2/);
     assert.equal(exitCode, 0);
   });
 });

--- a/tests/feature-store.test.js
+++ b/tests/feature-store.test.js
@@ -32,7 +32,7 @@ await test("store", async (t) => {
     assert.pathExists(packageUrl);
 
     assert.equal(stderr, "");
-    assert.match(stdout, /^adds TypeScript 5.2.2/);
+    assert.match(stdout, /adds TypeScript 5.2.2/);
     assert.equal(exitCode, 0);
   });
 
@@ -52,7 +52,7 @@ await test("store", async (t) => {
     assert.pathExists(packageUrl);
 
     assert.equal(stderr, "");
-    assert.match(stdout, /^uses TypeScript 5.2.2/);
+    assert.match(stdout, /uses TypeScript 5.2.2/);
     assert.equal(exitCode, 0);
   });
 

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -148,7 +148,7 @@ await test("TypeScript 4.x", async (t) => {
       });
 
       assert.equal(stderr, "");
-      assert.match(stdout, new RegExp(`^uses TypeScript ${version}\n`));
+      assert.match(stdout, new RegExp(`uses TypeScript ${version}\n`));
       assert.equal(exitCode, 0);
     });
   }
@@ -192,7 +192,7 @@ await test("TypeScript 5.x", async (t) => {
       });
 
       assert.equal(stderr, "");
-      assert.match(stdout, new RegExp(`^uses TypeScript ${version}\n`));
+      assert.match(stdout, new RegExp(`uses TypeScript ${version}\n`));
       assert.equal(exitCode, 0);
     });
   }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    "module": "node20",
     "noEmit": true,
     "types": ["node"]
   },


### PR DESCRIPTION
Close #596

As suggested in the issue, this change adds test runner version and root path to the output.