### PR TITLE
feat: enable testing of provided types with `.toBeConstructableWith()`

### DIFF
--- a/examples/Newable.tst.ts
+++ b/examples/Newable.tst.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "tstyche";
+
+type Newable<T extends abstract new (...args: any) => any> = {
+  new (...args: ConstructorParameters<T>): InstanceType<T>;
+};
+
+declare class Person {
+  constructor(name: string, age: number);
+}
+
+test("PersonConstructor", () => {
+  expect<Newable<typeof Person>>().type.toBeConstructableWith("Alice", 30);
+
+  expect<Newable<typeof Person>>().type.not.toBeConstructableWith("Alice");
+});

--- a/source/expect/ToBeConstructableWith.ts
+++ b/source/expect/ToBeConstructableWith.ts
@@ -16,22 +16,9 @@ export class ToBeConstructableWith extends AbilityMatcherBase {
     targetNodes: ts.NodeArray<ArgumentNode>,
     onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
   ): MatchResult | undefined {
-    let type: ts.Type | undefined;
+    const sourceType = matchWorker.getType(sourceNode);
 
-    if (this.compiler.isCallExpression(sourceNode)) {
-      type = matchWorker.typeChecker.getResolvedSignature(sourceNode)?.getReturnType();
-    }
-
-    if (
-      // allows instantiation expressions
-      this.compiler.isExpressionWithTypeArguments(sourceNode) ||
-      this.compiler.isIdentifier(sourceNode) ||
-      this.compiler.isPropertyAccessExpression(sourceNode)
-    ) {
-      type = matchWorker.getType(sourceNode);
-    }
-
-    if (!type || type.getConstructSignatures().length === 0) {
+    if (sourceType.getConstructSignatures().length === 0) {
       const text: Array<string> = [];
 
       if (nodeBelongsToArgumentList(this.compiler, sourceNode)) {
@@ -40,7 +27,7 @@ export class ToBeConstructableWith extends AbilityMatcherBase {
         text.push(ExpectDiagnosticText.typeArgumentMustBe("Source", "a constructable type"));
       }
 
-      if (type != null && type.getCallSignatures().length > 0) {
+      if (sourceType.getCallSignatures().length > 0) {
         text.push(ExpectDiagnosticText.didYouMeanToUse("the '.toBeCallableWith()' matcher"));
       }
 

--- a/tests/__fixtures__/api-toBeConstructableWith/__typetests__/generic-classes.tst.ts
+++ b/tests/__fixtures__/api-toBeConstructableWith/__typetests__/generic-classes.tst.ts
@@ -16,7 +16,7 @@ class Second<T> {
   }
 }
 
-describe("when target is an expression", () => {
+describe("when source is an expression", () => {
   test("is constructable with the given argument", () => {
     expect(First).type.toBeConstructableWith(["a", "b", "c"]);
     expect(First).type.not.toBeConstructableWith(["a", "b", "c"]); // fail
@@ -41,5 +41,33 @@ describe("when target is an expression", () => {
 
     expect(Second).type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
     expect(Second).type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
+  });
+});
+
+type FirstConstructor = new <T>(a: T) => First<T>;
+type SecondConstructor = new <T>(target: Array<T>, callback: (element: T) => void) => Second<T>;
+
+describe("when source is a type", () => {
+  test("is constructable with the given argument", () => {
+    expect<FirstConstructor>().type.toBeConstructableWith(["a", "b", "c"]);
+    expect<FirstConstructor>().type.not.toBeConstructableWith(["a", "b", "c"]); // fail
+  });
+
+  test("is not constructable without arguments", () => {
+    expect<FirstConstructor>().type.toBeConstructableWith();
+    expect<FirstConstructor>().type.not.toBeConstructableWith(); // fail: Expected 1 arguments, but got 0.
+  });
+
+  test("is constructable with the given arguments", () => {
+    expect<SecondConstructor>().type.toBeConstructableWith(["1", "2"], (_n: string) => {});
+    expect<SecondConstructor>().type.not.toBeConstructableWith(["1", "2"], (_n: string) => {}); // fail
+  });
+
+  test("is not constructable with the given arguments", () => {
+    expect<SecondConstructor>().type.not.toBeConstructableWith(["1", "2"], (_n: number) => {});
+    expect<SecondConstructor>().type.toBeConstructableWith(["1", "2"], (_n: number) => {}); // fail
+
+    expect<SecondConstructor>().type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
+    expect<SecondConstructor>().type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
   });
 });

--- a/tests/__fixtures__/api-toBeConstructableWith/__typetests__/overload-signatures.tst.ts
+++ b/tests/__fixtures__/api-toBeConstructableWith/__typetests__/overload-signatures.tst.ts
@@ -58,3 +58,49 @@ describe("when source is an expression", () => {
     expect(Point).type.toBeConstructableWith(4, 5, 6); // fail: Expected 1-2 arguments, but got 3.
   });
 });
+
+type PointConstructor = {
+  new (x: number, y: number): Point;
+  new (xy: string): Point;
+};
+
+type TestConstructor = {
+  new (name: string, cb: () => Promise<unknown>): Test;
+  new (name: string, cb: () => unknown): Test;
+};
+
+describe("when source is a type", () => {
+  test("is constructable with the given argument", () => {
+    expect<PointConstructor>().type.toBeConstructableWith("0:0");
+    expect<PointConstructor>().type.not.toBeConstructableWith("0:0"); // fail
+  });
+
+  test("is constructable with the given arguments", () => {
+    expect<PointConstructor>().type.toBeConstructableWith(4, 5);
+    expect<PointConstructor>().type.not.toBeConstructableWith(4, 5); // fail
+
+    expect<TestConstructor>().type.toBeConstructableWith("one", () => {});
+    expect<TestConstructor>().type.not.toBeConstructableWith("one", () => {}); // fail
+
+    expect<TestConstructor>().type.toBeConstructableWith("two", () => Promise.resolve());
+    expect<TestConstructor>().type.not.toBeConstructableWith("two", () => Promise.resolve()); // fail
+  });
+
+  test("is not constructable without arguments", () => {
+    expect<PointConstructor>().type.not.toBeConstructableWith();
+    expect<PointConstructor>().type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
+
+    expect<TestConstructor>().type.not.toBeConstructableWith();
+    expect<TestConstructor>().type.toBeConstructableWith(); // fail: Expected 2 arguments, but got 0.
+  });
+
+  test("is not constructable with the given argument", () => {
+    expect<TestConstructor>().type.not.toBeConstructableWith("nope");
+    expect<TestConstructor>().type.toBeConstructableWith("nope"); // fail: Expected 2 arguments, but got 1.
+  });
+
+  test("is not constructable with the given arguments", () => {
+    expect<PointConstructor>().type.not.toBeConstructableWith(4, 5, 6);
+    expect<PointConstructor>().type.toBeConstructableWith(4, 5, 6); // fail: Expected 1-2 arguments, but got 3.
+  });
+});

--- a/tests/__fixtures__/api-toBeConstructableWith/__typetests__/parameter-arity.tst.ts
+++ b/tests/__fixtures__/api-toBeConstructableWith/__typetests__/parameter-arity.tst.ts
@@ -41,7 +41,7 @@ class DefaultSecond {
   }
 }
 
-describe("when target is an expression", () => {
+describe("when source is an expression", () => {
   test("is constructable without arguments", () => {
     expect(Zero).type.toBeConstructableWith();
     expect(Zero).type.not.toBeConstructableWith(); // fail
@@ -148,5 +148,81 @@ describe("when target is an expression", () => {
 
     expect(DefaultSecond).type.not.toBeConstructableWith(...["one", 123, true]);
     expect(DefaultSecond).type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
+  });
+});
+
+type ZeroConstructor = new () => Zero;
+type OneConstructor = new (a: string) => One;
+type OptionalFirstConstructor = new (a?: string) => OptionalFirst;
+type OptionalSecondConstructor = new (a: string, b?: number) => OptionalSecond;
+
+describe("when source is a type", () => {
+  test("is constructable without arguments", () => {
+    expect<ZeroConstructor>().type.toBeConstructableWith();
+    expect<ZeroConstructor>().type.not.toBeConstructableWith(); // fail
+
+    expect<OptionalFirstConstructor>().type.toBeConstructableWith();
+    expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(); // fail
+  });
+
+  test("is not constructable without arguments", () => {
+    expect<OneConstructor>().type.not.toBeConstructableWith();
+    expect<OneConstructor>().type.toBeConstructableWith(); // fail: Expected 1 arguments, but got 0.
+
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith();
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
+  });
+
+  test("is constructable with the given argument", () => {
+    expect<OneConstructor>().type.toBeConstructableWith("one");
+    expect<OneConstructor>().type.not.toBeConstructableWith("one"); // fail
+
+    expect<OptionalFirstConstructor>().type.toBeConstructableWith(undefined);
+    expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(undefined); // fail
+
+    expect<OptionalFirstConstructor>().type.toBeConstructableWith("one");
+    expect<OptionalFirstConstructor>().type.not.toBeConstructableWith("one"); // fail
+
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith("one");
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one"); // fail
+  });
+
+  test("is not constructable with the given argument", () => {
+    expect<ZeroConstructor>().type.not.toBeConstructableWith("one");
+    expect<ZeroConstructor>().type.toBeConstructableWith("one"); // fail: Expected 0 arguments, but got 1.
+  });
+
+  test("is constructable with the given arguments", () => {
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", undefined);
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", undefined); // fail
+
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", undefined]);
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", undefined]); // fail
+
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", 123);
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", 123); // fail
+
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", 123]);
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", 123]); // fail
+  });
+
+  test("is not constructable with the given arguments", () => {
+    expect<OneConstructor>().type.not.toBeConstructableWith("one", "two");
+    expect<OneConstructor>().type.toBeConstructableWith("one", "two"); // fail: Expected 1 arguments, but got 2.
+
+    expect<OneConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+    expect<OneConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail: Expected 1 arguments, but got 2.
+
+    expect<OptionalFirstConstructor>().type.not.toBeConstructableWith("one", "two");
+    expect<OptionalFirstConstructor>().type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
+
+    expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+    expect<OptionalFirstConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
+
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", 123, true);
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
+
+    expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", 123, true]);
+    expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
   });
 });

--- a/tests/__fixtures__/api-toBeConstructableWith/__typetests__/rest-parameters.tst.ts
+++ b/tests/__fixtures__/api-toBeConstructableWith/__typetests__/rest-parameters.tst.ts
@@ -30,7 +30,7 @@ class Trailing {
   }
 }
 
-describe("when target is an expression", () => {
+describe("when source is an expression", () => {
   test("is constructable with the given argument", () => {
     expect(Optional).type.toBeConstructableWith("one");
     expect(Optional).type.not.toBeConstructableWith("one"); // fail
@@ -117,5 +117,100 @@ describe("when target is an expression", () => {
 
     expect(Trailing).type.not.toBeConstructableWith(false, ...[10, 11]);
     expect(Trailing).type.toBeConstructableWith(false, ...[10, 11]); // fail
+  });
+});
+
+type OptionalConstructor = new (...args: Array<unknown>) => Optional;
+type LeadingConstructor = new (...args: [...Array<string>, boolean]) => Leading;
+type MiddleConstructor = new (...args: [string, ...Array<number>, boolean]) => Middle;
+type TrailingConstructor = new (x: boolean, ...y: Array<string>) => Trailing;
+
+describe("when source is a type", () => {
+  test("is constructable with the given argument", () => {
+    expect<OptionalConstructor>().type.toBeConstructableWith("one");
+    expect<OptionalConstructor>().type.not.toBeConstructableWith("one"); // fail
+
+    expect<LeadingConstructor>().type.toBeConstructableWith(false);
+    expect<LeadingConstructor>().type.not.toBeConstructableWith(false); // fail
+
+    expect<TrailingConstructor>().type.toBeConstructableWith(true);
+    expect<TrailingConstructor>().type.not.toBeConstructableWith(true); // fail
+  });
+
+  test("is constructable with the given arguments", () => {
+    expect<OptionalConstructor>().type.toBeConstructableWith("one", 2, true);
+    expect<OptionalConstructor>().type.not.toBeConstructableWith("one", 2, true); // fail
+
+    expect<LeadingConstructor>().type.toBeConstructableWith("one", "two", true);
+    expect<LeadingConstructor>().type.not.toBeConstructableWith("one", "two", true); // fail
+
+    expect<LeadingConstructor>().type.toBeConstructableWith(...["one", "two"], true);
+    expect<LeadingConstructor>().type.not.toBeConstructableWith(...["one", "two"], true); // fail
+
+    expect<MiddleConstructor>().type.toBeConstructableWith("one", 123, 456, true);
+    expect<MiddleConstructor>().type.not.toBeConstructableWith("one", 123, 456, true); // fail
+
+    expect<MiddleConstructor>().type.toBeConstructableWith(...["one", 123, 456, true]);
+    expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", 123, 456, true]); // fail
+
+    expect<TrailingConstructor>().type.toBeConstructableWith(false, "ten", "eleven");
+    expect<TrailingConstructor>().type.not.toBeConstructableWith(false, "ten", "eleven"); // fail
+
+    expect<TrailingConstructor>().type.toBeConstructableWith(false, ...["ten", "eleven"]);
+    expect<TrailingConstructor>().type.not.toBeConstructableWith(false, ...["ten", "eleven"]); // fail
+  });
+
+  test("is constructable without arguments", () => {
+    expect<OptionalConstructor>().type.toBeConstructableWith();
+    expect<OptionalConstructor>().type.not.toBeConstructableWith(); // fail
+  });
+
+  test("is not constructable without arguments", () => {
+    expect<LeadingConstructor>().type.not.toBeConstructableWith();
+    expect<LeadingConstructor>().type.toBeConstructableWith(); // fail: Source has 0 element(s) but target requires 1.
+
+    expect<MiddleConstructor>().type.not.toBeConstructableWith();
+    expect<MiddleConstructor>().type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
+
+    expect<TrailingConstructor>().type.not.toBeConstructableWith();
+    expect<TrailingConstructor>().type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
+  });
+
+  test("is not constructable with the given arguments", () => {
+    expect<LeadingConstructor>().type.not.toBeConstructableWith("one", "two");
+    expect<LeadingConstructor>().type.toBeConstructableWith("one", "two"); // fail
+
+    expect<LeadingConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+    expect<LeadingConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail
+
+    expect<LeadingConstructor>().type.not.toBeConstructableWith(3, 4, true);
+    expect<LeadingConstructor>().type.toBeConstructableWith(3, 4, true); // fail
+
+    expect<LeadingConstructor>().type.not.toBeConstructableWith(...[3, 4], true);
+    expect<LeadingConstructor>().type.toBeConstructableWith(...[3, 4], true); // fail
+
+    expect<MiddleConstructor>().type.not.toBeConstructableWith("one", 2, 3);
+    expect<MiddleConstructor>().type.toBeConstructableWith("one", 2, 3); // fail
+
+    expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", 2, 3]);
+    expect<MiddleConstructor>().type.toBeConstructableWith(...["one", 2, 3]); // fail
+
+    expect<MiddleConstructor>().type.not.toBeConstructableWith("one", "two", "three", true);
+    expect<MiddleConstructor>().type.toBeConstructableWith("one", "two", "three", true); // fail
+
+    expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", "two", "three", true]);
+    expect<MiddleConstructor>().type.toBeConstructableWith(...["one", "two", "three", true]); // fail
+
+    expect<TrailingConstructor>().type.not.toBeConstructableWith("ten", "eleven");
+    expect<TrailingConstructor>().type.toBeConstructableWith("ten", "eleven"); // fail
+
+    expect<TrailingConstructor>().type.not.toBeConstructableWith(...["ten", "eleven"]);
+    expect<TrailingConstructor>().type.toBeConstructableWith(...["ten", "eleven"]); // fail
+
+    expect<TrailingConstructor>().type.not.toBeConstructableWith(false, 10, 11);
+    expect<TrailingConstructor>().type.toBeConstructableWith(false, 10, 11); // fail
+
+    expect<TrailingConstructor>().type.not.toBeConstructableWith(false, ...[10, 11]);
+    expect<TrailingConstructor>().type.toBeConstructableWith(false, ...[10, 11]); // fail
   });
 });

--- a/tests/__fixtures__/validation-toBeConstructableWith/__typetests__/toBeConstructableWith.tst.ts
+++ b/tests/__fixtures__/validation-toBeConstructableWith/__typetests__/toBeConstructableWith.tst.ts
@@ -52,6 +52,8 @@ describe("argument for 'source'", () => {
   test("allowed expressions", () => {
     expect(getPersonConstructor()).type.toBeConstructableWith("abc");
     expect(Person).type.toBeConstructableWith("abc");
+    expect({} as typeof Person).type.toBeConstructableWith("abc");
+    expect({} as new (name: string) => Person).type.toBeConstructableWith("abc");
     expect(obj.Person).type.toBeConstructableWith("abc");
   });
 

--- a/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stderr.snap.txt
@@ -8,7 +8,7 @@ Error: Expression is constructable with the given argument.
   24 | 
   25 |   test("is not constructable without arguments", () => {
 
-       at ./__typetests__/generic-classes.tst.ts:22:28 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/generic-classes.tst.ts:22:28 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is not constructable without arguments.
 
@@ -22,7 +22,7 @@ Expected 1 arguments, but got 0.
   28 |   });
   29 | 
 
-       at ./__typetests__/generic-classes.tst.ts:26:24 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/generic-classes.tst.ts:26:24 ❭ when source is an expression ❭ is not constructable without arguments
 
     An argument for 'a' was not provided. ts(6210)
 
@@ -46,7 +46,7 @@ Error: Expression is constructable with the given arguments.
   34 |     expect(Second<number | string>).type.toBeConstructableWith(["1", 2], (_n: string | number) => {});
   35 |     expect(Second<number | string>).type.not.toBeConstructableWith(["1", 2], (_n: string | number) => {}); // fail
 
-       at ./__typetests__/generic-classes.tst.ts:32:29 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/generic-classes.tst.ts:32:29 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -58,7 +58,7 @@ Error: Expression is constructable with the given arguments.
   37 | 
   38 |   test("is not constructable with the given arguments", () => {
 
-       at ./__typetests__/generic-classes.tst.ts:35:46 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/generic-classes.tst.ts:35:46 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -72,7 +72,7 @@ Type 'string' is not assignable to type 'number'.
   42 |     expect(Second).type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
   43 |     expect(Second).type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
 
-       at ./__typetests__/generic-classes.tst.ts:40:48 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/generic-classes.tst.ts:40:48 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -86,7 +86,7 @@ Type 'string' is not assignable to type 'number'.
   42 |     expect(Second).type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
   43 |     expect(Second).type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
 
-       at ./__typetests__/generic-classes.tst.ts:40:53 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/generic-classes.tst.ts:40:53 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -100,5 +100,97 @@ Type 'number' is not assignable to type 'string'.
   45 | });
   46 | 
 
-       at ./__typetests__/generic-classes.tst.ts:43:53 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/generic-classes.tst.ts:43:53 ❭ when source is an expression ❭ is not constructable with the given arguments
+
+Error: Type is constructable with the given argument.
+
+  51 |   test("is constructable with the given argument", () => {
+  52 |     expect<FirstConstructor>().type.toBeConstructableWith(["a", "b", "c"]);
+  53 |     expect<FirstConstructor>().type.not.toBeConstructableWith(["a", "b", "c"]); // fail
+     |                                         ~~~~~~~~~~~~~~~~~~~~~
+  54 |   });
+  55 | 
+  56 |   test("is not constructable without arguments", () => {
+
+       at ./__typetests__/generic-classes.tst.ts:53:41 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is not constructable without arguments.
+
+Expected 1 arguments, but got 0.
+
+  55 | 
+  56 |   test("is not constructable without arguments", () => {
+  57 |     expect<FirstConstructor>().type.toBeConstructableWith();
+     |                                     ~~~~~~~~~~~~~~~~~~~~~
+  58 |     expect<FirstConstructor>().type.not.toBeConstructableWith(); // fail: Expected 1 arguments, but got 0.
+  59 |   });
+  60 | 
+
+       at ./__typetests__/generic-classes.tst.ts:57:37 ❭ when source is a type ❭ is not constructable without arguments
+
+    An argument for 'a' was not provided. ts(6210)
+
+      45 | });
+      46 | 
+      47 | type FirstConstructor = new <T>(a: T) => First<T>;
+         |                                 ~~~~
+      48 | type SecondConstructor = new <T>(target: Array<T>, callback: (element: T) => void) => Second<T>;
+      49 | 
+      50 | describe("when source is a type", () => {
+
+           at ./__typetests__/generic-classes.tst.ts:47:33
+
+Error: Type is constructable with the given arguments.
+
+  61 |   test("is constructable with the given arguments", () => {
+  62 |     expect<SecondConstructor>().type.toBeConstructableWith(["1", "2"], (_n: string) => {});
+  63 |     expect<SecondConstructor>().type.not.toBeConstructableWith(["1", "2"], (_n: string) => {}); // fail
+     |                                          ~~~~~~~~~~~~~~~~~~~~~
+  64 |   });
+  65 | 
+  66 |   test("is not constructable with the given arguments", () => {
+
+       at ./__typetests__/generic-classes.tst.ts:63:42 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Type 'string' is not assignable to type 'number'.
+
+  66 |   test("is not constructable with the given arguments", () => {
+  67 |     expect<SecondConstructor>().type.not.toBeConstructableWith(["1", "2"], (_n: number) => {});
+  68 |     expect<SecondConstructor>().type.toBeConstructableWith(["1", "2"], (_n: number) => {}); // fail
+     |                                                             ~~~
+  69 | 
+  70 |     expect<SecondConstructor>().type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
+  71 |     expect<SecondConstructor>().type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
+
+       at ./__typetests__/generic-classes.tst.ts:68:61 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Type 'string' is not assignable to type 'number'.
+
+  66 |   test("is not constructable with the given arguments", () => {
+  67 |     expect<SecondConstructor>().type.not.toBeConstructableWith(["1", "2"], (_n: number) => {});
+  68 |     expect<SecondConstructor>().type.toBeConstructableWith(["1", "2"], (_n: number) => {}); // fail
+     |                                                                  ~~~
+  69 | 
+  70 |     expect<SecondConstructor>().type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
+  71 |     expect<SecondConstructor>().type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
+
+       at ./__typetests__/generic-classes.tst.ts:68:66 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Type 'number' is not assignable to type 'string'.
+
+  69 | 
+  70 |     expect<SecondConstructor>().type.not.toBeConstructableWith(["1", 2], (_n: string) => {});
+  71 |     expect<SecondConstructor>().type.toBeConstructableWith(["1", 2], (_n: string) => {}); // fail
+     |                                                                  ~
+  72 |   });
+  73 | });
+  74 | 
+
+       at ./__typetests__/generic-classes.tst.ts:71:66 ❭ when source is a type ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-generic-classes-stdout.snap.txt
@@ -3,7 +3,12 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/generic-classes.tst.ts
-  when target is an expression
+  when source is an expression
+    × is constructable with the given argument
+    × is not constructable without arguments
+    × is constructable with the given arguments
+    × is not constructable with the given arguments
+  when source is a type
     × is constructable with the given argument
     × is not constructable without arguments
     × is constructable with the given arguments
@@ -11,6 +16,6 @@ fail ./__typetests__/generic-classes.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      4 failed, 4 total
-Assertions: 6 failed, 6 passed, 12 total
+Tests:      8 failed, 8 total
+Assertions: 11 failed, 11 passed, 22 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stderr.snap.txt
@@ -153,3 +153,143 @@ Expected 1-2 arguments, but got 3.
 
        at ./__typetests__/overload-signatures.tst.ts:58:52 ❭ when source is an expression ❭ is not constructable with the given arguments
 
+Error: Type is constructable with the given argument.
+
+  73 |   test("is constructable with the given argument", () => {
+  74 |     expect<PointConstructor>().type.toBeConstructableWith("0:0");
+  75 |     expect<PointConstructor>().type.not.toBeConstructableWith("0:0"); // fail
+     |                                         ~~~~~~~~~~~~~~~~~~~~~
+  76 |   });
+  77 | 
+  78 |   test("is constructable with the given arguments", () => {
+
+       at ./__typetests__/overload-signatures.tst.ts:75:41 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given arguments.
+
+  78 |   test("is constructable with the given arguments", () => {
+  79 |     expect<PointConstructor>().type.toBeConstructableWith(4, 5);
+  80 |     expect<PointConstructor>().type.not.toBeConstructableWith(4, 5); // fail
+     |                                         ~~~~~~~~~~~~~~~~~~~~~
+  81 | 
+  82 |     expect<TestConstructor>().type.toBeConstructableWith("one", () => {});
+  83 |     expect<TestConstructor>().type.not.toBeConstructableWith("one", () => {}); // fail
+
+       at ./__typetests__/overload-signatures.tst.ts:80:41 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  81 | 
+  82 |     expect<TestConstructor>().type.toBeConstructableWith("one", () => {});
+  83 |     expect<TestConstructor>().type.not.toBeConstructableWith("one", () => {}); // fail
+     |                                        ~~~~~~~~~~~~~~~~~~~~~
+  84 | 
+  85 |     expect<TestConstructor>().type.toBeConstructableWith("two", () => Promise.resolve());
+  86 |     expect<TestConstructor>().type.not.toBeConstructableWith("two", () => Promise.resolve()); // fail
+
+       at ./__typetests__/overload-signatures.tst.ts:83:40 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  84 | 
+  85 |     expect<TestConstructor>().type.toBeConstructableWith("two", () => Promise.resolve());
+  86 |     expect<TestConstructor>().type.not.toBeConstructableWith("two", () => Promise.resolve()); // fail
+     |                                        ~~~~~~~~~~~~~~~~~~~~~
+  87 |   });
+  88 | 
+  89 |   test("is not constructable without arguments", () => {
+
+       at ./__typetests__/overload-signatures.tst.ts:86:40 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is not constructable without arguments.
+
+Expected 1-2 arguments, but got 0.
+
+  89 |   test("is not constructable without arguments", () => {
+  90 |     expect<PointConstructor>().type.not.toBeConstructableWith();
+  91 |     expect<PointConstructor>().type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
+     |                                     ~~~~~~~~~~~~~~~~~~~~~
+  92 | 
+  93 |     expect<TestConstructor>().type.not.toBeConstructableWith();
+  94 |     expect<TestConstructor>().type.toBeConstructableWith(); // fail: Expected 2 arguments, but got 0.
+
+       at ./__typetests__/overload-signatures.tst.ts:91:37 ❭ when source is a type ❭ is not constructable without arguments
+
+    An argument for 'xy' was not provided. ts(6210)
+
+      62 | type PointConstructor = {
+      63 |   new (x: number, y: number): Point;
+      64 |   new (xy: string): Point;
+         |        ~~~~~~~~~~
+      65 | };
+      66 | 
+      67 | type TestConstructor = {
+
+           at ./__typetests__/overload-signatures.tst.ts:64:8
+
+Error: Type is not constructable without arguments.
+
+Expected 2 arguments, but got 0.
+
+  92 | 
+  93 |     expect<TestConstructor>().type.not.toBeConstructableWith();
+  94 |     expect<TestConstructor>().type.toBeConstructableWith(); // fail: Expected 2 arguments, but got 0.
+     |                                    ~~~~~~~~~~~~~~~~~~~~~
+  95 |   });
+  96 | 
+  97 |   test("is not constructable with the given argument", () => {
+
+       at ./__typetests__/overload-signatures.tst.ts:94:36 ❭ when source is a type ❭ is not constructable without arguments
+
+    An argument for 'name' was not provided. ts(6210)
+
+      66 | 
+      67 | type TestConstructor = {
+      68 |   new (name: string, cb: () => Promise<unknown>): Test;
+         |        ~~~~~~~~~~~~
+      69 |   new (name: string, cb: () => unknown): Test;
+      70 | };
+      71 | 
+
+           at ./__typetests__/overload-signatures.tst.ts:68:8
+
+Error: Type is not constructable with the given argument.
+
+Expected 2 arguments, but got 1.
+
+   97 |   test("is not constructable with the given argument", () => {
+   98 |     expect<TestConstructor>().type.not.toBeConstructableWith("nope");
+   99 |     expect<TestConstructor>().type.toBeConstructableWith("nope"); // fail: Expected 2 arguments, but got 1.
+      |                                    ~~~~~~~~~~~~~~~~~~~~~
+  100 |   });
+  101 | 
+  102 |   test("is not constructable with the given arguments", () => {
+
+        at ./__typetests__/overload-signatures.tst.ts:99:36 ❭ when source is a type ❭ is not constructable with the given argument
+
+    An argument for 'cb' was not provided. ts(6210)
+
+      66 | 
+      67 | type TestConstructor = {
+      68 |   new (name: string, cb: () => Promise<unknown>): Test;
+         |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+      69 |   new (name: string, cb: () => unknown): Test;
+      70 | };
+      71 | 
+
+           at ./__typetests__/overload-signatures.tst.ts:68:22
+
+Error: Type is not constructable with the given arguments.
+
+Expected 1-2 arguments, but got 3.
+
+  102 |   test("is not constructable with the given arguments", () => {
+  103 |     expect<PointConstructor>().type.not.toBeConstructableWith(4, 5, 6);
+  104 |     expect<PointConstructor>().type.toBeConstructableWith(4, 5, 6); // fail: Expected 1-2 arguments, but got 3.
+      |                                                                 ~
+  105 |   });
+  106 | });
+  107 | 
+
+        at ./__typetests__/overload-signatures.tst.ts:104:65 ❭ when source is a type ❭ is not constructable with the given arguments
+

--- a/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-overload-signatures-stdout.snap.txt
@@ -9,9 +9,15 @@ fail ./__typetests__/overload-signatures.tst.ts
     × is not constructable without arguments
     × is not constructable with the given argument
     × is not constructable with the given arguments
+  when source is a type
+    × is constructable with the given argument
+    × is constructable with the given arguments
+    × is not constructable without arguments
+    × is not constructable with the given argument
+    × is not constructable with the given arguments
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      5 failed, 5 total
-Assertions: 8 failed, 8 passed, 16 total
+Tests:      10 failed, 10 total
+Assertions: 16 failed, 16 passed, 32 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stderr.snap.txt
@@ -8,7 +8,7 @@ Error: Expression is constructable without arguments.
   49 |     expect(OptionalFirst).type.toBeConstructableWith();
   50 |     expect(OptionalFirst).type.not.toBeConstructableWith(); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:47:27 ❭ when target is an expression ❭ is constructable without arguments
+       at ./__typetests__/parameter-arity.tst.ts:47:27 ❭ when source is an expression ❭ is constructable without arguments
 
 Error: Expression is constructable without arguments.
 
@@ -20,7 +20,7 @@ Error: Expression is constructable without arguments.
   52 |     expect(DefaultFirst).type.toBeConstructableWith();
   53 |     expect(DefaultFirst).type.not.toBeConstructableWith(); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:50:36 ❭ when target is an expression ❭ is constructable without arguments
+       at ./__typetests__/parameter-arity.tst.ts:50:36 ❭ when source is an expression ❭ is constructable without arguments
 
 Error: Expression is constructable without arguments.
 
@@ -32,7 +32,7 @@ Error: Expression is constructable without arguments.
   55 | 
   56 |   test("is not constructable without arguments", () => {
 
-       at ./__typetests__/parameter-arity.tst.ts:53:35 ❭ when target is an expression ❭ is constructable without arguments
+       at ./__typetests__/parameter-arity.tst.ts:53:35 ❭ when source is an expression ❭ is constructable without arguments
 
 Error: Expression is not constructable without arguments.
 
@@ -46,7 +46,7 @@ Expected 1 arguments, but got 0.
   60 |     expect(OptionalSecond).type.not.toBeConstructableWith();
   61 |     expect(OptionalSecond).type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
 
-       at ./__typetests__/parameter-arity.tst.ts:58:22 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/parameter-arity.tst.ts:58:22 ❭ when source is an expression ❭ is not constructable without arguments
 
     An argument for 'a' was not provided. ts(6210)
 
@@ -72,7 +72,7 @@ Expected 1-2 arguments, but got 0.
   63 |     expect(DefaultSecond).type.not.toBeConstructableWith();
   64 |     expect(DefaultSecond).type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
 
-       at ./__typetests__/parameter-arity.tst.ts:61:33 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/parameter-arity.tst.ts:61:33 ❭ when source is an expression ❭ is not constructable without arguments
 
     An argument for 'a' was not provided. ts(6210)
 
@@ -98,7 +98,7 @@ Expected 1-2 arguments, but got 0.
   66 | 
   67 |   test("is constructable with the given argument", () => {
 
-       at ./__typetests__/parameter-arity.tst.ts:64:32 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/parameter-arity.tst.ts:64:32 ❭ when source is an expression ❭ is not constructable without arguments
 
     An argument for 'a' was not provided. ts(6210)
 
@@ -122,7 +122,7 @@ Error: Expression is constructable with the given argument.
   71 |     expect(OptionalFirst).type.toBeConstructableWith(undefined);
   72 |     expect(OptionalFirst).type.not.toBeConstructableWith(undefined); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:69:26 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:69:26 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -134,7 +134,7 @@ Error: Expression is constructable with the given argument.
   74 |     expect(OptionalFirst).type.toBeConstructableWith("one");
   75 |     expect(OptionalFirst).type.not.toBeConstructableWith("one"); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:72:36 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:72:36 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -146,7 +146,7 @@ Error: Expression is constructable with the given argument.
   77 |     expect(OptionalSecond).type.toBeConstructableWith("one");
   78 |     expect(OptionalSecond).type.not.toBeConstructableWith("one"); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:75:36 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:75:36 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -158,7 +158,7 @@ Error: Expression is constructable with the given argument.
   80 |     expect(DefaultFirst).type.toBeConstructableWith(undefined);
   81 |     expect(DefaultFirst).type.not.toBeConstructableWith(undefined); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:78:37 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:78:37 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -170,7 +170,7 @@ Error: Expression is constructable with the given argument.
   83 |     expect(DefaultFirst).type.toBeConstructableWith("one");
   84 |     expect(DefaultFirst).type.not.toBeConstructableWith("one"); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:81:35 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:81:35 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -182,7 +182,7 @@ Error: Expression is constructable with the given argument.
   86 |     expect(DefaultSecond).type.toBeConstructableWith("one");
   87 |     expect(DefaultSecond).type.not.toBeConstructableWith("one"); // fail
 
-       at ./__typetests__/parameter-arity.tst.ts:84:35 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:84:35 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -194,7 +194,7 @@ Error: Expression is constructable with the given argument.
   89 | 
   90 |   test("is not constructable with the given argument", () => {
 
-       at ./__typetests__/parameter-arity.tst.ts:87:36 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:87:36 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is not constructable with the given argument.
 
@@ -208,7 +208,7 @@ Expected 0 arguments, but got 1.
   94 | 
   95 |   test("is constructable with the given arguments", () => {
 
-       at ./__typetests__/parameter-arity.tst.ts:92:45 ❭ when target is an expression ❭ is not constructable with the given argument
+       at ./__typetests__/parameter-arity.tst.ts:92:45 ❭ when source is an expression ❭ is not constructable with the given argument
 
 Error: Expression is constructable with the given arguments.
 
@@ -220,7 +220,7 @@ Error: Expression is constructable with the given arguments.
    99 |     expect(OptionalSecond).type.toBeConstructableWith(...["one", undefined]);
   100 |     expect(OptionalSecond).type.not.toBeConstructableWith(...["one", undefined]); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:97:37 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:97:37 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -232,7 +232,7 @@ Error: Expression is constructable with the given arguments.
   102 |     expect(OptionalSecond).type.toBeConstructableWith("one", 123);
   103 |     expect(OptionalSecond).type.not.toBeConstructableWith("one", 123); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:100:37 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:100:37 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -244,7 +244,7 @@ Error: Expression is constructable with the given arguments.
   105 |     expect(OptionalSecond).type.toBeConstructableWith(...["one", 123]);
   106 |     expect(OptionalSecond).type.not.toBeConstructableWith(...["one", 123]); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:103:37 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:103:37 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -256,7 +256,7 @@ Error: Expression is constructable with the given arguments.
   108 |     expect(DefaultSecond).type.toBeConstructableWith("one", undefined);
   109 |     expect(DefaultSecond).type.not.toBeConstructableWith("one", undefined); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:106:37 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:106:37 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -268,7 +268,7 @@ Error: Expression is constructable with the given arguments.
   111 |     expect(DefaultSecond).type.toBeConstructableWith(...["one", undefined]);
   112 |     expect(DefaultSecond).type.not.toBeConstructableWith(...["one", undefined]); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:109:36 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:109:36 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -280,7 +280,7 @@ Error: Expression is constructable with the given arguments.
   114 |     expect(DefaultSecond).type.toBeConstructableWith("one", 123);
   115 |     expect(DefaultSecond).type.not.toBeConstructableWith("one", 123); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:112:36 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:112:36 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -292,7 +292,7 @@ Error: Expression is constructable with the given arguments.
   117 |     expect(DefaultSecond).type.toBeConstructableWith(...["one", 123]);
   118 |     expect(DefaultSecond).type.not.toBeConstructableWith(...["one", 123]); // fail
 
-        at ./__typetests__/parameter-arity.tst.ts:115:36 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:115:36 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -304,7 +304,7 @@ Error: Expression is constructable with the given arguments.
   120 | 
   121 |   test("is not constructable with the given arguments", () => {
 
-        at ./__typetests__/parameter-arity.tst.ts:118:36 ❭ when target is an expression ❭ is constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:118:36 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -318,7 +318,7 @@ Expected 1 arguments, but got 2.
   125 |     expect(One).type.not.toBeConstructableWith(...["one", "two"]);
   126 |     expect(One).type.toBeConstructableWith(...["one", "two"]); // fail: Expected 1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:123:51 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:123:51 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -332,7 +332,7 @@ Expected 1 arguments, but got 2.
   128 |     expect(OptionalFirst).type.not.toBeConstructableWith("one", "two");
   129 |     expect(OptionalFirst).type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:126:44 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:126:44 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -346,7 +346,7 @@ Expected 0-1 arguments, but got 2.
   131 |     expect(OptionalFirst).type.not.toBeConstructableWith(...["one", "two"]);
   132 |     expect(OptionalFirst).type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:129:61 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:129:61 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -360,7 +360,7 @@ Expected 0-1 arguments, but got 2.
   134 |     expect(OptionalSecond).type.not.toBeConstructableWith("one", 123, true);
   135 |     expect(OptionalSecond).type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:132:54 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:132:54 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -374,7 +374,7 @@ Expected 1-2 arguments, but got 3.
   137 |     expect(OptionalSecond).type.not.toBeConstructableWith(...["one", 123, true]);
   138 |     expect(OptionalSecond).type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:135:67 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:135:67 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -388,7 +388,7 @@ Expected 1-2 arguments, but got 3.
   140 |     expect(DefaultFirst).type.not.toBeConstructableWith("one", "two");
   141 |     expect(DefaultFirst).type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:138:55 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:138:55 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -402,7 +402,7 @@ Expected 0-1 arguments, but got 2.
   143 |     expect(DefaultFirst).type.not.toBeConstructableWith(...["one", "two"]);
   144 |     expect(DefaultFirst).type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
 
-        at ./__typetests__/parameter-arity.tst.ts:141:60 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:141:60 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -416,7 +416,7 @@ Expected 0-1 arguments, but got 2.
   146 |     expect(DefaultSecond).type.not.toBeConstructableWith("one", 123, true);
   147 |     expect(DefaultSecond).type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:144:53 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:144:53 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -430,7 +430,7 @@ Expected 1-2 arguments, but got 3.
   149 |     expect(DefaultSecond).type.not.toBeConstructableWith(...["one", 123, true]);
   150 |     expect(DefaultSecond).type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
 
-        at ./__typetests__/parameter-arity.tst.ts:147:66 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:147:66 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -444,5 +444,275 @@ Expected 1-2 arguments, but got 3.
   152 | });
   153 | 
 
-        at ./__typetests__/parameter-arity.tst.ts:150:54 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/parameter-arity.tst.ts:150:54 ❭ when source is an expression ❭ is not constructable with the given arguments
+
+Error: Type is constructable without arguments.
+
+  160 |   test("is constructable without arguments", () => {
+  161 |     expect<ZeroConstructor>().type.toBeConstructableWith();
+  162 |     expect<ZeroConstructor>().type.not.toBeConstructableWith(); // fail
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  163 | 
+  164 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith();
+  165 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:162:40 ❭ when source is a type ❭ is constructable without arguments
+
+Error: Type is constructable without arguments.
+
+  163 | 
+  164 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith();
+  165 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(); // fail
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  166 |   });
+  167 | 
+  168 |   test("is not constructable without arguments", () => {
+
+        at ./__typetests__/parameter-arity.tst.ts:165:49 ❭ when source is a type ❭ is constructable without arguments
+
+Error: Type is not constructable without arguments.
+
+Expected 1 arguments, but got 0.
+
+  168 |   test("is not constructable without arguments", () => {
+  169 |     expect<OneConstructor>().type.not.toBeConstructableWith();
+  170 |     expect<OneConstructor>().type.toBeConstructableWith(); // fail: Expected 1 arguments, but got 0.
+      |                                   ~~~~~~~~~~~~~~~~~~~~~
+  171 | 
+  172 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith();
+  173 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
+
+        at ./__typetests__/parameter-arity.tst.ts:170:35 ❭ when source is a type ❭ is not constructable without arguments
+
+    An argument for 'a' was not provided. ts(6210)
+
+      153 | 
+      154 | type ZeroConstructor = new () => Zero;
+      155 | type OneConstructor = new (a: string) => One;
+          |                            ~~~~~~~~~
+      156 | type OptionalFirstConstructor = new (a?: string) => OptionalFirst;
+      157 | type OptionalSecondConstructor = new (a: string, b?: number) => OptionalSecond;
+      158 | 
+
+            at ./__typetests__/parameter-arity.tst.ts:155:28
+
+Error: Type is not constructable without arguments.
+
+Expected 1-2 arguments, but got 0.
+
+  171 | 
+  172 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith();
+  173 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(); // fail: Expected 1-2 arguments, but got 0.
+      |                                              ~~~~~~~~~~~~~~~~~~~~~
+  174 |   });
+  175 | 
+  176 |   test("is constructable with the given argument", () => {
+
+        at ./__typetests__/parameter-arity.tst.ts:173:46 ❭ when source is a type ❭ is not constructable without arguments
+
+    An argument for 'a' was not provided. ts(6210)
+
+      155 | type OneConstructor = new (a: string) => One;
+      156 | type OptionalFirstConstructor = new (a?: string) => OptionalFirst;
+      157 | type OptionalSecondConstructor = new (a: string, b?: number) => OptionalSecond;
+          |                                       ~~~~~~~~~
+      158 | 
+      159 | describe("when source is a type", () => {
+      160 |   test("is constructable without arguments", () => {
+
+            at ./__typetests__/parameter-arity.tst.ts:157:39
+
+Error: Type is constructable with the given argument.
+
+  176 |   test("is constructable with the given argument", () => {
+  177 |     expect<OneConstructor>().type.toBeConstructableWith("one");
+  178 |     expect<OneConstructor>().type.not.toBeConstructableWith("one"); // fail
+      |                                       ~~~~~~~~~~~~~~~~~~~~~
+  179 | 
+  180 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith(undefined);
+  181 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(undefined); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:178:39 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given argument.
+
+  179 | 
+  180 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith(undefined);
+  181 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(undefined); // fail
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  182 | 
+  183 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith("one");
+  184 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith("one"); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:181:49 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given argument.
+
+  182 | 
+  183 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith("one");
+  184 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith("one"); // fail
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  185 | 
+  186 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one");
+  187 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one"); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:184:49 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given argument.
+
+  185 | 
+  186 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one");
+  187 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one"); // fail
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  188 |   });
+  189 | 
+  190 |   test("is not constructable with the given argument", () => {
+
+        at ./__typetests__/parameter-arity.tst.ts:187:50 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is not constructable with the given argument.
+
+Expected 0 arguments, but got 1.
+
+  190 |   test("is not constructable with the given argument", () => {
+  191 |     expect<ZeroConstructor>().type.not.toBeConstructableWith("one");
+  192 |     expect<ZeroConstructor>().type.toBeConstructableWith("one"); // fail: Expected 0 arguments, but got 1.
+      |                                                          ~~~~~
+  193 |   });
+  194 | 
+  195 |   test("is constructable with the given arguments", () => {
+
+        at ./__typetests__/parameter-arity.tst.ts:192:58 ❭ when source is a type ❭ is not constructable with the given argument
+
+Error: Type is constructable with the given arguments.
+
+  195 |   test("is constructable with the given arguments", () => {
+  196 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", undefined);
+  197 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", undefined); // fail
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  198 | 
+  199 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", undefined]);
+  200 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", undefined]); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:197:50 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  198 | 
+  199 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", undefined]);
+  200 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", undefined]); // fail
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  201 | 
+  202 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", 123);
+  203 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", 123); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:200:50 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  201 | 
+  202 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", 123);
+  203 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", 123); // fail
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  204 | 
+  205 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", 123]);
+  206 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", 123]); // fail
+
+        at ./__typetests__/parameter-arity.tst.ts:203:50 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  204 | 
+  205 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", 123]);
+  206 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", 123]); // fail
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  207 |   });
+  208 | 
+  209 |   test("is not constructable with the given arguments", () => {
+
+        at ./__typetests__/parameter-arity.tst.ts:206:50 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Expected 1 arguments, but got 2.
+
+  209 |   test("is not constructable with the given arguments", () => {
+  210 |     expect<OneConstructor>().type.not.toBeConstructableWith("one", "two");
+  211 |     expect<OneConstructor>().type.toBeConstructableWith("one", "two"); // fail: Expected 1 arguments, but got 2.
+      |                                                                ~~~~~
+  212 | 
+  213 |     expect<OneConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+  214 |     expect<OneConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail: Expected 1 arguments, but got 2.
+
+        at ./__typetests__/parameter-arity.tst.ts:211:64 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Expected 1 arguments, but got 2.
+
+  212 | 
+  213 |     expect<OneConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+  214 |     expect<OneConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail: Expected 1 arguments, but got 2.
+      |                                                         ~~~~~~~~~~~~~~~~~
+  215 | 
+  216 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith("one", "two");
+  217 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
+
+        at ./__typetests__/parameter-arity.tst.ts:214:57 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Expected 0-1 arguments, but got 2.
+
+  215 | 
+  216 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith("one", "two");
+  217 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith("one", "two"); // fail: Expected 0-1 arguments, but got 2.
+      |                                                                          ~~~~~
+  218 | 
+  219 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+  220 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
+
+        at ./__typetests__/parameter-arity.tst.ts:217:74 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Expected 0-1 arguments, but got 2.
+
+  218 | 
+  219 |     expect<OptionalFirstConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+  220 |     expect<OptionalFirstConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail: Expected 0-1 arguments, but got 2.
+      |                                                                   ~~~~~~~~~~~~~~~~~
+  221 | 
+  222 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", 123, true);
+  223 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
+
+        at ./__typetests__/parameter-arity.tst.ts:220:67 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Expected 1-2 arguments, but got 3.
+
+  221 | 
+  222 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith("one", 123, true);
+  223 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith("one", 123, true); // fail: Expected 1-2 arguments, but got 3.
+      |                                                                                ~~~~
+  224 | 
+  225 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", 123, true]);
+  226 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
+
+        at ./__typetests__/parameter-arity.tst.ts:223:80 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Expected 1-2 arguments, but got 3.
+
+  224 | 
+  225 |     expect<OptionalSecondConstructor>().type.not.toBeConstructableWith(...["one", 123, true]);
+  226 |     expect<OptionalSecondConstructor>().type.toBeConstructableWith(...["one", 123, true]); // fail: Expected 1-2 arguments, but got 3.
+      |                                                                    ~~~~~~~~~~~~~~~~~~~~~
+  227 |   });
+  228 | });
+  229 | 
+
+        at ./__typetests__/parameter-arity.tst.ts:226:68 ❭ when source is a type ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-parameter-arity-stdout.snap.txt
@@ -3,7 +3,14 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/parameter-arity.tst.ts
-  when target is an expression
+  when source is an expression
+    × is constructable without arguments
+    × is not constructable without arguments
+    × is constructable with the given argument
+    × is not constructable with the given argument
+    × is constructable with the given arguments
+    × is not constructable with the given arguments
+  when source is a type
     × is constructable without arguments
     × is not constructable without arguments
     × is constructable with the given argument
@@ -13,6 +20,6 @@ fail ./__typetests__/parameter-arity.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      6 failed, 6 total
-Assertions: 32 failed, 32 passed, 64 total
+Tests:      12 failed, 12 total
+Assertions: 51 failed, 51 passed, 102 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stderr.snap.txt
@@ -8,7 +8,7 @@ Error: Expression is constructable with the given argument.
   38 |     expect(Leading).type.toBeConstructableWith(false);
   39 |     expect(Leading).type.not.toBeConstructableWith(false); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:36:31 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/rest-parameters.tst.ts:36:31 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -20,7 +20,7 @@ Error: Expression is constructable with the given argument.
   41 |     expect(Trailing).type.toBeConstructableWith(true);
   42 |     expect(Trailing).type.not.toBeConstructableWith(true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:39:30 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/rest-parameters.tst.ts:39:30 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given argument.
 
@@ -32,7 +32,7 @@ Error: Expression is constructable with the given argument.
   44 | 
   45 |   test("is constructable with the given arguments", () => {
 
-       at ./__typetests__/rest-parameters.tst.ts:42:31 ❭ when target is an expression ❭ is constructable with the given argument
+       at ./__typetests__/rest-parameters.tst.ts:42:31 ❭ when source is an expression ❭ is constructable with the given argument
 
 Error: Expression is constructable with the given arguments.
 
@@ -44,7 +44,7 @@ Error: Expression is constructable with the given arguments.
   49 |     expect(Leading).type.toBeConstructableWith("one", "two", true);
   50 |     expect(Leading).type.not.toBeConstructableWith("one", "two", true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:47:31 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:47:31 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -56,7 +56,7 @@ Error: Expression is constructable with the given arguments.
   52 |     expect(Leading).type.toBeConstructableWith(...["one", "two"], true);
   53 |     expect(Leading).type.not.toBeConstructableWith(...["one", "two"], true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:50:30 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:50:30 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -68,7 +68,7 @@ Error: Expression is constructable with the given arguments.
   55 |     expect(Middle).type.toBeConstructableWith("one", 123, 456, true);
   56 |     expect(Middle).type.not.toBeConstructableWith("one", 123, 456, true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:53:30 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:53:30 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -80,7 +80,7 @@ Error: Expression is constructable with the given arguments.
   58 |     expect(Middle).type.toBeConstructableWith(...["one", 123, 456, true]);
   59 |     expect(Middle).type.not.toBeConstructableWith(...["one", 123, 456, true]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:56:29 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:56:29 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -92,7 +92,7 @@ Error: Expression is constructable with the given arguments.
   61 |     expect(Trailing).type.toBeConstructableWith(false, "ten", "eleven");
   62 |     expect(Trailing).type.not.toBeConstructableWith(false, "ten", "eleven"); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:59:29 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:59:29 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -104,7 +104,7 @@ Error: Expression is constructable with the given arguments.
   64 |     expect(Trailing).type.toBeConstructableWith(false, ...["ten", "eleven"]);
   65 |     expect(Trailing).type.not.toBeConstructableWith(false, ...["ten", "eleven"]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:62:31 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:62:31 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable with the given arguments.
 
@@ -116,7 +116,7 @@ Error: Expression is constructable with the given arguments.
   67 | 
   68 |   test("is constructable without arguments", () => {
 
-       at ./__typetests__/rest-parameters.tst.ts:65:31 ❭ when target is an expression ❭ is constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:65:31 ❭ when source is an expression ❭ is constructable with the given arguments
 
 Error: Expression is constructable without arguments.
 
@@ -128,7 +128,7 @@ Error: Expression is constructable without arguments.
   72 | 
   73 |   test("is not constructable without arguments", () => {
 
-       at ./__typetests__/rest-parameters.tst.ts:70:31 ❭ when target is an expression ❭ is constructable without arguments
+       at ./__typetests__/rest-parameters.tst.ts:70:31 ❭ when source is an expression ❭ is constructable without arguments
 
 Error: Expression is not constructable without arguments.
 
@@ -143,7 +143,7 @@ Source has 0 element(s) but target requires 1.
   77 |     expect(Middle).type.not.toBeConstructableWith();
   78 |     expect(Middle).type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
 
-       at ./__typetests__/rest-parameters.tst.ts:75:26 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/rest-parameters.tst.ts:75:26 ❭ when source is an expression ❭ is not constructable without arguments
 
 Error: Expression is not constructable without arguments.
 
@@ -157,7 +157,7 @@ Expected at least 1 arguments, but got 0.
   80 |     expect(Trailing).type.not.toBeConstructableWith();
   81 |     expect(Trailing).type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
 
-       at ./__typetests__/rest-parameters.tst.ts:78:25 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/rest-parameters.tst.ts:78:25 ❭ when source is an expression ❭ is not constructable without arguments
 
     Arguments for the rest parameter 'args' were not provided. ts(6236)
 
@@ -183,7 +183,7 @@ Expected at least 1 arguments, but got 0.
   83 | 
   84 |   test("is not constructable with the given arguments", () => {
 
-       at ./__typetests__/rest-parameters.tst.ts:81:27 ❭ when target is an expression ❭ is not constructable without arguments
+       at ./__typetests__/rest-parameters.tst.ts:81:27 ❭ when source is an expression ❭ is not constructable without arguments
 
     An argument for 'x' was not provided. ts(6210)
 
@@ -211,7 +211,7 @@ Type 'string' is not assignable to type 'boolean'.
   88 |     expect(Leading).type.not.toBeConstructableWith(...["one", "two"]);
   89 |     expect(Leading).type.toBeConstructableWith(...["one", "two"]); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:86:48 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:86:48 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -227,7 +227,7 @@ Type 'string' is not assignable to type 'boolean'.
   91 |     expect(Leading).type.not.toBeConstructableWith(3, 4, true);
   92 |     expect(Leading).type.toBeConstructableWith(3, 4, true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:89:48 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:89:48 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -243,7 +243,7 @@ Type 'number' is not assignable to type 'string'.
   94 |     expect(Leading).type.not.toBeConstructableWith(...[3, 4], true);
   95 |     expect(Leading).type.toBeConstructableWith(...[3, 4], true); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:92:48 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:92:48 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -259,7 +259,7 @@ Type 'number' is not assignable to type 'string'.
   97 |     expect(Middle).type.not.toBeConstructableWith("one", 2, 3);
   98 |     expect(Middle).type.toBeConstructableWith("one", 2, 3); // fail
 
-       at ./__typetests__/rest-parameters.tst.ts:95:48 ❭ when target is an expression ❭ is not constructable with the given arguments
+       at ./__typetests__/rest-parameters.tst.ts:95:48 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -275,7 +275,7 @@ Type 'number' is not assignable to type 'boolean'.
   100 |     expect(Middle).type.not.toBeConstructableWith(...["one", 2, 3]);
   101 |     expect(Middle).type.toBeConstructableWith(...["one", 2, 3]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:98:54 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:98:54 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -291,7 +291,7 @@ Type 'number' is not assignable to type 'boolean'.
   103 |     expect(Middle).type.not.toBeConstructableWith("one", "two", "three", true);
   104 |     expect(Middle).type.toBeConstructableWith("one", "two", "three", true); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:101:47 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:101:47 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -307,7 +307,7 @@ Type 'string' is not assignable to type 'number'.
   106 |     expect(Middle).type.not.toBeConstructableWith(...["one", "two", "three", true]);
   107 |     expect(Middle).type.toBeConstructableWith(...["one", "two", "three", true]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:104:54 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:104:54 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -323,7 +323,7 @@ Type 'string' is not assignable to type 'number'.
   109 |     expect(Trailing).type.not.toBeConstructableWith("ten", "eleven");
   110 |     expect(Trailing).type.toBeConstructableWith("ten", "eleven"); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:107:47 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:107:47 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -337,7 +337,7 @@ Argument of type 'string' is not assignable to parameter of type 'boolean'.
   112 |     expect(Trailing).type.not.toBeConstructableWith(...["ten", "eleven"]);
   113 |     expect(Trailing).type.toBeConstructableWith(...["ten", "eleven"]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:110:49 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:110:49 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -351,7 +351,7 @@ Argument of type 'string' is not assignable to parameter of type 'boolean'.
   115 |     expect(Trailing).type.not.toBeConstructableWith(false, 10, 11);
   116 |     expect(Trailing).type.toBeConstructableWith(false, 10, 11); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:113:49 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:113:49 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -365,7 +365,7 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   118 |     expect(Trailing).type.not.toBeConstructableWith(false, ...[10, 11]);
   119 |     expect(Trailing).type.toBeConstructableWith(false, ...[10, 11]); // fail
 
-        at ./__typetests__/rest-parameters.tst.ts:116:56 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:116:56 ❭ when source is an expression ❭ is not constructable with the given arguments
 
 Error: Expression is not constructable with the given arguments.
 
@@ -379,5 +379,388 @@ Argument of type 'number' is not assignable to parameter of type 'string'.
   121 | });
   122 | 
 
-        at ./__typetests__/rest-parameters.tst.ts:119:56 ❭ when target is an expression ❭ is not constructable with the given arguments
+        at ./__typetests__/rest-parameters.tst.ts:119:56 ❭ when source is an expression ❭ is not constructable with the given arguments
+
+Error: Type is constructable with the given argument.
+
+  129 |   test("is constructable with the given argument", () => {
+  130 |     expect<OptionalConstructor>().type.toBeConstructableWith("one");
+  131 |     expect<OptionalConstructor>().type.not.toBeConstructableWith("one"); // fail
+      |                                            ~~~~~~~~~~~~~~~~~~~~~
+  132 | 
+  133 |     expect<LeadingConstructor>().type.toBeConstructableWith(false);
+  134 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(false); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:131:44 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given argument.
+
+  132 | 
+  133 |     expect<LeadingConstructor>().type.toBeConstructableWith(false);
+  134 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(false); // fail
+      |                                           ~~~~~~~~~~~~~~~~~~~~~
+  135 | 
+  136 |     expect<TrailingConstructor>().type.toBeConstructableWith(true);
+  137 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:134:43 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given argument.
+
+  135 | 
+  136 |     expect<TrailingConstructor>().type.toBeConstructableWith(true);
+  137 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(true); // fail
+      |                                            ~~~~~~~~~~~~~~~~~~~~~
+  138 |   });
+  139 | 
+  140 |   test("is constructable with the given arguments", () => {
+
+        at ./__typetests__/rest-parameters.tst.ts:137:44 ❭ when source is a type ❭ is constructable with the given argument
+
+Error: Type is constructable with the given arguments.
+
+  140 |   test("is constructable with the given arguments", () => {
+  141 |     expect<OptionalConstructor>().type.toBeConstructableWith("one", 2, true);
+  142 |     expect<OptionalConstructor>().type.not.toBeConstructableWith("one", 2, true); // fail
+      |                                            ~~~~~~~~~~~~~~~~~~~~~
+  143 | 
+  144 |     expect<LeadingConstructor>().type.toBeConstructableWith("one", "two", true);
+  145 |     expect<LeadingConstructor>().type.not.toBeConstructableWith("one", "two", true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:142:44 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  143 | 
+  144 |     expect<LeadingConstructor>().type.toBeConstructableWith("one", "two", true);
+  145 |     expect<LeadingConstructor>().type.not.toBeConstructableWith("one", "two", true); // fail
+      |                                           ~~~~~~~~~~~~~~~~~~~~~
+  146 | 
+  147 |     expect<LeadingConstructor>().type.toBeConstructableWith(...["one", "two"], true);
+  148 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(...["one", "two"], true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:145:43 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  146 | 
+  147 |     expect<LeadingConstructor>().type.toBeConstructableWith(...["one", "two"], true);
+  148 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(...["one", "two"], true); // fail
+      |                                           ~~~~~~~~~~~~~~~~~~~~~
+  149 | 
+  150 |     expect<MiddleConstructor>().type.toBeConstructableWith("one", 123, 456, true);
+  151 |     expect<MiddleConstructor>().type.not.toBeConstructableWith("one", 123, 456, true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:148:43 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  149 | 
+  150 |     expect<MiddleConstructor>().type.toBeConstructableWith("one", 123, 456, true);
+  151 |     expect<MiddleConstructor>().type.not.toBeConstructableWith("one", 123, 456, true); // fail
+      |                                          ~~~~~~~~~~~~~~~~~~~~~
+  152 | 
+  153 |     expect<MiddleConstructor>().type.toBeConstructableWith(...["one", 123, 456, true]);
+  154 |     expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", 123, 456, true]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:151:42 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  152 | 
+  153 |     expect<MiddleConstructor>().type.toBeConstructableWith(...["one", 123, 456, true]);
+  154 |     expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", 123, 456, true]); // fail
+      |                                          ~~~~~~~~~~~~~~~~~~~~~
+  155 | 
+  156 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, "ten", "eleven");
+  157 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, "ten", "eleven"); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:154:42 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  155 | 
+  156 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, "ten", "eleven");
+  157 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, "ten", "eleven"); // fail
+      |                                            ~~~~~~~~~~~~~~~~~~~~~
+  158 | 
+  159 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, ...["ten", "eleven"]);
+  160 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, ...["ten", "eleven"]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:157:44 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable with the given arguments.
+
+  158 | 
+  159 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, ...["ten", "eleven"]);
+  160 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, ...["ten", "eleven"]); // fail
+      |                                            ~~~~~~~~~~~~~~~~~~~~~
+  161 |   });
+  162 | 
+  163 |   test("is constructable without arguments", () => {
+
+        at ./__typetests__/rest-parameters.tst.ts:160:44 ❭ when source is a type ❭ is constructable with the given arguments
+
+Error: Type is constructable without arguments.
+
+  163 |   test("is constructable without arguments", () => {
+  164 |     expect<OptionalConstructor>().type.toBeConstructableWith();
+  165 |     expect<OptionalConstructor>().type.not.toBeConstructableWith(); // fail
+      |                                            ~~~~~~~~~~~~~~~~~~~~~
+  166 |   });
+  167 | 
+  168 |   test("is not constructable without arguments", () => {
+
+        at ./__typetests__/rest-parameters.tst.ts:165:44 ❭ when source is a type ❭ is constructable without arguments
+
+Error: Type is not constructable without arguments.
+
+Argument of type '[]' is not assignable to parameter of type '[...string[], boolean]'.
+Source has 0 element(s) but target requires 1.
+
+  168 |   test("is not constructable without arguments", () => {
+  169 |     expect<LeadingConstructor>().type.not.toBeConstructableWith();
+  170 |     expect<LeadingConstructor>().type.toBeConstructableWith(); // fail: Source has 0 element(s) but target requires 1.
+      |                                       ~~~~~~~~~~~~~~~~~~~~~
+  171 | 
+  172 |     expect<MiddleConstructor>().type.not.toBeConstructableWith();
+  173 |     expect<MiddleConstructor>().type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
+
+        at ./__typetests__/rest-parameters.tst.ts:170:39 ❭ when source is a type ❭ is not constructable without arguments
+
+Error: Type is not constructable without arguments.
+
+Expected at least 1 arguments, but got 0.
+
+  171 | 
+  172 |     expect<MiddleConstructor>().type.not.toBeConstructableWith();
+  173 |     expect<MiddleConstructor>().type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
+      |                                      ~~~~~~~~~~~~~~~~~~~~~
+  174 | 
+  175 |     expect<TrailingConstructor>().type.not.toBeConstructableWith();
+  176 |     expect<TrailingConstructor>().type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
+
+        at ./__typetests__/rest-parameters.tst.ts:173:38 ❭ when source is a type ❭ is not constructable without arguments
+
+    Arguments for the rest parameter 'args' were not provided. ts(6236)
+
+      123 | type OptionalConstructor = new (...args: Array<unknown>) => Optional;
+      124 | type LeadingConstructor = new (...args: [...Array<string>, boolean]) => Leading;
+      125 | type MiddleConstructor = new (...args: [string, ...Array<number>, boolean]) => Middle;
+          |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      126 | type TrailingConstructor = new (x: boolean, ...y: Array<string>) => Trailing;
+      127 | 
+      128 | describe("when source is a type", () => {
+
+            at ./__typetests__/rest-parameters.tst.ts:125:31
+
+Error: Type is not constructable without arguments.
+
+Expected at least 1 arguments, but got 0.
+
+  174 | 
+  175 |     expect<TrailingConstructor>().type.not.toBeConstructableWith();
+  176 |     expect<TrailingConstructor>().type.toBeConstructableWith(); // fail: Expected at least 1 arguments, but got 0.
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  177 |   });
+  178 | 
+  179 |   test("is not constructable with the given arguments", () => {
+
+        at ./__typetests__/rest-parameters.tst.ts:176:40 ❭ when source is a type ❭ is not constructable without arguments
+
+    An argument for 'x' was not provided. ts(6210)
+
+      124 | type LeadingConstructor = new (...args: [...Array<string>, boolean]) => Leading;
+      125 | type MiddleConstructor = new (...args: [string, ...Array<number>, boolean]) => Middle;
+      126 | type TrailingConstructor = new (x: boolean, ...y: Array<string>) => Trailing;
+          |                                 ~~~~~~~~~~
+      127 | 
+      128 | describe("when source is a type", () => {
+      129 |   test("is constructable with the given argument", () => {
+
+            at ./__typetests__/rest-parameters.tst.ts:126:33
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '["one", "two"]' is not assignable to parameter of type '[...string[], boolean]'.
+Type at position 1 in source is not compatible with type at position 1 in target.
+Type 'string' is not assignable to type 'boolean'.
+
+  179 |   test("is not constructable with the given arguments", () => {
+  180 |     expect<LeadingConstructor>().type.not.toBeConstructableWith("one", "two");
+  181 |     expect<LeadingConstructor>().type.toBeConstructableWith("one", "two"); // fail
+      |                                                             ~~~~~~~~~~~~
+  182 | 
+  183 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+  184 |     expect<LeadingConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:181:61 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '[string, string]' is not assignable to parameter of type '[...string[], boolean]'.
+Type at position 1 in source is not compatible with type at position 1 in target.
+Type 'string' is not assignable to type 'boolean'.
+
+  182 | 
+  183 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(...["one", "two"]);
+  184 |     expect<LeadingConstructor>().type.toBeConstructableWith(...["one", "two"]); // fail
+      |                                                             ~~~~~~~~~~~~~~~~~
+  185 | 
+  186 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(3, 4, true);
+  187 |     expect<LeadingConstructor>().type.toBeConstructableWith(3, 4, true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:184:61 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '[3, 4, true]' is not assignable to parameter of type '[...string[], boolean]'.
+Type at positions 0 through 1 in source is not compatible with type at position 0 in target.
+Type 'number' is not assignable to type 'string'.
+
+  185 | 
+  186 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(3, 4, true);
+  187 |     expect<LeadingConstructor>().type.toBeConstructableWith(3, 4, true); // fail
+      |                                                             ~~~~~~~~~~
+  188 | 
+  189 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(...[3, 4], true);
+  190 |     expect<LeadingConstructor>().type.toBeConstructableWith(...[3, 4], true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:187:61 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '[number, number, true]' is not assignable to parameter of type '[...string[], boolean]'.
+Type at positions 0 through 1 in source is not compatible with type at position 0 in target.
+Type 'number' is not assignable to type 'string'.
+
+  188 | 
+  189 |     expect<LeadingConstructor>().type.not.toBeConstructableWith(...[3, 4], true);
+  190 |     expect<LeadingConstructor>().type.toBeConstructableWith(...[3, 4], true); // fail
+      |                                                             ~~~~~~~~~~~~~~~
+  191 | 
+  192 |     expect<MiddleConstructor>().type.not.toBeConstructableWith("one", 2, 3);
+  193 |     expect<MiddleConstructor>().type.toBeConstructableWith("one", 2, 3); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:190:61 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '[2, 3]' is not assignable to parameter of type '[...number[], boolean]'.
+Type at position 1 in source is not compatible with type at position 1 in target.
+Type 'number' is not assignable to type 'boolean'.
+
+  191 | 
+  192 |     expect<MiddleConstructor>().type.not.toBeConstructableWith("one", 2, 3);
+  193 |     expect<MiddleConstructor>().type.toBeConstructableWith("one", 2, 3); // fail
+      |                                                                   ~~~~
+  194 | 
+  195 |     expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", 2, 3]);
+  196 |     expect<MiddleConstructor>().type.toBeConstructableWith(...["one", 2, 3]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:193:67 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '[number, number]' is not assignable to parameter of type '[...number[], boolean]'.
+Type at position 1 in source is not compatible with type at position 1 in target.
+Type 'number' is not assignable to type 'boolean'.
+
+  194 | 
+  195 |     expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", 2, 3]);
+  196 |     expect<MiddleConstructor>().type.toBeConstructableWith(...["one", 2, 3]); // fail
+      |                                                            ~~~~~~~~~~~~~~~~
+  197 | 
+  198 |     expect<MiddleConstructor>().type.not.toBeConstructableWith("one", "two", "three", true);
+  199 |     expect<MiddleConstructor>().type.toBeConstructableWith("one", "two", "three", true); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:196:60 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '["two", "three", true]' is not assignable to parameter of type '[...number[], boolean]'.
+Type at positions 0 through 1 in source is not compatible with type at position 0 in target.
+Type 'string' is not assignable to type 'number'.
+
+  197 | 
+  198 |     expect<MiddleConstructor>().type.not.toBeConstructableWith("one", "two", "three", true);
+  199 |     expect<MiddleConstructor>().type.toBeConstructableWith("one", "two", "three", true); // fail
+      |                                                                   ~~~~~~~~~~~~~~~~~~~~
+  200 | 
+  201 |     expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", "two", "three", true]);
+  202 |     expect<MiddleConstructor>().type.toBeConstructableWith(...["one", "two", "three", true]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:199:67 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type '[string, string, boolean]' is not assignable to parameter of type '[...number[], boolean]'.
+Type at positions 0 through 1 in source is not compatible with type at position 0 in target.
+Type 'string' is not assignable to type 'number'.
+
+  200 | 
+  201 |     expect<MiddleConstructor>().type.not.toBeConstructableWith(...["one", "two", "three", true]);
+  202 |     expect<MiddleConstructor>().type.toBeConstructableWith(...["one", "two", "three", true]); // fail
+      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  203 | 
+  204 |     expect<TrailingConstructor>().type.not.toBeConstructableWith("ten", "eleven");
+  205 |     expect<TrailingConstructor>().type.toBeConstructableWith("ten", "eleven"); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:202:60 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type 'string' is not assignable to parameter of type 'boolean'.
+
+  203 | 
+  204 |     expect<TrailingConstructor>().type.not.toBeConstructableWith("ten", "eleven");
+  205 |     expect<TrailingConstructor>().type.toBeConstructableWith("ten", "eleven"); // fail
+      |                                                              ~~~~~
+  206 | 
+  207 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(...["ten", "eleven"]);
+  208 |     expect<TrailingConstructor>().type.toBeConstructableWith(...["ten", "eleven"]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:205:62 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type 'string' is not assignable to parameter of type 'boolean'.
+
+  206 | 
+  207 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(...["ten", "eleven"]);
+  208 |     expect<TrailingConstructor>().type.toBeConstructableWith(...["ten", "eleven"]); // fail
+      |                                                              ~~~~~~~~~~~~~~~~~~~~
+  209 | 
+  210 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, 10, 11);
+  211 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, 10, 11); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:208:62 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  209 | 
+  210 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, 10, 11);
+  211 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, 10, 11); // fail
+      |                                                                     ~~
+  212 | 
+  213 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, ...[10, 11]);
+  214 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, ...[10, 11]); // fail
+
+        at ./__typetests__/rest-parameters.tst.ts:211:69 ❭ when source is a type ❭ is not constructable with the given arguments
+
+Error: Type is not constructable with the given arguments.
+
+Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  212 | 
+  213 |     expect<TrailingConstructor>().type.not.toBeConstructableWith(false, ...[10, 11]);
+  214 |     expect<TrailingConstructor>().type.toBeConstructableWith(false, ...[10, 11]); // fail
+      |                                                                     ~~~~~~~~~~~
+  215 |   });
+  216 | });
+  217 | 
+
+        at ./__typetests__/rest-parameters.tst.ts:214:69 ❭ when source is a type ❭ is not constructable with the given arguments
 

--- a/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBeConstructableWith-rest-parameters-stdout.snap.txt
@@ -3,7 +3,13 @@
 uses TypeScript <<version>> with ./tsconfig.json
 
 fail ./__typetests__/rest-parameters.tst.ts
-  when target is an expression
+  when source is an expression
+    × is constructable with the given argument
+    × is constructable with the given arguments
+    × is constructable without arguments
+    × is not constructable without arguments
+    × is not constructable with the given arguments
+  when source is a type
     × is constructable with the given argument
     × is constructable with the given arguments
     × is constructable without arguments
@@ -12,6 +18,6 @@ fail ./__typetests__/rest-parameters.tst.ts
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      5 failed, 5 total
-Assertions: 26 failed, 26 passed, 52 total
+Tests:      10 failed, 10 total
+Assertions: 52 failed, 52 passed, 104 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-toBeConstructableWith-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toBeConstructableWith-stderr.snap.txt
@@ -72,6 +72,8 @@ Error: An argument for 'source' must be a constructable expression.
 
 Error: An argument for 'source' must be a constructable expression.
 
+Did you mean to use the '.toBeCallableWith()' matcher?
+
   38 |     expect(null).type.toBeConstructableWith();
   39 | 
   40 |     expect(() => undefined).type.toBeConstructableWith();
@@ -84,6 +86,8 @@ Error: An argument for 'source' must be a constructable expression.
 
 Error: An argument for 'source' must be a constructable expression.
 
+Did you mean to use the '.toBeCallableWith()' matcher?
+
   39 | 
   40 |     expect(() => undefined).type.toBeConstructableWith();
   41 |     expect(() => {}).type.toBeConstructableWith();
@@ -95,6 +99,8 @@ Error: An argument for 'source' must be a constructable expression.
        at ./__typetests__/toBeConstructableWith.tst.ts:41:12
 
 Error: An argument for 'source' must be a constructable expression.
+
+Did you mean to use the '.toBeCallableWith()' matcher?
 
   40 |     expect(() => undefined).type.toBeConstructableWith();
   41 |     expect(() => {}).type.toBeConstructableWith();
@@ -179,28 +185,28 @@ Error: An argument for 'source' cannot be of the 'any' type.
 The 'any' type was rejected because the 'rejectAnyType' option is enabled.
 If this check is necessary, pass 'any' as the type argument explicitly.
 
-  57 | 
-  58 |   test("is rejected type?", () => {
-  59 |     expect("abc" as any).type.toBeConstructableWith();
+  59 | 
+  60 |   test("is rejected type?", () => {
+  61 |     expect("abc" as any).type.toBeConstructableWith();
      |            ~~~~~~~~~~~~
-  60 |     expect("abc" as never).type.toBeConstructableWith();
-  61 |   });
-  62 | });
+  62 |     expect("abc" as never).type.toBeConstructableWith();
+  63 |   });
+  64 | });
 
-       at ./__typetests__/toBeConstructableWith.tst.ts:59:12
+       at ./__typetests__/toBeConstructableWith.tst.ts:61:12
 
 Error: An argument for 'source' cannot be of the 'never' type.
 
 The 'never' type was rejected because the 'rejectNeverType' option is enabled.
 If this check is necessary, pass 'never' as the type argument explicitly.
 
-  58 |   test("is rejected type?", () => {
-  59 |     expect("abc" as any).type.toBeConstructableWith();
-  60 |     expect("abc" as never).type.toBeConstructableWith();
+  60 |   test("is rejected type?", () => {
+  61 |     expect("abc" as any).type.toBeConstructableWith();
+  62 |     expect("abc" as never).type.toBeConstructableWith();
      |            ~~~~~~~~~~~~~~
-  61 |   });
-  62 | });
-  63 | 
+  63 |   });
+  64 | });
+  65 | 
 
-       at ./__typetests__/toBeConstructableWith.tst.ts:60:12
+       at ./__typetests__/toBeConstructableWith.tst.ts:62:12
 

--- a/tests/__snapshots__/validation-toBeConstructableWith-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toBeConstructableWith-stdout.snap.txt
@@ -12,5 +12,5 @@ fail ./__typetests__/toBeConstructableWith.tst.ts
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
 Tests:      3 failed, 1 passed, 4 total
-Assertions: 16 failed, 3 passed, 19 total
+Assertions: 16 failed, 5 passed, 21 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
Partly #592

Currently `.toBeConstructableWith()` can only test inferred types of expressions. This change enables testing of provided types as well:


```ts
import { expect, test } from "tstyche";

type Newable<T extends abstract new (...args: any) => any> = {
  new (...args: ConstructorParameters<T>): InstanceType<T>;
};

declare class Person {
  constructor(name: string, age: number);
}

test("PersonConstructor", () => {
  expect<Newable<typeof Person>>().type.toBeConstructableWith("Alice", 30);

  expect<Newable<typeof Person>>().type.not.toBeConstructableWith("Alice");
});
```