### PR TITLE
refactor!: drop support for TypeScript `4.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types@4.x": {
-        "import": "./build/4.x/index.d.ts",
-        "require": "./build/4.x/index.d.cts"
-      },
       "import": "./build/index.js",
       "require": "./build/index.cjs"
     },
@@ -34,13 +30,6 @@
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
-  "typesVersions": {
-    "4.x": {
-      "build/*": [
-        "./build/4.x/*"
-      ]
-    }
-  },
   "bin": "./build/bin.js",
   "files": [
     "build/**/*"
@@ -82,7 +71,7 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "typescript": ">=4.7"
+    "typescript": ">=5.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/scripts/rollup.ts
+++ b/scripts/rollup.ts
@@ -77,27 +77,6 @@ function tidyDts(): Plugin {
   };
 }
 
-// TODO remove this plugin and 'package.json' entries after dropping support for TypeScript 4.x
-function downlevelDts(): Plugin {
-  return {
-    name: "downlevel-dts",
-
-    async renderChunk(code, chunkInfo) {
-      if (chunkInfo.fileName.startsWith("index")) {
-        const updatedCode = code.replace(
-          / {4}\/\*\*\n {5}\* Checks if the decorator[\s\S]*DecoratorContext\) => void;\n/,
-          "",
-        );
-
-        await fs.mkdir(path.resolve(output.dir, "4.x"), { recursive: true });
-        await fs.writeFile(path.resolve(output.dir, "4.x", chunkInfo.fileName), updatedCode);
-      }
-
-      return null;
-    },
-  };
-}
-
 const config: Array<RollupOptions> = [
   {
     external: [/^node:/],
@@ -112,7 +91,6 @@ const config: Array<RollupOptions> = [
       typescript({ tsconfig }),
       dts({ tsconfig }),
       tidyDts(),
-      downlevelDts(),
     ],
   },
 
@@ -126,7 +104,6 @@ const config: Array<RollupOptions> = [
       // @ts-expect-error TODO: https://github.com/rollup/plugins/issues/1541
       typescript({ tsconfig }),
       dts({ tsconfig }),
-      downlevelDts(),
     ],
   },
 

--- a/source/project/ProjectService.ts
+++ b/source/project/ProjectService.ts
@@ -67,6 +67,7 @@ export class ProjectService {
 
   #getDefaultCompilerOptions() {
     const defaultCompilerOptions: ts.server.protocol.CompilerOptions = {
+      allowImportingTsExtensions: true,
       exactOptionalPropertyTypes: true,
       jsx: this.#compiler.JsxEmit.Preserve,
       module: this.#compiler.ModuleKind.NodeNext,
@@ -74,13 +75,9 @@ export class ProjectService {
       noUncheckedIndexedAccess: true,
       resolveJsonModule: true,
       strict: true,
+      verbatimModuleSyntax: true,
       target: this.#compiler.ScriptTarget.ESNext,
     };
-
-    if (Version.isSatisfiedWith(this.#compiler.version, "5.0")) {
-      defaultCompilerOptions.allowImportingTsExtensions = true;
-      defaultCompilerOptions.verbatimModuleSyntax = true;
-    }
 
     if (Version.isSatisfiedWith(this.#compiler.version, "5.6")) {
       defaultCompilerOptions.noUncheckedSideEffectImports = true;

--- a/source/store/ManifestService.ts
+++ b/source/store/ManifestService.ts
@@ -61,7 +61,7 @@ export class ManifestService {
     const packageMetadata = (await response.json()) as PackageMetadata;
 
     for (const [tag, meta] of Object.entries(packageMetadata.versions)) {
-      if (!tag.includes("-") && Version.isSatisfiedWith(tag, "4.7.2")) {
+      if (!tag.includes("-") && Version.isSatisfiedWith(tag, "5.0.2")) {
         versions.push(tag);
 
         packages[tag] = { integrity: meta.dist.integrity, tarball: meta.dist.tarball };

--- a/source/store/PackageService.ts
+++ b/source/store/PackageService.ts
@@ -32,11 +32,6 @@ export class PackageService {
       const tarReader = new TarReader(stream);
 
       for await (const file of tarReader.extract()) {
-        // TODO remove this check after dropping support for TypeScript 4.8
-        if (!file.name.startsWith("package/")) {
-          continue;
-        }
-
         const filePath = Path.join(targetPath, file.name.replace(/^package\//, ""));
         const directoryPath = Path.dirname(filePath);
 

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -110,50 +110,6 @@ const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 const storeUrl = new URL("./.store/", fixtureUrl);
 
-await test("TypeScript 4.x", async (t) => {
-  t.after(async () => {
-    await clearFixture(fixtureUrl);
-  });
-
-  await writeFixture(fixtureUrl, {
-    ["__typetests__/subtype.test.ts"]: `import { omit, pick } from "tstyche"\n${subtypeTestText}`,
-    ["__typetests__/toAcceptProps.test.tsx"]: toAcceptPropsTestText,
-    ["__typetests__/toBe.test.ts"]: toBeTestText,
-    ["__typetests__/toBeAssignableTo.test.ts"]: toBeAssignableToTestText,
-    ["__typetests__/toBeAssignableFrom.test.ts"]: toBeAssignableFromTestText,
-    ["__typetests__/toHaveProperty.test.ts"]: toHavePropertyTestText,
-    ["__typetests__/toRaiseError.test.ts"]: toRaiseErrorTestText,
-  });
-
-  await spawnTyche(fixtureUrl, ["--update"]);
-
-  const manifestText = await fs.readFile(new URL("./store-manifest.json", storeUrl), { encoding: "utf8" });
-
-  const { resolutions } = /** @type {{ resolutions: Record<string, string> }} */ (JSON.parse(manifestText));
-
-  const versions = Object.entries(resolutions)
-    .filter((resolution) => resolution[0].startsWith("4"))
-    .map((resolution) => resolution[1]);
-
-  const testCases = ["4.7.2", ...versions];
-
-  for (const version of testCases) {
-    await t.test(`uses TypeScript ${version} as the target`, async () => {
-      await spawnTyche(fixtureUrl, ["--fetch", "--target", version]);
-
-      const typescriptModule = new URL(`./typescript@${version}/lib/typescript.js`, storeUrl).toString();
-
-      const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
-        env: { ["TSTYCHE_TYPESCRIPT_MODULE"]: typescriptModule },
-      });
-
-      assert.equal(stderr, "");
-      assert.match(stdout, new RegExp(`uses TypeScript ${version}\n`));
-      assert.equal(exitCode, 0);
-    });
-  }
-});
-
 await test("TypeScript 5.x", async (t) => {
   t.after(async () => {
     await clearFixture(fixtureUrl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,7 +2327,7 @@ __metadata:
     tslib: "npm:2.8.1"
     typescript: "npm:5.9.3"
   peerDependencies:
-    typescript: ">=4.7"
+    typescript: ">=5.0"
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
This PR drops support for TypeScript `4.x`.