### PR TITLE
chore: test against Node.js 25

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.12', '20', '22', '24']
+        node-version: ['20.12', '20', '22', '24', '25']
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Let’s run tests against Node.js 25.