### PR TITLE
feat: compare unions using the structure-based `.toBe()` matcher

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
   "words": [
     "codacy",
     "findup",
+    "Freshable",
     "jsxs",
     "monocart",
     "tsserverlibrary",

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -39,7 +39,7 @@ export class ExpectService {
     this.#typeChecker = typeChecker;
 
     this.toAcceptProps = new ToAcceptProps(compiler, typeChecker);
-    this.toBe = environmentOptions.noPatch ? new ToBe() : new LegacyToBe();
+    this.toBe = environmentOptions.noPatch ? new ToBe(compiler, typeChecker) : new LegacyToBe();
     this.toBeApplicable = new ToBeApplicable(compiler);
     this.toBeAssignableFrom = new ToBeAssignableFrom();
     this.toBeAssignableTo = new ToBeAssignableTo();

--- a/source/expect/ToBe.ts
+++ b/source/expect/ToBe.ts
@@ -1,3 +1,4 @@
+import type ts from "typescript";
 import { Structure } from "#structure";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchWorker } from "./MatchWorker.js";
@@ -5,7 +6,13 @@ import { RelationMatcherBase } from "./RelationMatcherBase.js";
 import type { ArgumentNode, MatchResult } from "./types.js";
 
 export class ToBe extends RelationMatcherBase {
-  #structure = new Structure();
+  #structure: Structure;
+
+  constructor(compiler: typeof ts, typeChecker: ts.TypeChecker) {
+    super();
+
+    this.#structure = new Structure(compiler, typeChecker);
+  }
 
   explainText = ExpectDiagnosticText.isTheSame;
   explainNotText = ExpectDiagnosticText.isNotTheSame;

--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -1,11 +1,64 @@
 import type ts from "typescript";
+import { isFreshLiteralType, isIntersection, isUnion } from "./helpers.js";
 
 export class Structure {
+  #compiler: typeof ts;
+  #typeChecker: ts.TypeChecker;
+
+  constructor(compiler: typeof ts, typeChecker: ts.TypeChecker) {
+    this.#compiler = compiler;
+    this.#typeChecker = typeChecker;
+  }
+
   compare(a: ts.Type, b: ts.Type): boolean {
-    if (a === b) {
-      return true;
+    a = this.#normalize(a);
+    b = this.#normalize(b);
+
+    if (isUnion(a, this.#compiler) && isUnion(b, this.#compiler)) {
+      return this.compareUnions(a, b);
     }
 
-    return false;
+    return a === b;
+  }
+
+  compareProperties(a: ts.Type, b: ts.Type): boolean {
+    const aProperties = this.#typeChecker.getPropertiesOfType(a);
+    const bProperties = this.#typeChecker.getPropertiesOfType(b);
+
+    if (aProperties.length !== bProperties.length) {
+      return false;
+    }
+
+    // TODO compare properties
+
+    return true;
+  }
+
+  compareUnions(a: ts.UnionType, b: ts.UnionType): boolean {
+    if (a.types.length !== b.types.length) {
+      return false;
+    }
+
+    return (
+      a.types.every((aType) => b.types.some((bType) => this.compare(aType, bType))) &&
+      b.types.every((bType) => a.types.some((aType) => this.compare(bType, aType)))
+    );
+  }
+
+  #normalize(type: ts.Type): ts.Type {
+    if (isFreshLiteralType(type, this.#compiler)) {
+      type = type.regularType;
+    }
+
+    if (isUnion(type, this.#compiler) || isIntersection(type, this.#compiler)) {
+      // biome-ignore lint/style/noNonNullAssertion: intersections or unions have at least two members
+      const candidateType = this.#normalize(type.types[0]!);
+
+      if (type.types.every((type) => this.compare(this.#normalize(type), candidateType))) {
+        return candidateType;
+      }
+    }
+
+    return type;
   }
 }

--- a/source/structure/helpers.ts
+++ b/source/structure/helpers.ts
@@ -1,0 +1,17 @@
+import type ts from "typescript";
+
+export function isFreshLiteralType(type: ts.Type, compiler: typeof ts): type is ts.FreshableType {
+  return !!(type.flags & compiler.TypeFlags.Freshable) && (type as ts.LiteralType).freshType === type;
+}
+
+export function isIntersection(type: ts.Type, compiler: typeof ts): type is ts.IntersectionType {
+  return !!(type.flags & compiler.TypeFlags.Intersection);
+}
+
+export function isObjectType(type: ts.Type, compiler: typeof ts): type is ts.ObjectType {
+  return !!(type.flags & compiler.TypeFlags.Object);
+}
+
+export function isUnion(type: ts.Type, compiler: typeof ts): type is ts.UnionType {
+  return !!(type.flags & compiler.TypeFlags.Union);
+}

--- a/tests/__fixtures__/api-toBe/__typetests__/enums.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/enums.tst.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "tstyche";
+
+enum Horizontal {
+  Left = "left",
+  Right = "right",
+}
+
+enum Vertical {
+  Up,
+  Down,
+}
+
+enum Choice {
+  Yes,
+  No,
+}
+
+test("is string enum?", () => {
+  expect<Horizontal.Left>().type.toBe<Horizontal.Left>();
+
+  expect<Horizontal.Left>().type.not.toBe<Horizontal.Right>();
+  expect<Horizontal.Left>().type.not.toBe<"left">();
+  expect<Horizontal.Left>().type.not.toBe<string>();
+});
+
+test("is numeric enum?", () => {
+  expect<Vertical.Up>().type.toBe<Vertical.Up>();
+
+  expect<Vertical.Up>().type.not.toBe<Vertical.Down>();
+  expect<Vertical.Up>().type.not.toBe<0>();
+  expect<Vertical.Up>().type.not.toBe<number>();
+  expect<Vertical.Up>().type.not.toBe<Choice.Yes>();
+});
+
+test("enum literal is the same as the union of its values", () => {
+  expect<Horizontal>().type.toBe<(typeof Horizontal)[keyof typeof Horizontal]>();
+  expect<Horizontal>().type.toBe<Horizontal.Left | Horizontal.Right>();
+  expect<Horizontal.Left | Horizontal.Right>().type.toBe<Horizontal>();
+
+  expect<Vertical>().type.not.toBe<Vertical.Up | 1>();
+  expect<Vertical>().type.not.toBe<Vertical.Up | number>();
+  expect<Vertical>().type.not.toBe<Vertical.Up | Choice.No>();
+  expect<Vertical>().type.not.toBe<Choice.Yes | Choice.No>();
+
+  expect<Vertical.Up | 1>().type.not.toBe<Vertical>();
+  expect<Vertical.Up | number>().type.not.toBe<Vertical>();
+  expect<Vertical.Up | Choice.No>().type.not.toBe<Vertical>();
+  expect<Choice.Yes | Choice.No>().type.not.toBe<Vertical>();
+});

--- a/tests/__fixtures__/api-toBe/__typetests__/structure.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/structure.tst.ts
@@ -29,6 +29,11 @@ const samples = [
 
   "Array<string>",
   "number[]",
+
+  // unions
+
+  "string | number",
+  "string | Array<string>",
 ];
 
 // TODO

--- a/tests/__fixtures__/api-toBe/__typetests__/unions.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/unions.tst.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "tstyche";
+
+// TODO
+// objects, array of objects
+// tuples, array of tuples
+// type references, like 'Promise<string>'
+
+test("edge cases", () => {
+  expect<string | any>().type.toBe<any>();
+  expect<string | unknown>().type.toBe<unknown>();
+  expect<string | never>().type.toBe<string>();
+});
+
+test("is union the same?", () => {
+  expect<string | number>().type.toBe<string | number>();
+  expect<string | Array<string>>().type.toBe<string | Array<string>>();
+
+  expect<string | number>().type.toBe<string | boolean>(); // fail
+  expect<string | Array<string>>().type.toBe<string | Array<number>>(); // fail
+});
+
+test("is union NOT the same?", () => {
+  expect<string | number>().type.not.toBe<string | boolean>();
+  expect<string | Array<string>>().type.not.toBe<string | Array<number>>();
+
+  expect<string | number>().type.not.toBe<string | number>(); // fail
+  expect<string | Array<string>>().type.not.toBe<string | Array<string>>(); // fail
+});

--- a/tests/__snapshots__/api-toBe-enums-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-enums-stdout.snap.txt
@@ -1,0 +1,14 @@
+···· TSTyche <<version>> at <<basePath>>/tests/__fixtures__/api-toBe
+
+uses TypeScript <<version>> with ./tsconfig.json
+
+pass ./__typetests__/enums.tst.ts
+  + is string enum?
+  + is numeric enum?
+  + enum literal is the same as the union of its values
+
+Targets:    1 passed, 1 total
+Test files: 1 passed, 1 total
+Tests:      3 passed, 3 total
+Assertions: 20 passed, 20 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBe-structure-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stderr.snap.txt
@@ -222,7 +222,7 @@ Error: Type 'any' is not the same as type 'false'.
      |                           ~~~~~
   25 |   expect<any>().type.toBe<Array<string>>(); // fail
   26 |   expect<any>().type.toBe<number[]>(); // fail
-  27 | });
+  27 |   expect<any>().type.toBe<string | number>(); // fail
 
        at ./__typetests__/structure.tst.ts:24:27 ❭ is any?
 
@@ -233,8 +233,8 @@ Error: Type 'any' is not the same as type 'string[]'.
   25 |   expect<any>().type.toBe<Array<string>>(); // fail
      |                           ~~~~~~~~~~~~~
   26 |   expect<any>().type.toBe<number[]>(); // fail
-  27 | });
-  28 | 
+  27 |   expect<any>().type.toBe<string | number>(); // fail
+  28 |   expect<any>().type.toBe<string | Array<string>>(); // fail
 
        at ./__typetests__/structure.tst.ts:25:27 ❭ is any?
 
@@ -244,5564 +244,6668 @@ Error: Type 'any' is not the same as type 'number[]'.
   25 |   expect<any>().type.toBe<Array<string>>(); // fail
   26 |   expect<any>().type.toBe<number[]>(); // fail
      |                           ~~~~~~~~
-  27 | });
-  28 | 
-  29 | test("is NOT any?", () => {
+  27 |   expect<any>().type.toBe<string | number>(); // fail
+  28 |   expect<any>().type.toBe<string | Array<string>>(); // fail
+  29 | });
 
        at ./__typetests__/structure.tst.ts:26:27 ❭ is any?
 
+Error: Type 'any' is not the same as type 'string | number'.
+
+  25 |   expect<any>().type.toBe<Array<string>>(); // fail
+  26 |   expect<any>().type.toBe<number[]>(); // fail
+  27 |   expect<any>().type.toBe<string | number>(); // fail
+     |                           ~~~~~~~~~~~~~~~
+  28 |   expect<any>().type.toBe<string | Array<string>>(); // fail
+  29 | });
+  30 | 
+
+       at ./__typetests__/structure.tst.ts:27:27 ❭ is any?
+
+Error: Type 'any' is not the same as type 'string | string[]'.
+
+  26 |   expect<any>().type.toBe<number[]>(); // fail
+  27 |   expect<any>().type.toBe<string | number>(); // fail
+  28 |   expect<any>().type.toBe<string | Array<string>>(); // fail
+     |                           ~~~~~~~~~~~~~~~~~~~~~~
+  29 | });
+  30 | 
+  31 | test("is NOT any?", () => {
+
+       at ./__typetests__/structure.tst.ts:28:27 ❭ is any?
+
 Error: Type 'any' is the same as type 'any'.
 
-  50 |   expect<any>().type.not.toBe<number[]>();
-  51 | 
-  52 |   expect<any>().type.not.toBe<any>(); // fail
+  54 |   expect<any>().type.not.toBe<string | Array<string>>();
+  55 | 
+  56 |   expect<any>().type.not.toBe<any>(); // fail
      |                               ~~~
-  53 | });
-  54 | 
-  55 | test("is unknown?", () => {
+  57 | });
+  58 | 
+  59 | test("is unknown?", () => {
 
-       at ./__typetests__/structure.tst.ts:52:31 ❭ is NOT any?
+       at ./__typetests__/structure.tst.ts:56:31 ❭ is NOT any?
 
 Error: Type 'unknown' is not the same as type 'any'.
 
-  56 |   expect<unknown>().type.toBe<unknown>();
-  57 | 
-  58 |   expect<unknown>().type.toBe<any>(); // fail
+  60 |   expect<unknown>().type.toBe<unknown>();
+  61 | 
+  62 |   expect<unknown>().type.toBe<any>(); // fail
      |                               ~~~
-  59 |   expect<unknown>().type.toBe<string>(); // fail
-  60 |   expect<unknown>().type.toBe<number>(); // fail
-  61 |   expect<unknown>().type.toBe<bigint>(); // fail
-
-       at ./__typetests__/structure.tst.ts:58:31 ❭ is unknown?
-
-Error: Type 'unknown' is not the same as type 'string'.
-
-  57 | 
-  58 |   expect<unknown>().type.toBe<any>(); // fail
-  59 |   expect<unknown>().type.toBe<string>(); // fail
-     |                               ~~~~~~
-  60 |   expect<unknown>().type.toBe<number>(); // fail
-  61 |   expect<unknown>().type.toBe<bigint>(); // fail
-  62 |   expect<unknown>().type.toBe<boolean>(); // fail
-
-       at ./__typetests__/structure.tst.ts:59:31 ❭ is unknown?
-
-Error: Type 'unknown' is not the same as type 'number'.
-
-  58 |   expect<unknown>().type.toBe<any>(); // fail
-  59 |   expect<unknown>().type.toBe<string>(); // fail
-  60 |   expect<unknown>().type.toBe<number>(); // fail
-     |                               ~~~~~~
-  61 |   expect<unknown>().type.toBe<bigint>(); // fail
-  62 |   expect<unknown>().type.toBe<boolean>(); // fail
-  63 |   expect<unknown>().type.toBe<symbol>(); // fail
-
-       at ./__typetests__/structure.tst.ts:60:31 ❭ is unknown?
-
-Error: Type 'unknown' is not the same as type 'bigint'.
-
-  59 |   expect<unknown>().type.toBe<string>(); // fail
-  60 |   expect<unknown>().type.toBe<number>(); // fail
-  61 |   expect<unknown>().type.toBe<bigint>(); // fail
-     |                               ~~~~~~
-  62 |   expect<unknown>().type.toBe<boolean>(); // fail
-  63 |   expect<unknown>().type.toBe<symbol>(); // fail
-  64 |   expect<unknown>().type.toBe<object>(); // fail
-
-       at ./__typetests__/structure.tst.ts:61:31 ❭ is unknown?
-
-Error: Type 'unknown' is not the same as type 'boolean'.
-
-  60 |   expect<unknown>().type.toBe<number>(); // fail
-  61 |   expect<unknown>().type.toBe<bigint>(); // fail
-  62 |   expect<unknown>().type.toBe<boolean>(); // fail
-     |                               ~~~~~~~
-  63 |   expect<unknown>().type.toBe<symbol>(); // fail
-  64 |   expect<unknown>().type.toBe<object>(); // fail
-  65 |   expect<unknown>().type.toBe<void>(); // fail
+  63 |   expect<unknown>().type.toBe<string>(); // fail
+  64 |   expect<unknown>().type.toBe<number>(); // fail
+  65 |   expect<unknown>().type.toBe<bigint>(); // fail
 
        at ./__typetests__/structure.tst.ts:62:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'symbol'.
+Error: Type 'unknown' is not the same as type 'string'.
 
-  61 |   expect<unknown>().type.toBe<bigint>(); // fail
-  62 |   expect<unknown>().type.toBe<boolean>(); // fail
-  63 |   expect<unknown>().type.toBe<symbol>(); // fail
+  61 | 
+  62 |   expect<unknown>().type.toBe<any>(); // fail
+  63 |   expect<unknown>().type.toBe<string>(); // fail
      |                               ~~~~~~
-  64 |   expect<unknown>().type.toBe<object>(); // fail
-  65 |   expect<unknown>().type.toBe<void>(); // fail
-  66 |   expect<unknown>().type.toBe<undefined>(); // fail
+  64 |   expect<unknown>().type.toBe<number>(); // fail
+  65 |   expect<unknown>().type.toBe<bigint>(); // fail
+  66 |   expect<unknown>().type.toBe<boolean>(); // fail
 
        at ./__typetests__/structure.tst.ts:63:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'object'.
+Error: Type 'unknown' is not the same as type 'number'.
 
-  62 |   expect<unknown>().type.toBe<boolean>(); // fail
-  63 |   expect<unknown>().type.toBe<symbol>(); // fail
-  64 |   expect<unknown>().type.toBe<object>(); // fail
+  62 |   expect<unknown>().type.toBe<any>(); // fail
+  63 |   expect<unknown>().type.toBe<string>(); // fail
+  64 |   expect<unknown>().type.toBe<number>(); // fail
      |                               ~~~~~~
-  65 |   expect<unknown>().type.toBe<void>(); // fail
-  66 |   expect<unknown>().type.toBe<undefined>(); // fail
-  67 |   expect<unknown>().type.toBe<null>(); // fail
+  65 |   expect<unknown>().type.toBe<bigint>(); // fail
+  66 |   expect<unknown>().type.toBe<boolean>(); // fail
+  67 |   expect<unknown>().type.toBe<symbol>(); // fail
 
        at ./__typetests__/structure.tst.ts:64:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'void'.
+Error: Type 'unknown' is not the same as type 'bigint'.
 
-  63 |   expect<unknown>().type.toBe<symbol>(); // fail
-  64 |   expect<unknown>().type.toBe<object>(); // fail
-  65 |   expect<unknown>().type.toBe<void>(); // fail
-     |                               ~~~~
-  66 |   expect<unknown>().type.toBe<undefined>(); // fail
-  67 |   expect<unknown>().type.toBe<null>(); // fail
-  68 |   expect<unknown>().type.toBe<never>(); // fail
+  63 |   expect<unknown>().type.toBe<string>(); // fail
+  64 |   expect<unknown>().type.toBe<number>(); // fail
+  65 |   expect<unknown>().type.toBe<bigint>(); // fail
+     |                               ~~~~~~
+  66 |   expect<unknown>().type.toBe<boolean>(); // fail
+  67 |   expect<unknown>().type.toBe<symbol>(); // fail
+  68 |   expect<unknown>().type.toBe<object>(); // fail
 
        at ./__typetests__/structure.tst.ts:65:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'undefined'.
+Error: Type 'unknown' is not the same as type 'boolean'.
 
-  64 |   expect<unknown>().type.toBe<object>(); // fail
-  65 |   expect<unknown>().type.toBe<void>(); // fail
-  66 |   expect<unknown>().type.toBe<undefined>(); // fail
-     |                               ~~~~~~~~~
-  67 |   expect<unknown>().type.toBe<null>(); // fail
-  68 |   expect<unknown>().type.toBe<never>(); // fail
-  69 |   expect<unknown>().type.toBe<'abc'>(); // fail
+  64 |   expect<unknown>().type.toBe<number>(); // fail
+  65 |   expect<unknown>().type.toBe<bigint>(); // fail
+  66 |   expect<unknown>().type.toBe<boolean>(); // fail
+     |                               ~~~~~~~
+  67 |   expect<unknown>().type.toBe<symbol>(); // fail
+  68 |   expect<unknown>().type.toBe<object>(); // fail
+  69 |   expect<unknown>().type.toBe<void>(); // fail
 
        at ./__typetests__/structure.tst.ts:66:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'null'.
+Error: Type 'unknown' is not the same as type 'symbol'.
 
-  65 |   expect<unknown>().type.toBe<void>(); // fail
-  66 |   expect<unknown>().type.toBe<undefined>(); // fail
-  67 |   expect<unknown>().type.toBe<null>(); // fail
-     |                               ~~~~
-  68 |   expect<unknown>().type.toBe<never>(); // fail
-  69 |   expect<unknown>().type.toBe<'abc'>(); // fail
-  70 |   expect<unknown>().type.toBe<'def'>(); // fail
+  65 |   expect<unknown>().type.toBe<bigint>(); // fail
+  66 |   expect<unknown>().type.toBe<boolean>(); // fail
+  67 |   expect<unknown>().type.toBe<symbol>(); // fail
+     |                               ~~~~~~
+  68 |   expect<unknown>().type.toBe<object>(); // fail
+  69 |   expect<unknown>().type.toBe<void>(); // fail
+  70 |   expect<unknown>().type.toBe<undefined>(); // fail
 
        at ./__typetests__/structure.tst.ts:67:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'never'.
+Error: Type 'unknown' is not the same as type 'object'.
 
-  66 |   expect<unknown>().type.toBe<undefined>(); // fail
-  67 |   expect<unknown>().type.toBe<null>(); // fail
-  68 |   expect<unknown>().type.toBe<never>(); // fail
-     |                               ~~~~~
-  69 |   expect<unknown>().type.toBe<'abc'>(); // fail
-  70 |   expect<unknown>().type.toBe<'def'>(); // fail
-  71 |   expect<unknown>().type.toBe<123>(); // fail
+  66 |   expect<unknown>().type.toBe<boolean>(); // fail
+  67 |   expect<unknown>().type.toBe<symbol>(); // fail
+  68 |   expect<unknown>().type.toBe<object>(); // fail
+     |                               ~~~~~~
+  69 |   expect<unknown>().type.toBe<void>(); // fail
+  70 |   expect<unknown>().type.toBe<undefined>(); // fail
+  71 |   expect<unknown>().type.toBe<null>(); // fail
 
        at ./__typetests__/structure.tst.ts:68:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type '"abc"'.
+Error: Type 'unknown' is not the same as type 'void'.
 
-  67 |   expect<unknown>().type.toBe<null>(); // fail
-  68 |   expect<unknown>().type.toBe<never>(); // fail
-  69 |   expect<unknown>().type.toBe<'abc'>(); // fail
-     |                               ~~~~~
-  70 |   expect<unknown>().type.toBe<'def'>(); // fail
-  71 |   expect<unknown>().type.toBe<123>(); // fail
-  72 |   expect<unknown>().type.toBe<456>(); // fail
+  67 |   expect<unknown>().type.toBe<symbol>(); // fail
+  68 |   expect<unknown>().type.toBe<object>(); // fail
+  69 |   expect<unknown>().type.toBe<void>(); // fail
+     |                               ~~~~
+  70 |   expect<unknown>().type.toBe<undefined>(); // fail
+  71 |   expect<unknown>().type.toBe<null>(); // fail
+  72 |   expect<unknown>().type.toBe<never>(); // fail
 
        at ./__typetests__/structure.tst.ts:69:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type '"def"'.
+Error: Type 'unknown' is not the same as type 'undefined'.
 
-  68 |   expect<unknown>().type.toBe<never>(); // fail
-  69 |   expect<unknown>().type.toBe<'abc'>(); // fail
-  70 |   expect<unknown>().type.toBe<'def'>(); // fail
-     |                               ~~~~~
-  71 |   expect<unknown>().type.toBe<123>(); // fail
-  72 |   expect<unknown>().type.toBe<456>(); // fail
-  73 |   expect<unknown>().type.toBe<887n>(); // fail
+  68 |   expect<unknown>().type.toBe<object>(); // fail
+  69 |   expect<unknown>().type.toBe<void>(); // fail
+  70 |   expect<unknown>().type.toBe<undefined>(); // fail
+     |                               ~~~~~~~~~
+  71 |   expect<unknown>().type.toBe<null>(); // fail
+  72 |   expect<unknown>().type.toBe<never>(); // fail
+  73 |   expect<unknown>().type.toBe<'abc'>(); // fail
 
        at ./__typetests__/structure.tst.ts:70:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type '123'.
+Error: Type 'unknown' is not the same as type 'null'.
 
-  69 |   expect<unknown>().type.toBe<'abc'>(); // fail
-  70 |   expect<unknown>().type.toBe<'def'>(); // fail
-  71 |   expect<unknown>().type.toBe<123>(); // fail
-     |                               ~~~
-  72 |   expect<unknown>().type.toBe<456>(); // fail
-  73 |   expect<unknown>().type.toBe<887n>(); // fail
-  74 |   expect<unknown>().type.toBe<998n>(); // fail
+  69 |   expect<unknown>().type.toBe<void>(); // fail
+  70 |   expect<unknown>().type.toBe<undefined>(); // fail
+  71 |   expect<unknown>().type.toBe<null>(); // fail
+     |                               ~~~~
+  72 |   expect<unknown>().type.toBe<never>(); // fail
+  73 |   expect<unknown>().type.toBe<'abc'>(); // fail
+  74 |   expect<unknown>().type.toBe<'def'>(); // fail
 
        at ./__typetests__/structure.tst.ts:71:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type '456'.
+Error: Type 'unknown' is not the same as type 'never'.
 
-  70 |   expect<unknown>().type.toBe<'def'>(); // fail
-  71 |   expect<unknown>().type.toBe<123>(); // fail
-  72 |   expect<unknown>().type.toBe<456>(); // fail
-     |                               ~~~
-  73 |   expect<unknown>().type.toBe<887n>(); // fail
-  74 |   expect<unknown>().type.toBe<998n>(); // fail
-  75 |   expect<unknown>().type.toBe<true>(); // fail
+  70 |   expect<unknown>().type.toBe<undefined>(); // fail
+  71 |   expect<unknown>().type.toBe<null>(); // fail
+  72 |   expect<unknown>().type.toBe<never>(); // fail
+     |                               ~~~~~
+  73 |   expect<unknown>().type.toBe<'abc'>(); // fail
+  74 |   expect<unknown>().type.toBe<'def'>(); // fail
+  75 |   expect<unknown>().type.toBe<123>(); // fail
 
        at ./__typetests__/structure.tst.ts:72:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type '887n'.
+Error: Type 'unknown' is not the same as type '"abc"'.
 
-  71 |   expect<unknown>().type.toBe<123>(); // fail
-  72 |   expect<unknown>().type.toBe<456>(); // fail
-  73 |   expect<unknown>().type.toBe<887n>(); // fail
-     |                               ~~~~
-  74 |   expect<unknown>().type.toBe<998n>(); // fail
-  75 |   expect<unknown>().type.toBe<true>(); // fail
-  76 |   expect<unknown>().type.toBe<false>(); // fail
+  71 |   expect<unknown>().type.toBe<null>(); // fail
+  72 |   expect<unknown>().type.toBe<never>(); // fail
+  73 |   expect<unknown>().type.toBe<'abc'>(); // fail
+     |                               ~~~~~
+  74 |   expect<unknown>().type.toBe<'def'>(); // fail
+  75 |   expect<unknown>().type.toBe<123>(); // fail
+  76 |   expect<unknown>().type.toBe<456>(); // fail
 
        at ./__typetests__/structure.tst.ts:73:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type '998n'.
+Error: Type 'unknown' is not the same as type '"def"'.
 
-  72 |   expect<unknown>().type.toBe<456>(); // fail
-  73 |   expect<unknown>().type.toBe<887n>(); // fail
-  74 |   expect<unknown>().type.toBe<998n>(); // fail
-     |                               ~~~~
-  75 |   expect<unknown>().type.toBe<true>(); // fail
-  76 |   expect<unknown>().type.toBe<false>(); // fail
-  77 |   expect<unknown>().type.toBe<Array<string>>(); // fail
+  72 |   expect<unknown>().type.toBe<never>(); // fail
+  73 |   expect<unknown>().type.toBe<'abc'>(); // fail
+  74 |   expect<unknown>().type.toBe<'def'>(); // fail
+     |                               ~~~~~
+  75 |   expect<unknown>().type.toBe<123>(); // fail
+  76 |   expect<unknown>().type.toBe<456>(); // fail
+  77 |   expect<unknown>().type.toBe<887n>(); // fail
 
        at ./__typetests__/structure.tst.ts:74:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'true'.
+Error: Type 'unknown' is not the same as type '123'.
 
-  73 |   expect<unknown>().type.toBe<887n>(); // fail
-  74 |   expect<unknown>().type.toBe<998n>(); // fail
-  75 |   expect<unknown>().type.toBe<true>(); // fail
-     |                               ~~~~
-  76 |   expect<unknown>().type.toBe<false>(); // fail
-  77 |   expect<unknown>().type.toBe<Array<string>>(); // fail
-  78 |   expect<unknown>().type.toBe<number[]>(); // fail
+  73 |   expect<unknown>().type.toBe<'abc'>(); // fail
+  74 |   expect<unknown>().type.toBe<'def'>(); // fail
+  75 |   expect<unknown>().type.toBe<123>(); // fail
+     |                               ~~~
+  76 |   expect<unknown>().type.toBe<456>(); // fail
+  77 |   expect<unknown>().type.toBe<887n>(); // fail
+  78 |   expect<unknown>().type.toBe<998n>(); // fail
 
        at ./__typetests__/structure.tst.ts:75:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'false'.
+Error: Type 'unknown' is not the same as type '456'.
 
-  74 |   expect<unknown>().type.toBe<998n>(); // fail
-  75 |   expect<unknown>().type.toBe<true>(); // fail
-  76 |   expect<unknown>().type.toBe<false>(); // fail
-     |                               ~~~~~
-  77 |   expect<unknown>().type.toBe<Array<string>>(); // fail
-  78 |   expect<unknown>().type.toBe<number[]>(); // fail
-  79 | });
+  74 |   expect<unknown>().type.toBe<'def'>(); // fail
+  75 |   expect<unknown>().type.toBe<123>(); // fail
+  76 |   expect<unknown>().type.toBe<456>(); // fail
+     |                               ~~~
+  77 |   expect<unknown>().type.toBe<887n>(); // fail
+  78 |   expect<unknown>().type.toBe<998n>(); // fail
+  79 |   expect<unknown>().type.toBe<true>(); // fail
 
        at ./__typetests__/structure.tst.ts:76:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'string[]'.
+Error: Type 'unknown' is not the same as type '887n'.
 
-  75 |   expect<unknown>().type.toBe<true>(); // fail
-  76 |   expect<unknown>().type.toBe<false>(); // fail
-  77 |   expect<unknown>().type.toBe<Array<string>>(); // fail
-     |                               ~~~~~~~~~~~~~
-  78 |   expect<unknown>().type.toBe<number[]>(); // fail
-  79 | });
-  80 | 
+  75 |   expect<unknown>().type.toBe<123>(); // fail
+  76 |   expect<unknown>().type.toBe<456>(); // fail
+  77 |   expect<unknown>().type.toBe<887n>(); // fail
+     |                               ~~~~
+  78 |   expect<unknown>().type.toBe<998n>(); // fail
+  79 |   expect<unknown>().type.toBe<true>(); // fail
+  80 |   expect<unknown>().type.toBe<false>(); // fail
 
        at ./__typetests__/structure.tst.ts:77:31 ❭ is unknown?
 
-Error: Type 'unknown' is not the same as type 'number[]'.
+Error: Type 'unknown' is not the same as type '998n'.
 
-  76 |   expect<unknown>().type.toBe<false>(); // fail
-  77 |   expect<unknown>().type.toBe<Array<string>>(); // fail
-  78 |   expect<unknown>().type.toBe<number[]>(); // fail
-     |                               ~~~~~~~~
-  79 | });
-  80 | 
-  81 | test("is NOT unknown?", () => {
+  76 |   expect<unknown>().type.toBe<456>(); // fail
+  77 |   expect<unknown>().type.toBe<887n>(); // fail
+  78 |   expect<unknown>().type.toBe<998n>(); // fail
+     |                               ~~~~
+  79 |   expect<unknown>().type.toBe<true>(); // fail
+  80 |   expect<unknown>().type.toBe<false>(); // fail
+  81 |   expect<unknown>().type.toBe<Array<string>>(); // fail
 
        at ./__typetests__/structure.tst.ts:78:31 ❭ is unknown?
 
+Error: Type 'unknown' is not the same as type 'true'.
+
+  77 |   expect<unknown>().type.toBe<887n>(); // fail
+  78 |   expect<unknown>().type.toBe<998n>(); // fail
+  79 |   expect<unknown>().type.toBe<true>(); // fail
+     |                               ~~~~
+  80 |   expect<unknown>().type.toBe<false>(); // fail
+  81 |   expect<unknown>().type.toBe<Array<string>>(); // fail
+  82 |   expect<unknown>().type.toBe<number[]>(); // fail
+
+       at ./__typetests__/structure.tst.ts:79:31 ❭ is unknown?
+
+Error: Type 'unknown' is not the same as type 'false'.
+
+  78 |   expect<unknown>().type.toBe<998n>(); // fail
+  79 |   expect<unknown>().type.toBe<true>(); // fail
+  80 |   expect<unknown>().type.toBe<false>(); // fail
+     |                               ~~~~~
+  81 |   expect<unknown>().type.toBe<Array<string>>(); // fail
+  82 |   expect<unknown>().type.toBe<number[]>(); // fail
+  83 |   expect<unknown>().type.toBe<string | number>(); // fail
+
+       at ./__typetests__/structure.tst.ts:80:31 ❭ is unknown?
+
+Error: Type 'unknown' is not the same as type 'string[]'.
+
+  79 |   expect<unknown>().type.toBe<true>(); // fail
+  80 |   expect<unknown>().type.toBe<false>(); // fail
+  81 |   expect<unknown>().type.toBe<Array<string>>(); // fail
+     |                               ~~~~~~~~~~~~~
+  82 |   expect<unknown>().type.toBe<number[]>(); // fail
+  83 |   expect<unknown>().type.toBe<string | number>(); // fail
+  84 |   expect<unknown>().type.toBe<string | Array<string>>(); // fail
+
+       at ./__typetests__/structure.tst.ts:81:31 ❭ is unknown?
+
+Error: Type 'unknown' is not the same as type 'number[]'.
+
+  80 |   expect<unknown>().type.toBe<false>(); // fail
+  81 |   expect<unknown>().type.toBe<Array<string>>(); // fail
+  82 |   expect<unknown>().type.toBe<number[]>(); // fail
+     |                               ~~~~~~~~
+  83 |   expect<unknown>().type.toBe<string | number>(); // fail
+  84 |   expect<unknown>().type.toBe<string | Array<string>>(); // fail
+  85 | });
+
+       at ./__typetests__/structure.tst.ts:82:31 ❭ is unknown?
+
+Error: Type 'unknown' is not the same as type 'string | number'.
+
+  81 |   expect<unknown>().type.toBe<Array<string>>(); // fail
+  82 |   expect<unknown>().type.toBe<number[]>(); // fail
+  83 |   expect<unknown>().type.toBe<string | number>(); // fail
+     |                               ~~~~~~~~~~~~~~~
+  84 |   expect<unknown>().type.toBe<string | Array<string>>(); // fail
+  85 | });
+  86 | 
+
+       at ./__typetests__/structure.tst.ts:83:31 ❭ is unknown?
+
+Error: Type 'unknown' is not the same as type 'string | string[]'.
+
+  82 |   expect<unknown>().type.toBe<number[]>(); // fail
+  83 |   expect<unknown>().type.toBe<string | number>(); // fail
+  84 |   expect<unknown>().type.toBe<string | Array<string>>(); // fail
+     |                               ~~~~~~~~~~~~~~~~~~~~~~
+  85 | });
+  86 | 
+  87 | test("is NOT unknown?", () => {
+
+       at ./__typetests__/structure.tst.ts:84:31 ❭ is unknown?
+
 Error: Type 'unknown' is the same as type 'unknown'.
 
-  102 |   expect<unknown>().type.not.toBe<number[]>();
-  103 | 
-  104 |   expect<unknown>().type.not.toBe<unknown>(); // fail
+  110 |   expect<unknown>().type.not.toBe<string | Array<string>>();
+  111 | 
+  112 |   expect<unknown>().type.not.toBe<unknown>(); // fail
       |                                   ~~~~~~~
-  105 | });
-  106 | 
-  107 | test("is string?", () => {
+  113 | });
+  114 | 
+  115 | test("is string?", () => {
 
-        at ./__typetests__/structure.tst.ts:104:35 ❭ is NOT unknown?
+        at ./__typetests__/structure.tst.ts:112:35 ❭ is NOT unknown?
 
 Error: Type 'string' is not the same as type 'any'.
 
-  108 |   expect<string>().type.toBe<string>();
-  109 | 
-  110 |   expect<string>().type.toBe<any>(); // fail
+  116 |   expect<string>().type.toBe<string>();
+  117 | 
+  118 |   expect<string>().type.toBe<any>(); // fail
       |                              ~~~
-  111 |   expect<string>().type.toBe<unknown>(); // fail
-  112 |   expect<string>().type.toBe<number>(); // fail
-  113 |   expect<string>().type.toBe<bigint>(); // fail
-
-        at ./__typetests__/structure.tst.ts:110:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'unknown'.
-
-  109 | 
-  110 |   expect<string>().type.toBe<any>(); // fail
-  111 |   expect<string>().type.toBe<unknown>(); // fail
-      |                              ~~~~~~~
-  112 |   expect<string>().type.toBe<number>(); // fail
-  113 |   expect<string>().type.toBe<bigint>(); // fail
-  114 |   expect<string>().type.toBe<boolean>(); // fail
-
-        at ./__typetests__/structure.tst.ts:111:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'number'.
-
-  110 |   expect<string>().type.toBe<any>(); // fail
-  111 |   expect<string>().type.toBe<unknown>(); // fail
-  112 |   expect<string>().type.toBe<number>(); // fail
-      |                              ~~~~~~
-  113 |   expect<string>().type.toBe<bigint>(); // fail
-  114 |   expect<string>().type.toBe<boolean>(); // fail
-  115 |   expect<string>().type.toBe<symbol>(); // fail
-
-        at ./__typetests__/structure.tst.ts:112:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'bigint'.
-
-  111 |   expect<string>().type.toBe<unknown>(); // fail
-  112 |   expect<string>().type.toBe<number>(); // fail
-  113 |   expect<string>().type.toBe<bigint>(); // fail
-      |                              ~~~~~~
-  114 |   expect<string>().type.toBe<boolean>(); // fail
-  115 |   expect<string>().type.toBe<symbol>(); // fail
-  116 |   expect<string>().type.toBe<object>(); // fail
-
-        at ./__typetests__/structure.tst.ts:113:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'boolean'.
-
-  112 |   expect<string>().type.toBe<number>(); // fail
-  113 |   expect<string>().type.toBe<bigint>(); // fail
-  114 |   expect<string>().type.toBe<boolean>(); // fail
-      |                              ~~~~~~~
-  115 |   expect<string>().type.toBe<symbol>(); // fail
-  116 |   expect<string>().type.toBe<object>(); // fail
-  117 |   expect<string>().type.toBe<void>(); // fail
-
-        at ./__typetests__/structure.tst.ts:114:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'symbol'.
-
-  113 |   expect<string>().type.toBe<bigint>(); // fail
-  114 |   expect<string>().type.toBe<boolean>(); // fail
-  115 |   expect<string>().type.toBe<symbol>(); // fail
-      |                              ~~~~~~
-  116 |   expect<string>().type.toBe<object>(); // fail
-  117 |   expect<string>().type.toBe<void>(); // fail
-  118 |   expect<string>().type.toBe<undefined>(); // fail
-
-        at ./__typetests__/structure.tst.ts:115:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'object'.
-
-  114 |   expect<string>().type.toBe<boolean>(); // fail
-  115 |   expect<string>().type.toBe<symbol>(); // fail
-  116 |   expect<string>().type.toBe<object>(); // fail
-      |                              ~~~~~~
-  117 |   expect<string>().type.toBe<void>(); // fail
-  118 |   expect<string>().type.toBe<undefined>(); // fail
-  119 |   expect<string>().type.toBe<null>(); // fail
-
-        at ./__typetests__/structure.tst.ts:116:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'void'.
-
-  115 |   expect<string>().type.toBe<symbol>(); // fail
-  116 |   expect<string>().type.toBe<object>(); // fail
-  117 |   expect<string>().type.toBe<void>(); // fail
-      |                              ~~~~
-  118 |   expect<string>().type.toBe<undefined>(); // fail
-  119 |   expect<string>().type.toBe<null>(); // fail
-  120 |   expect<string>().type.toBe<never>(); // fail
-
-        at ./__typetests__/structure.tst.ts:117:30 ❭ is string?
-
-Error: Type 'string' is not the same as type 'undefined'.
-
-  116 |   expect<string>().type.toBe<object>(); // fail
-  117 |   expect<string>().type.toBe<void>(); // fail
-  118 |   expect<string>().type.toBe<undefined>(); // fail
-      |                              ~~~~~~~~~
-  119 |   expect<string>().type.toBe<null>(); // fail
-  120 |   expect<string>().type.toBe<never>(); // fail
-  121 |   expect<string>().type.toBe<'abc'>(); // fail
+  119 |   expect<string>().type.toBe<unknown>(); // fail
+  120 |   expect<string>().type.toBe<number>(); // fail
+  121 |   expect<string>().type.toBe<bigint>(); // fail
 
         at ./__typetests__/structure.tst.ts:118:30 ❭ is string?
 
-Error: Type 'string' is not the same as type 'null'.
+Error: Type 'string' is not the same as type 'unknown'.
 
-  117 |   expect<string>().type.toBe<void>(); // fail
-  118 |   expect<string>().type.toBe<undefined>(); // fail
-  119 |   expect<string>().type.toBe<null>(); // fail
-      |                              ~~~~
-  120 |   expect<string>().type.toBe<never>(); // fail
-  121 |   expect<string>().type.toBe<'abc'>(); // fail
-  122 |   expect<string>().type.toBe<'def'>(); // fail
+  117 | 
+  118 |   expect<string>().type.toBe<any>(); // fail
+  119 |   expect<string>().type.toBe<unknown>(); // fail
+      |                              ~~~~~~~
+  120 |   expect<string>().type.toBe<number>(); // fail
+  121 |   expect<string>().type.toBe<bigint>(); // fail
+  122 |   expect<string>().type.toBe<boolean>(); // fail
 
         at ./__typetests__/structure.tst.ts:119:30 ❭ is string?
 
-Error: Type 'string' is not the same as type 'never'.
+Error: Type 'string' is not the same as type 'number'.
 
-  118 |   expect<string>().type.toBe<undefined>(); // fail
-  119 |   expect<string>().type.toBe<null>(); // fail
-  120 |   expect<string>().type.toBe<never>(); // fail
-      |                              ~~~~~
-  121 |   expect<string>().type.toBe<'abc'>(); // fail
-  122 |   expect<string>().type.toBe<'def'>(); // fail
-  123 |   expect<string>().type.toBe<123>(); // fail
+  118 |   expect<string>().type.toBe<any>(); // fail
+  119 |   expect<string>().type.toBe<unknown>(); // fail
+  120 |   expect<string>().type.toBe<number>(); // fail
+      |                              ~~~~~~
+  121 |   expect<string>().type.toBe<bigint>(); // fail
+  122 |   expect<string>().type.toBe<boolean>(); // fail
+  123 |   expect<string>().type.toBe<symbol>(); // fail
 
         at ./__typetests__/structure.tst.ts:120:30 ❭ is string?
 
-Error: Type 'string' is not the same as type '"abc"'.
+Error: Type 'string' is not the same as type 'bigint'.
 
-  119 |   expect<string>().type.toBe<null>(); // fail
-  120 |   expect<string>().type.toBe<never>(); // fail
-  121 |   expect<string>().type.toBe<'abc'>(); // fail
-      |                              ~~~~~
-  122 |   expect<string>().type.toBe<'def'>(); // fail
-  123 |   expect<string>().type.toBe<123>(); // fail
-  124 |   expect<string>().type.toBe<456>(); // fail
+  119 |   expect<string>().type.toBe<unknown>(); // fail
+  120 |   expect<string>().type.toBe<number>(); // fail
+  121 |   expect<string>().type.toBe<bigint>(); // fail
+      |                              ~~~~~~
+  122 |   expect<string>().type.toBe<boolean>(); // fail
+  123 |   expect<string>().type.toBe<symbol>(); // fail
+  124 |   expect<string>().type.toBe<object>(); // fail
 
         at ./__typetests__/structure.tst.ts:121:30 ❭ is string?
 
-Error: Type 'string' is not the same as type '"def"'.
+Error: Type 'string' is not the same as type 'boolean'.
 
-  120 |   expect<string>().type.toBe<never>(); // fail
-  121 |   expect<string>().type.toBe<'abc'>(); // fail
-  122 |   expect<string>().type.toBe<'def'>(); // fail
-      |                              ~~~~~
-  123 |   expect<string>().type.toBe<123>(); // fail
-  124 |   expect<string>().type.toBe<456>(); // fail
-  125 |   expect<string>().type.toBe<887n>(); // fail
+  120 |   expect<string>().type.toBe<number>(); // fail
+  121 |   expect<string>().type.toBe<bigint>(); // fail
+  122 |   expect<string>().type.toBe<boolean>(); // fail
+      |                              ~~~~~~~
+  123 |   expect<string>().type.toBe<symbol>(); // fail
+  124 |   expect<string>().type.toBe<object>(); // fail
+  125 |   expect<string>().type.toBe<void>(); // fail
 
         at ./__typetests__/structure.tst.ts:122:30 ❭ is string?
 
-Error: Type 'string' is not the same as type '123'.
+Error: Type 'string' is not the same as type 'symbol'.
 
-  121 |   expect<string>().type.toBe<'abc'>(); // fail
-  122 |   expect<string>().type.toBe<'def'>(); // fail
-  123 |   expect<string>().type.toBe<123>(); // fail
-      |                              ~~~
-  124 |   expect<string>().type.toBe<456>(); // fail
-  125 |   expect<string>().type.toBe<887n>(); // fail
-  126 |   expect<string>().type.toBe<998n>(); // fail
+  121 |   expect<string>().type.toBe<bigint>(); // fail
+  122 |   expect<string>().type.toBe<boolean>(); // fail
+  123 |   expect<string>().type.toBe<symbol>(); // fail
+      |                              ~~~~~~
+  124 |   expect<string>().type.toBe<object>(); // fail
+  125 |   expect<string>().type.toBe<void>(); // fail
+  126 |   expect<string>().type.toBe<undefined>(); // fail
 
         at ./__typetests__/structure.tst.ts:123:30 ❭ is string?
 
-Error: Type 'string' is not the same as type '456'.
+Error: Type 'string' is not the same as type 'object'.
 
-  122 |   expect<string>().type.toBe<'def'>(); // fail
-  123 |   expect<string>().type.toBe<123>(); // fail
-  124 |   expect<string>().type.toBe<456>(); // fail
-      |                              ~~~
-  125 |   expect<string>().type.toBe<887n>(); // fail
-  126 |   expect<string>().type.toBe<998n>(); // fail
-  127 |   expect<string>().type.toBe<true>(); // fail
+  122 |   expect<string>().type.toBe<boolean>(); // fail
+  123 |   expect<string>().type.toBe<symbol>(); // fail
+  124 |   expect<string>().type.toBe<object>(); // fail
+      |                              ~~~~~~
+  125 |   expect<string>().type.toBe<void>(); // fail
+  126 |   expect<string>().type.toBe<undefined>(); // fail
+  127 |   expect<string>().type.toBe<null>(); // fail
 
         at ./__typetests__/structure.tst.ts:124:30 ❭ is string?
 
-Error: Type 'string' is not the same as type '887n'.
+Error: Type 'string' is not the same as type 'void'.
 
-  123 |   expect<string>().type.toBe<123>(); // fail
-  124 |   expect<string>().type.toBe<456>(); // fail
-  125 |   expect<string>().type.toBe<887n>(); // fail
+  123 |   expect<string>().type.toBe<symbol>(); // fail
+  124 |   expect<string>().type.toBe<object>(); // fail
+  125 |   expect<string>().type.toBe<void>(); // fail
       |                              ~~~~
-  126 |   expect<string>().type.toBe<998n>(); // fail
-  127 |   expect<string>().type.toBe<true>(); // fail
-  128 |   expect<string>().type.toBe<false>(); // fail
+  126 |   expect<string>().type.toBe<undefined>(); // fail
+  127 |   expect<string>().type.toBe<null>(); // fail
+  128 |   expect<string>().type.toBe<never>(); // fail
 
         at ./__typetests__/structure.tst.ts:125:30 ❭ is string?
 
-Error: Type 'string' is not the same as type '998n'.
+Error: Type 'string' is not the same as type 'undefined'.
 
-  124 |   expect<string>().type.toBe<456>(); // fail
-  125 |   expect<string>().type.toBe<887n>(); // fail
-  126 |   expect<string>().type.toBe<998n>(); // fail
-      |                              ~~~~
-  127 |   expect<string>().type.toBe<true>(); // fail
-  128 |   expect<string>().type.toBe<false>(); // fail
-  129 |   expect<string>().type.toBe<Array<string>>(); // fail
+  124 |   expect<string>().type.toBe<object>(); // fail
+  125 |   expect<string>().type.toBe<void>(); // fail
+  126 |   expect<string>().type.toBe<undefined>(); // fail
+      |                              ~~~~~~~~~
+  127 |   expect<string>().type.toBe<null>(); // fail
+  128 |   expect<string>().type.toBe<never>(); // fail
+  129 |   expect<string>().type.toBe<'abc'>(); // fail
 
         at ./__typetests__/structure.tst.ts:126:30 ❭ is string?
 
-Error: Type 'string' is not the same as type 'true'.
+Error: Type 'string' is not the same as type 'null'.
 
-  125 |   expect<string>().type.toBe<887n>(); // fail
-  126 |   expect<string>().type.toBe<998n>(); // fail
-  127 |   expect<string>().type.toBe<true>(); // fail
+  125 |   expect<string>().type.toBe<void>(); // fail
+  126 |   expect<string>().type.toBe<undefined>(); // fail
+  127 |   expect<string>().type.toBe<null>(); // fail
       |                              ~~~~
-  128 |   expect<string>().type.toBe<false>(); // fail
-  129 |   expect<string>().type.toBe<Array<string>>(); // fail
-  130 |   expect<string>().type.toBe<number[]>(); // fail
+  128 |   expect<string>().type.toBe<never>(); // fail
+  129 |   expect<string>().type.toBe<'abc'>(); // fail
+  130 |   expect<string>().type.toBe<'def'>(); // fail
 
         at ./__typetests__/structure.tst.ts:127:30 ❭ is string?
 
-Error: Type 'string' is not the same as type 'false'.
+Error: Type 'string' is not the same as type 'never'.
 
-  126 |   expect<string>().type.toBe<998n>(); // fail
-  127 |   expect<string>().type.toBe<true>(); // fail
-  128 |   expect<string>().type.toBe<false>(); // fail
+  126 |   expect<string>().type.toBe<undefined>(); // fail
+  127 |   expect<string>().type.toBe<null>(); // fail
+  128 |   expect<string>().type.toBe<never>(); // fail
       |                              ~~~~~
-  129 |   expect<string>().type.toBe<Array<string>>(); // fail
-  130 |   expect<string>().type.toBe<number[]>(); // fail
-  131 | });
+  129 |   expect<string>().type.toBe<'abc'>(); // fail
+  130 |   expect<string>().type.toBe<'def'>(); // fail
+  131 |   expect<string>().type.toBe<123>(); // fail
 
         at ./__typetests__/structure.tst.ts:128:30 ❭ is string?
 
-Error: Type 'string' is not the same as type 'string[]'.
+Error: Type 'string' is not the same as type '"abc"'.
 
-  127 |   expect<string>().type.toBe<true>(); // fail
-  128 |   expect<string>().type.toBe<false>(); // fail
-  129 |   expect<string>().type.toBe<Array<string>>(); // fail
-      |                              ~~~~~~~~~~~~~
-  130 |   expect<string>().type.toBe<number[]>(); // fail
-  131 | });
-  132 | 
+  127 |   expect<string>().type.toBe<null>(); // fail
+  128 |   expect<string>().type.toBe<never>(); // fail
+  129 |   expect<string>().type.toBe<'abc'>(); // fail
+      |                              ~~~~~
+  130 |   expect<string>().type.toBe<'def'>(); // fail
+  131 |   expect<string>().type.toBe<123>(); // fail
+  132 |   expect<string>().type.toBe<456>(); // fail
 
         at ./__typetests__/structure.tst.ts:129:30 ❭ is string?
 
-Error: Type 'string' is not the same as type 'number[]'.
+Error: Type 'string' is not the same as type '"def"'.
 
-  128 |   expect<string>().type.toBe<false>(); // fail
-  129 |   expect<string>().type.toBe<Array<string>>(); // fail
-  130 |   expect<string>().type.toBe<number[]>(); // fail
-      |                              ~~~~~~~~
-  131 | });
-  132 | 
-  133 | test("is NOT string?", () => {
+  128 |   expect<string>().type.toBe<never>(); // fail
+  129 |   expect<string>().type.toBe<'abc'>(); // fail
+  130 |   expect<string>().type.toBe<'def'>(); // fail
+      |                              ~~~~~
+  131 |   expect<string>().type.toBe<123>(); // fail
+  132 |   expect<string>().type.toBe<456>(); // fail
+  133 |   expect<string>().type.toBe<887n>(); // fail
 
         at ./__typetests__/structure.tst.ts:130:30 ❭ is string?
 
+Error: Type 'string' is not the same as type '123'.
+
+  129 |   expect<string>().type.toBe<'abc'>(); // fail
+  130 |   expect<string>().type.toBe<'def'>(); // fail
+  131 |   expect<string>().type.toBe<123>(); // fail
+      |                              ~~~
+  132 |   expect<string>().type.toBe<456>(); // fail
+  133 |   expect<string>().type.toBe<887n>(); // fail
+  134 |   expect<string>().type.toBe<998n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:131:30 ❭ is string?
+
+Error: Type 'string' is not the same as type '456'.
+
+  130 |   expect<string>().type.toBe<'def'>(); // fail
+  131 |   expect<string>().type.toBe<123>(); // fail
+  132 |   expect<string>().type.toBe<456>(); // fail
+      |                              ~~~
+  133 |   expect<string>().type.toBe<887n>(); // fail
+  134 |   expect<string>().type.toBe<998n>(); // fail
+  135 |   expect<string>().type.toBe<true>(); // fail
+
+        at ./__typetests__/structure.tst.ts:132:30 ❭ is string?
+
+Error: Type 'string' is not the same as type '887n'.
+
+  131 |   expect<string>().type.toBe<123>(); // fail
+  132 |   expect<string>().type.toBe<456>(); // fail
+  133 |   expect<string>().type.toBe<887n>(); // fail
+      |                              ~~~~
+  134 |   expect<string>().type.toBe<998n>(); // fail
+  135 |   expect<string>().type.toBe<true>(); // fail
+  136 |   expect<string>().type.toBe<false>(); // fail
+
+        at ./__typetests__/structure.tst.ts:133:30 ❭ is string?
+
+Error: Type 'string' is not the same as type '998n'.
+
+  132 |   expect<string>().type.toBe<456>(); // fail
+  133 |   expect<string>().type.toBe<887n>(); // fail
+  134 |   expect<string>().type.toBe<998n>(); // fail
+      |                              ~~~~
+  135 |   expect<string>().type.toBe<true>(); // fail
+  136 |   expect<string>().type.toBe<false>(); // fail
+  137 |   expect<string>().type.toBe<Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:134:30 ❭ is string?
+
+Error: Type 'string' is not the same as type 'true'.
+
+  133 |   expect<string>().type.toBe<887n>(); // fail
+  134 |   expect<string>().type.toBe<998n>(); // fail
+  135 |   expect<string>().type.toBe<true>(); // fail
+      |                              ~~~~
+  136 |   expect<string>().type.toBe<false>(); // fail
+  137 |   expect<string>().type.toBe<Array<string>>(); // fail
+  138 |   expect<string>().type.toBe<number[]>(); // fail
+
+        at ./__typetests__/structure.tst.ts:135:30 ❭ is string?
+
+Error: Type 'string' is not the same as type 'false'.
+
+  134 |   expect<string>().type.toBe<998n>(); // fail
+  135 |   expect<string>().type.toBe<true>(); // fail
+  136 |   expect<string>().type.toBe<false>(); // fail
+      |                              ~~~~~
+  137 |   expect<string>().type.toBe<Array<string>>(); // fail
+  138 |   expect<string>().type.toBe<number[]>(); // fail
+  139 |   expect<string>().type.toBe<string | number>(); // fail
+
+        at ./__typetests__/structure.tst.ts:136:30 ❭ is string?
+
+Error: Type 'string' is not the same as type 'string[]'.
+
+  135 |   expect<string>().type.toBe<true>(); // fail
+  136 |   expect<string>().type.toBe<false>(); // fail
+  137 |   expect<string>().type.toBe<Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~
+  138 |   expect<string>().type.toBe<number[]>(); // fail
+  139 |   expect<string>().type.toBe<string | number>(); // fail
+  140 |   expect<string>().type.toBe<string | Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:137:30 ❭ is string?
+
+Error: Type 'string' is not the same as type 'number[]'.
+
+  136 |   expect<string>().type.toBe<false>(); // fail
+  137 |   expect<string>().type.toBe<Array<string>>(); // fail
+  138 |   expect<string>().type.toBe<number[]>(); // fail
+      |                              ~~~~~~~~
+  139 |   expect<string>().type.toBe<string | number>(); // fail
+  140 |   expect<string>().type.toBe<string | Array<string>>(); // fail
+  141 | });
+
+        at ./__typetests__/structure.tst.ts:138:30 ❭ is string?
+
+Error: Type 'string' is not the same as type 'string | number'.
+
+  137 |   expect<string>().type.toBe<Array<string>>(); // fail
+  138 |   expect<string>().type.toBe<number[]>(); // fail
+  139 |   expect<string>().type.toBe<string | number>(); // fail
+      |                              ~~~~~~~~~~~~~~~
+  140 |   expect<string>().type.toBe<string | Array<string>>(); // fail
+  141 | });
+  142 | 
+
+        at ./__typetests__/structure.tst.ts:139:30 ❭ is string?
+
+Error: Type 'string' is not the same as type 'string | string[]'.
+
+  138 |   expect<string>().type.toBe<number[]>(); // fail
+  139 |   expect<string>().type.toBe<string | number>(); // fail
+  140 |   expect<string>().type.toBe<string | Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~~~~~~~~~~
+  141 | });
+  142 | 
+  143 | test("is NOT string?", () => {
+
+        at ./__typetests__/structure.tst.ts:140:30 ❭ is string?
+
 Error: Type 'string' is the same as type 'string'.
 
-  154 |   expect<string>().type.not.toBe<number[]>();
-  155 | 
-  156 |   expect<string>().type.not.toBe<string>(); // fail
+  166 |   expect<string>().type.not.toBe<string | Array<string>>();
+  167 | 
+  168 |   expect<string>().type.not.toBe<string>(); // fail
       |                                  ~~~~~~
-  157 | });
-  158 | 
-  159 | test("is number?", () => {
+  169 | });
+  170 | 
+  171 | test("is number?", () => {
 
-        at ./__typetests__/structure.tst.ts:156:34 ❭ is NOT string?
+        at ./__typetests__/structure.tst.ts:168:34 ❭ is NOT string?
 
 Error: Type 'number' is not the same as type 'any'.
 
-  160 |   expect<number>().type.toBe<number>();
-  161 | 
-  162 |   expect<number>().type.toBe<any>(); // fail
+  172 |   expect<number>().type.toBe<number>();
+  173 | 
+  174 |   expect<number>().type.toBe<any>(); // fail
       |                              ~~~
-  163 |   expect<number>().type.toBe<unknown>(); // fail
-  164 |   expect<number>().type.toBe<string>(); // fail
-  165 |   expect<number>().type.toBe<bigint>(); // fail
-
-        at ./__typetests__/structure.tst.ts:162:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'unknown'.
-
-  161 | 
-  162 |   expect<number>().type.toBe<any>(); // fail
-  163 |   expect<number>().type.toBe<unknown>(); // fail
-      |                              ~~~~~~~
-  164 |   expect<number>().type.toBe<string>(); // fail
-  165 |   expect<number>().type.toBe<bigint>(); // fail
-  166 |   expect<number>().type.toBe<boolean>(); // fail
-
-        at ./__typetests__/structure.tst.ts:163:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'string'.
-
-  162 |   expect<number>().type.toBe<any>(); // fail
-  163 |   expect<number>().type.toBe<unknown>(); // fail
-  164 |   expect<number>().type.toBe<string>(); // fail
-      |                              ~~~~~~
-  165 |   expect<number>().type.toBe<bigint>(); // fail
-  166 |   expect<number>().type.toBe<boolean>(); // fail
-  167 |   expect<number>().type.toBe<symbol>(); // fail
-
-        at ./__typetests__/structure.tst.ts:164:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'bigint'.
-
-  163 |   expect<number>().type.toBe<unknown>(); // fail
-  164 |   expect<number>().type.toBe<string>(); // fail
-  165 |   expect<number>().type.toBe<bigint>(); // fail
-      |                              ~~~~~~
-  166 |   expect<number>().type.toBe<boolean>(); // fail
-  167 |   expect<number>().type.toBe<symbol>(); // fail
-  168 |   expect<number>().type.toBe<object>(); // fail
-
-        at ./__typetests__/structure.tst.ts:165:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'boolean'.
-
-  164 |   expect<number>().type.toBe<string>(); // fail
-  165 |   expect<number>().type.toBe<bigint>(); // fail
-  166 |   expect<number>().type.toBe<boolean>(); // fail
-      |                              ~~~~~~~
-  167 |   expect<number>().type.toBe<symbol>(); // fail
-  168 |   expect<number>().type.toBe<object>(); // fail
-  169 |   expect<number>().type.toBe<void>(); // fail
-
-        at ./__typetests__/structure.tst.ts:166:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'symbol'.
-
-  165 |   expect<number>().type.toBe<bigint>(); // fail
-  166 |   expect<number>().type.toBe<boolean>(); // fail
-  167 |   expect<number>().type.toBe<symbol>(); // fail
-      |                              ~~~~~~
-  168 |   expect<number>().type.toBe<object>(); // fail
-  169 |   expect<number>().type.toBe<void>(); // fail
-  170 |   expect<number>().type.toBe<undefined>(); // fail
-
-        at ./__typetests__/structure.tst.ts:167:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'object'.
-
-  166 |   expect<number>().type.toBe<boolean>(); // fail
-  167 |   expect<number>().type.toBe<symbol>(); // fail
-  168 |   expect<number>().type.toBe<object>(); // fail
-      |                              ~~~~~~
-  169 |   expect<number>().type.toBe<void>(); // fail
-  170 |   expect<number>().type.toBe<undefined>(); // fail
-  171 |   expect<number>().type.toBe<null>(); // fail
-
-        at ./__typetests__/structure.tst.ts:168:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'void'.
-
-  167 |   expect<number>().type.toBe<symbol>(); // fail
-  168 |   expect<number>().type.toBe<object>(); // fail
-  169 |   expect<number>().type.toBe<void>(); // fail
-      |                              ~~~~
-  170 |   expect<number>().type.toBe<undefined>(); // fail
-  171 |   expect<number>().type.toBe<null>(); // fail
-  172 |   expect<number>().type.toBe<never>(); // fail
-
-        at ./__typetests__/structure.tst.ts:169:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'undefined'.
-
-  168 |   expect<number>().type.toBe<object>(); // fail
-  169 |   expect<number>().type.toBe<void>(); // fail
-  170 |   expect<number>().type.toBe<undefined>(); // fail
-      |                              ~~~~~~~~~
-  171 |   expect<number>().type.toBe<null>(); // fail
-  172 |   expect<number>().type.toBe<never>(); // fail
-  173 |   expect<number>().type.toBe<'abc'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:170:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'null'.
-
-  169 |   expect<number>().type.toBe<void>(); // fail
-  170 |   expect<number>().type.toBe<undefined>(); // fail
-  171 |   expect<number>().type.toBe<null>(); // fail
-      |                              ~~~~
-  172 |   expect<number>().type.toBe<never>(); // fail
-  173 |   expect<number>().type.toBe<'abc'>(); // fail
-  174 |   expect<number>().type.toBe<'def'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:171:30 ❭ is number?
-
-Error: Type 'number' is not the same as type 'never'.
-
-  170 |   expect<number>().type.toBe<undefined>(); // fail
-  171 |   expect<number>().type.toBe<null>(); // fail
-  172 |   expect<number>().type.toBe<never>(); // fail
-      |                              ~~~~~
-  173 |   expect<number>().type.toBe<'abc'>(); // fail
-  174 |   expect<number>().type.toBe<'def'>(); // fail
-  175 |   expect<number>().type.toBe<123>(); // fail
-
-        at ./__typetests__/structure.tst.ts:172:30 ❭ is number?
-
-Error: Type 'number' is not the same as type '"abc"'.
-
-  171 |   expect<number>().type.toBe<null>(); // fail
-  172 |   expect<number>().type.toBe<never>(); // fail
-  173 |   expect<number>().type.toBe<'abc'>(); // fail
-      |                              ~~~~~
-  174 |   expect<number>().type.toBe<'def'>(); // fail
-  175 |   expect<number>().type.toBe<123>(); // fail
-  176 |   expect<number>().type.toBe<456>(); // fail
-
-        at ./__typetests__/structure.tst.ts:173:30 ❭ is number?
-
-Error: Type 'number' is not the same as type '"def"'.
-
-  172 |   expect<number>().type.toBe<never>(); // fail
-  173 |   expect<number>().type.toBe<'abc'>(); // fail
-  174 |   expect<number>().type.toBe<'def'>(); // fail
-      |                              ~~~~~
-  175 |   expect<number>().type.toBe<123>(); // fail
-  176 |   expect<number>().type.toBe<456>(); // fail
-  177 |   expect<number>().type.toBe<887n>(); // fail
+  175 |   expect<number>().type.toBe<unknown>(); // fail
+  176 |   expect<number>().type.toBe<string>(); // fail
+  177 |   expect<number>().type.toBe<bigint>(); // fail
 
         at ./__typetests__/structure.tst.ts:174:30 ❭ is number?
 
-Error: Type 'number' is not the same as type '123'.
+Error: Type 'number' is not the same as type 'unknown'.
 
-  173 |   expect<number>().type.toBe<'abc'>(); // fail
-  174 |   expect<number>().type.toBe<'def'>(); // fail
-  175 |   expect<number>().type.toBe<123>(); // fail
-      |                              ~~~
-  176 |   expect<number>().type.toBe<456>(); // fail
-  177 |   expect<number>().type.toBe<887n>(); // fail
-  178 |   expect<number>().type.toBe<998n>(); // fail
+  173 | 
+  174 |   expect<number>().type.toBe<any>(); // fail
+  175 |   expect<number>().type.toBe<unknown>(); // fail
+      |                              ~~~~~~~
+  176 |   expect<number>().type.toBe<string>(); // fail
+  177 |   expect<number>().type.toBe<bigint>(); // fail
+  178 |   expect<number>().type.toBe<boolean>(); // fail
 
         at ./__typetests__/structure.tst.ts:175:30 ❭ is number?
 
-Error: Type 'number' is not the same as type '456'.
+Error: Type 'number' is not the same as type 'string'.
 
-  174 |   expect<number>().type.toBe<'def'>(); // fail
-  175 |   expect<number>().type.toBe<123>(); // fail
-  176 |   expect<number>().type.toBe<456>(); // fail
-      |                              ~~~
-  177 |   expect<number>().type.toBe<887n>(); // fail
-  178 |   expect<number>().type.toBe<998n>(); // fail
-  179 |   expect<number>().type.toBe<true>(); // fail
+  174 |   expect<number>().type.toBe<any>(); // fail
+  175 |   expect<number>().type.toBe<unknown>(); // fail
+  176 |   expect<number>().type.toBe<string>(); // fail
+      |                              ~~~~~~
+  177 |   expect<number>().type.toBe<bigint>(); // fail
+  178 |   expect<number>().type.toBe<boolean>(); // fail
+  179 |   expect<number>().type.toBe<symbol>(); // fail
 
         at ./__typetests__/structure.tst.ts:176:30 ❭ is number?
 
-Error: Type 'number' is not the same as type '887n'.
+Error: Type 'number' is not the same as type 'bigint'.
 
-  175 |   expect<number>().type.toBe<123>(); // fail
-  176 |   expect<number>().type.toBe<456>(); // fail
-  177 |   expect<number>().type.toBe<887n>(); // fail
-      |                              ~~~~
-  178 |   expect<number>().type.toBe<998n>(); // fail
-  179 |   expect<number>().type.toBe<true>(); // fail
-  180 |   expect<number>().type.toBe<false>(); // fail
+  175 |   expect<number>().type.toBe<unknown>(); // fail
+  176 |   expect<number>().type.toBe<string>(); // fail
+  177 |   expect<number>().type.toBe<bigint>(); // fail
+      |                              ~~~~~~
+  178 |   expect<number>().type.toBe<boolean>(); // fail
+  179 |   expect<number>().type.toBe<symbol>(); // fail
+  180 |   expect<number>().type.toBe<object>(); // fail
 
         at ./__typetests__/structure.tst.ts:177:30 ❭ is number?
 
-Error: Type 'number' is not the same as type '998n'.
+Error: Type 'number' is not the same as type 'boolean'.
 
-  176 |   expect<number>().type.toBe<456>(); // fail
-  177 |   expect<number>().type.toBe<887n>(); // fail
-  178 |   expect<number>().type.toBe<998n>(); // fail
-      |                              ~~~~
-  179 |   expect<number>().type.toBe<true>(); // fail
-  180 |   expect<number>().type.toBe<false>(); // fail
-  181 |   expect<number>().type.toBe<Array<string>>(); // fail
+  176 |   expect<number>().type.toBe<string>(); // fail
+  177 |   expect<number>().type.toBe<bigint>(); // fail
+  178 |   expect<number>().type.toBe<boolean>(); // fail
+      |                              ~~~~~~~
+  179 |   expect<number>().type.toBe<symbol>(); // fail
+  180 |   expect<number>().type.toBe<object>(); // fail
+  181 |   expect<number>().type.toBe<void>(); // fail
 
         at ./__typetests__/structure.tst.ts:178:30 ❭ is number?
 
-Error: Type 'number' is not the same as type 'true'.
+Error: Type 'number' is not the same as type 'symbol'.
 
-  177 |   expect<number>().type.toBe<887n>(); // fail
-  178 |   expect<number>().type.toBe<998n>(); // fail
-  179 |   expect<number>().type.toBe<true>(); // fail
-      |                              ~~~~
-  180 |   expect<number>().type.toBe<false>(); // fail
-  181 |   expect<number>().type.toBe<Array<string>>(); // fail
-  182 |   expect<number>().type.toBe<number[]>(); // fail
+  177 |   expect<number>().type.toBe<bigint>(); // fail
+  178 |   expect<number>().type.toBe<boolean>(); // fail
+  179 |   expect<number>().type.toBe<symbol>(); // fail
+      |                              ~~~~~~
+  180 |   expect<number>().type.toBe<object>(); // fail
+  181 |   expect<number>().type.toBe<void>(); // fail
+  182 |   expect<number>().type.toBe<undefined>(); // fail
 
         at ./__typetests__/structure.tst.ts:179:30 ❭ is number?
 
-Error: Type 'number' is not the same as type 'false'.
+Error: Type 'number' is not the same as type 'object'.
 
-  178 |   expect<number>().type.toBe<998n>(); // fail
-  179 |   expect<number>().type.toBe<true>(); // fail
-  180 |   expect<number>().type.toBe<false>(); // fail
-      |                              ~~~~~
-  181 |   expect<number>().type.toBe<Array<string>>(); // fail
-  182 |   expect<number>().type.toBe<number[]>(); // fail
-  183 | });
+  178 |   expect<number>().type.toBe<boolean>(); // fail
+  179 |   expect<number>().type.toBe<symbol>(); // fail
+  180 |   expect<number>().type.toBe<object>(); // fail
+      |                              ~~~~~~
+  181 |   expect<number>().type.toBe<void>(); // fail
+  182 |   expect<number>().type.toBe<undefined>(); // fail
+  183 |   expect<number>().type.toBe<null>(); // fail
 
         at ./__typetests__/structure.tst.ts:180:30 ❭ is number?
 
-Error: Type 'number' is not the same as type 'string[]'.
+Error: Type 'number' is not the same as type 'void'.
 
-  179 |   expect<number>().type.toBe<true>(); // fail
-  180 |   expect<number>().type.toBe<false>(); // fail
-  181 |   expect<number>().type.toBe<Array<string>>(); // fail
-      |                              ~~~~~~~~~~~~~
-  182 |   expect<number>().type.toBe<number[]>(); // fail
-  183 | });
-  184 | 
+  179 |   expect<number>().type.toBe<symbol>(); // fail
+  180 |   expect<number>().type.toBe<object>(); // fail
+  181 |   expect<number>().type.toBe<void>(); // fail
+      |                              ~~~~
+  182 |   expect<number>().type.toBe<undefined>(); // fail
+  183 |   expect<number>().type.toBe<null>(); // fail
+  184 |   expect<number>().type.toBe<never>(); // fail
 
         at ./__typetests__/structure.tst.ts:181:30 ❭ is number?
 
-Error: Type 'number' is not the same as type 'number[]'.
+Error: Type 'number' is not the same as type 'undefined'.
 
-  180 |   expect<number>().type.toBe<false>(); // fail
-  181 |   expect<number>().type.toBe<Array<string>>(); // fail
-  182 |   expect<number>().type.toBe<number[]>(); // fail
-      |                              ~~~~~~~~
-  183 | });
-  184 | 
-  185 | test("is NOT number?", () => {
+  180 |   expect<number>().type.toBe<object>(); // fail
+  181 |   expect<number>().type.toBe<void>(); // fail
+  182 |   expect<number>().type.toBe<undefined>(); // fail
+      |                              ~~~~~~~~~
+  183 |   expect<number>().type.toBe<null>(); // fail
+  184 |   expect<number>().type.toBe<never>(); // fail
+  185 |   expect<number>().type.toBe<'abc'>(); // fail
 
         at ./__typetests__/structure.tst.ts:182:30 ❭ is number?
 
+Error: Type 'number' is not the same as type 'null'.
+
+  181 |   expect<number>().type.toBe<void>(); // fail
+  182 |   expect<number>().type.toBe<undefined>(); // fail
+  183 |   expect<number>().type.toBe<null>(); // fail
+      |                              ~~~~
+  184 |   expect<number>().type.toBe<never>(); // fail
+  185 |   expect<number>().type.toBe<'abc'>(); // fail
+  186 |   expect<number>().type.toBe<'def'>(); // fail
+
+        at ./__typetests__/structure.tst.ts:183:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'never'.
+
+  182 |   expect<number>().type.toBe<undefined>(); // fail
+  183 |   expect<number>().type.toBe<null>(); // fail
+  184 |   expect<number>().type.toBe<never>(); // fail
+      |                              ~~~~~
+  185 |   expect<number>().type.toBe<'abc'>(); // fail
+  186 |   expect<number>().type.toBe<'def'>(); // fail
+  187 |   expect<number>().type.toBe<123>(); // fail
+
+        at ./__typetests__/structure.tst.ts:184:30 ❭ is number?
+
+Error: Type 'number' is not the same as type '"abc"'.
+
+  183 |   expect<number>().type.toBe<null>(); // fail
+  184 |   expect<number>().type.toBe<never>(); // fail
+  185 |   expect<number>().type.toBe<'abc'>(); // fail
+      |                              ~~~~~
+  186 |   expect<number>().type.toBe<'def'>(); // fail
+  187 |   expect<number>().type.toBe<123>(); // fail
+  188 |   expect<number>().type.toBe<456>(); // fail
+
+        at ./__typetests__/structure.tst.ts:185:30 ❭ is number?
+
+Error: Type 'number' is not the same as type '"def"'.
+
+  184 |   expect<number>().type.toBe<never>(); // fail
+  185 |   expect<number>().type.toBe<'abc'>(); // fail
+  186 |   expect<number>().type.toBe<'def'>(); // fail
+      |                              ~~~~~
+  187 |   expect<number>().type.toBe<123>(); // fail
+  188 |   expect<number>().type.toBe<456>(); // fail
+  189 |   expect<number>().type.toBe<887n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:186:30 ❭ is number?
+
+Error: Type 'number' is not the same as type '123'.
+
+  185 |   expect<number>().type.toBe<'abc'>(); // fail
+  186 |   expect<number>().type.toBe<'def'>(); // fail
+  187 |   expect<number>().type.toBe<123>(); // fail
+      |                              ~~~
+  188 |   expect<number>().type.toBe<456>(); // fail
+  189 |   expect<number>().type.toBe<887n>(); // fail
+  190 |   expect<number>().type.toBe<998n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:187:30 ❭ is number?
+
+Error: Type 'number' is not the same as type '456'.
+
+  186 |   expect<number>().type.toBe<'def'>(); // fail
+  187 |   expect<number>().type.toBe<123>(); // fail
+  188 |   expect<number>().type.toBe<456>(); // fail
+      |                              ~~~
+  189 |   expect<number>().type.toBe<887n>(); // fail
+  190 |   expect<number>().type.toBe<998n>(); // fail
+  191 |   expect<number>().type.toBe<true>(); // fail
+
+        at ./__typetests__/structure.tst.ts:188:30 ❭ is number?
+
+Error: Type 'number' is not the same as type '887n'.
+
+  187 |   expect<number>().type.toBe<123>(); // fail
+  188 |   expect<number>().type.toBe<456>(); // fail
+  189 |   expect<number>().type.toBe<887n>(); // fail
+      |                              ~~~~
+  190 |   expect<number>().type.toBe<998n>(); // fail
+  191 |   expect<number>().type.toBe<true>(); // fail
+  192 |   expect<number>().type.toBe<false>(); // fail
+
+        at ./__typetests__/structure.tst.ts:189:30 ❭ is number?
+
+Error: Type 'number' is not the same as type '998n'.
+
+  188 |   expect<number>().type.toBe<456>(); // fail
+  189 |   expect<number>().type.toBe<887n>(); // fail
+  190 |   expect<number>().type.toBe<998n>(); // fail
+      |                              ~~~~
+  191 |   expect<number>().type.toBe<true>(); // fail
+  192 |   expect<number>().type.toBe<false>(); // fail
+  193 |   expect<number>().type.toBe<Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:190:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'true'.
+
+  189 |   expect<number>().type.toBe<887n>(); // fail
+  190 |   expect<number>().type.toBe<998n>(); // fail
+  191 |   expect<number>().type.toBe<true>(); // fail
+      |                              ~~~~
+  192 |   expect<number>().type.toBe<false>(); // fail
+  193 |   expect<number>().type.toBe<Array<string>>(); // fail
+  194 |   expect<number>().type.toBe<number[]>(); // fail
+
+        at ./__typetests__/structure.tst.ts:191:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'false'.
+
+  190 |   expect<number>().type.toBe<998n>(); // fail
+  191 |   expect<number>().type.toBe<true>(); // fail
+  192 |   expect<number>().type.toBe<false>(); // fail
+      |                              ~~~~~
+  193 |   expect<number>().type.toBe<Array<string>>(); // fail
+  194 |   expect<number>().type.toBe<number[]>(); // fail
+  195 |   expect<number>().type.toBe<string | number>(); // fail
+
+        at ./__typetests__/structure.tst.ts:192:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'string[]'.
+
+  191 |   expect<number>().type.toBe<true>(); // fail
+  192 |   expect<number>().type.toBe<false>(); // fail
+  193 |   expect<number>().type.toBe<Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~
+  194 |   expect<number>().type.toBe<number[]>(); // fail
+  195 |   expect<number>().type.toBe<string | number>(); // fail
+  196 |   expect<number>().type.toBe<string | Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:193:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'number[]'.
+
+  192 |   expect<number>().type.toBe<false>(); // fail
+  193 |   expect<number>().type.toBe<Array<string>>(); // fail
+  194 |   expect<number>().type.toBe<number[]>(); // fail
+      |                              ~~~~~~~~
+  195 |   expect<number>().type.toBe<string | number>(); // fail
+  196 |   expect<number>().type.toBe<string | Array<string>>(); // fail
+  197 | });
+
+        at ./__typetests__/structure.tst.ts:194:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'string | number'.
+
+  193 |   expect<number>().type.toBe<Array<string>>(); // fail
+  194 |   expect<number>().type.toBe<number[]>(); // fail
+  195 |   expect<number>().type.toBe<string | number>(); // fail
+      |                              ~~~~~~~~~~~~~~~
+  196 |   expect<number>().type.toBe<string | Array<string>>(); // fail
+  197 | });
+  198 | 
+
+        at ./__typetests__/structure.tst.ts:195:30 ❭ is number?
+
+Error: Type 'number' is not the same as type 'string | string[]'.
+
+  194 |   expect<number>().type.toBe<number[]>(); // fail
+  195 |   expect<number>().type.toBe<string | number>(); // fail
+  196 |   expect<number>().type.toBe<string | Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~~~~~~~~~~
+  197 | });
+  198 | 
+  199 | test("is NOT number?", () => {
+
+        at ./__typetests__/structure.tst.ts:196:30 ❭ is number?
+
 Error: Type 'number' is the same as type 'number'.
 
-  206 |   expect<number>().type.not.toBe<number[]>();
-  207 | 
-  208 |   expect<number>().type.not.toBe<number>(); // fail
+  222 |   expect<number>().type.not.toBe<string | Array<string>>();
+  223 | 
+  224 |   expect<number>().type.not.toBe<number>(); // fail
       |                                  ~~~~~~
-  209 | });
-  210 | 
-  211 | test("is bigint?", () => {
+  225 | });
+  226 | 
+  227 | test("is bigint?", () => {
 
-        at ./__typetests__/structure.tst.ts:208:34 ❭ is NOT number?
+        at ./__typetests__/structure.tst.ts:224:34 ❭ is NOT number?
 
 Error: Type 'bigint' is not the same as type 'any'.
 
-  212 |   expect<bigint>().type.toBe<bigint>();
-  213 | 
-  214 |   expect<bigint>().type.toBe<any>(); // fail
+  228 |   expect<bigint>().type.toBe<bigint>();
+  229 | 
+  230 |   expect<bigint>().type.toBe<any>(); // fail
       |                              ~~~
-  215 |   expect<bigint>().type.toBe<unknown>(); // fail
-  216 |   expect<bigint>().type.toBe<string>(); // fail
-  217 |   expect<bigint>().type.toBe<number>(); // fail
-
-        at ./__typetests__/structure.tst.ts:214:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'unknown'.
-
-  213 | 
-  214 |   expect<bigint>().type.toBe<any>(); // fail
-  215 |   expect<bigint>().type.toBe<unknown>(); // fail
-      |                              ~~~~~~~
-  216 |   expect<bigint>().type.toBe<string>(); // fail
-  217 |   expect<bigint>().type.toBe<number>(); // fail
-  218 |   expect<bigint>().type.toBe<boolean>(); // fail
-
-        at ./__typetests__/structure.tst.ts:215:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'string'.
-
-  214 |   expect<bigint>().type.toBe<any>(); // fail
-  215 |   expect<bigint>().type.toBe<unknown>(); // fail
-  216 |   expect<bigint>().type.toBe<string>(); // fail
-      |                              ~~~~~~
-  217 |   expect<bigint>().type.toBe<number>(); // fail
-  218 |   expect<bigint>().type.toBe<boolean>(); // fail
-  219 |   expect<bigint>().type.toBe<symbol>(); // fail
-
-        at ./__typetests__/structure.tst.ts:216:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'number'.
-
-  215 |   expect<bigint>().type.toBe<unknown>(); // fail
-  216 |   expect<bigint>().type.toBe<string>(); // fail
-  217 |   expect<bigint>().type.toBe<number>(); // fail
-      |                              ~~~~~~
-  218 |   expect<bigint>().type.toBe<boolean>(); // fail
-  219 |   expect<bigint>().type.toBe<symbol>(); // fail
-  220 |   expect<bigint>().type.toBe<object>(); // fail
-
-        at ./__typetests__/structure.tst.ts:217:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'boolean'.
-
-  216 |   expect<bigint>().type.toBe<string>(); // fail
-  217 |   expect<bigint>().type.toBe<number>(); // fail
-  218 |   expect<bigint>().type.toBe<boolean>(); // fail
-      |                              ~~~~~~~
-  219 |   expect<bigint>().type.toBe<symbol>(); // fail
-  220 |   expect<bigint>().type.toBe<object>(); // fail
-  221 |   expect<bigint>().type.toBe<void>(); // fail
-
-        at ./__typetests__/structure.tst.ts:218:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'symbol'.
-
-  217 |   expect<bigint>().type.toBe<number>(); // fail
-  218 |   expect<bigint>().type.toBe<boolean>(); // fail
-  219 |   expect<bigint>().type.toBe<symbol>(); // fail
-      |                              ~~~~~~
-  220 |   expect<bigint>().type.toBe<object>(); // fail
-  221 |   expect<bigint>().type.toBe<void>(); // fail
-  222 |   expect<bigint>().type.toBe<undefined>(); // fail
-
-        at ./__typetests__/structure.tst.ts:219:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'object'.
-
-  218 |   expect<bigint>().type.toBe<boolean>(); // fail
-  219 |   expect<bigint>().type.toBe<symbol>(); // fail
-  220 |   expect<bigint>().type.toBe<object>(); // fail
-      |                              ~~~~~~
-  221 |   expect<bigint>().type.toBe<void>(); // fail
-  222 |   expect<bigint>().type.toBe<undefined>(); // fail
-  223 |   expect<bigint>().type.toBe<null>(); // fail
-
-        at ./__typetests__/structure.tst.ts:220:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'void'.
-
-  219 |   expect<bigint>().type.toBe<symbol>(); // fail
-  220 |   expect<bigint>().type.toBe<object>(); // fail
-  221 |   expect<bigint>().type.toBe<void>(); // fail
-      |                              ~~~~
-  222 |   expect<bigint>().type.toBe<undefined>(); // fail
-  223 |   expect<bigint>().type.toBe<null>(); // fail
-  224 |   expect<bigint>().type.toBe<never>(); // fail
-
-        at ./__typetests__/structure.tst.ts:221:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'undefined'.
-
-  220 |   expect<bigint>().type.toBe<object>(); // fail
-  221 |   expect<bigint>().type.toBe<void>(); // fail
-  222 |   expect<bigint>().type.toBe<undefined>(); // fail
-      |                              ~~~~~~~~~
-  223 |   expect<bigint>().type.toBe<null>(); // fail
-  224 |   expect<bigint>().type.toBe<never>(); // fail
-  225 |   expect<bigint>().type.toBe<'abc'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:222:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'null'.
-
-  221 |   expect<bigint>().type.toBe<void>(); // fail
-  222 |   expect<bigint>().type.toBe<undefined>(); // fail
-  223 |   expect<bigint>().type.toBe<null>(); // fail
-      |                              ~~~~
-  224 |   expect<bigint>().type.toBe<never>(); // fail
-  225 |   expect<bigint>().type.toBe<'abc'>(); // fail
-  226 |   expect<bigint>().type.toBe<'def'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:223:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type 'never'.
-
-  222 |   expect<bigint>().type.toBe<undefined>(); // fail
-  223 |   expect<bigint>().type.toBe<null>(); // fail
-  224 |   expect<bigint>().type.toBe<never>(); // fail
-      |                              ~~~~~
-  225 |   expect<bigint>().type.toBe<'abc'>(); // fail
-  226 |   expect<bigint>().type.toBe<'def'>(); // fail
-  227 |   expect<bigint>().type.toBe<123>(); // fail
-
-        at ./__typetests__/structure.tst.ts:224:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type '"abc"'.
-
-  223 |   expect<bigint>().type.toBe<null>(); // fail
-  224 |   expect<bigint>().type.toBe<never>(); // fail
-  225 |   expect<bigint>().type.toBe<'abc'>(); // fail
-      |                              ~~~~~
-  226 |   expect<bigint>().type.toBe<'def'>(); // fail
-  227 |   expect<bigint>().type.toBe<123>(); // fail
-  228 |   expect<bigint>().type.toBe<456>(); // fail
-
-        at ./__typetests__/structure.tst.ts:225:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type '"def"'.
-
-  224 |   expect<bigint>().type.toBe<never>(); // fail
-  225 |   expect<bigint>().type.toBe<'abc'>(); // fail
-  226 |   expect<bigint>().type.toBe<'def'>(); // fail
-      |                              ~~~~~
-  227 |   expect<bigint>().type.toBe<123>(); // fail
-  228 |   expect<bigint>().type.toBe<456>(); // fail
-  229 |   expect<bigint>().type.toBe<887n>(); // fail
-
-        at ./__typetests__/structure.tst.ts:226:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type '123'.
-
-  225 |   expect<bigint>().type.toBe<'abc'>(); // fail
-  226 |   expect<bigint>().type.toBe<'def'>(); // fail
-  227 |   expect<bigint>().type.toBe<123>(); // fail
-      |                              ~~~
-  228 |   expect<bigint>().type.toBe<456>(); // fail
-  229 |   expect<bigint>().type.toBe<887n>(); // fail
-  230 |   expect<bigint>().type.toBe<998n>(); // fail
-
-        at ./__typetests__/structure.tst.ts:227:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type '456'.
-
-  226 |   expect<bigint>().type.toBe<'def'>(); // fail
-  227 |   expect<bigint>().type.toBe<123>(); // fail
-  228 |   expect<bigint>().type.toBe<456>(); // fail
-      |                              ~~~
-  229 |   expect<bigint>().type.toBe<887n>(); // fail
-  230 |   expect<bigint>().type.toBe<998n>(); // fail
-  231 |   expect<bigint>().type.toBe<true>(); // fail
-
-        at ./__typetests__/structure.tst.ts:228:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type '887n'.
-
-  227 |   expect<bigint>().type.toBe<123>(); // fail
-  228 |   expect<bigint>().type.toBe<456>(); // fail
-  229 |   expect<bigint>().type.toBe<887n>(); // fail
-      |                              ~~~~
-  230 |   expect<bigint>().type.toBe<998n>(); // fail
-  231 |   expect<bigint>().type.toBe<true>(); // fail
-  232 |   expect<bigint>().type.toBe<false>(); // fail
-
-        at ./__typetests__/structure.tst.ts:229:30 ❭ is bigint?
-
-Error: Type 'bigint' is not the same as type '998n'.
-
-  228 |   expect<bigint>().type.toBe<456>(); // fail
-  229 |   expect<bigint>().type.toBe<887n>(); // fail
-  230 |   expect<bigint>().type.toBe<998n>(); // fail
-      |                              ~~~~
-  231 |   expect<bigint>().type.toBe<true>(); // fail
-  232 |   expect<bigint>().type.toBe<false>(); // fail
-  233 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+  231 |   expect<bigint>().type.toBe<unknown>(); // fail
+  232 |   expect<bigint>().type.toBe<string>(); // fail
+  233 |   expect<bigint>().type.toBe<number>(); // fail
 
         at ./__typetests__/structure.tst.ts:230:30 ❭ is bigint?
 
-Error: Type 'bigint' is not the same as type 'true'.
+Error: Type 'bigint' is not the same as type 'unknown'.
 
-  229 |   expect<bigint>().type.toBe<887n>(); // fail
-  230 |   expect<bigint>().type.toBe<998n>(); // fail
-  231 |   expect<bigint>().type.toBe<true>(); // fail
-      |                              ~~~~
-  232 |   expect<bigint>().type.toBe<false>(); // fail
-  233 |   expect<bigint>().type.toBe<Array<string>>(); // fail
-  234 |   expect<bigint>().type.toBe<number[]>(); // fail
+  229 | 
+  230 |   expect<bigint>().type.toBe<any>(); // fail
+  231 |   expect<bigint>().type.toBe<unknown>(); // fail
+      |                              ~~~~~~~
+  232 |   expect<bigint>().type.toBe<string>(); // fail
+  233 |   expect<bigint>().type.toBe<number>(); // fail
+  234 |   expect<bigint>().type.toBe<boolean>(); // fail
 
         at ./__typetests__/structure.tst.ts:231:30 ❭ is bigint?
 
-Error: Type 'bigint' is not the same as type 'false'.
+Error: Type 'bigint' is not the same as type 'string'.
 
-  230 |   expect<bigint>().type.toBe<998n>(); // fail
-  231 |   expect<bigint>().type.toBe<true>(); // fail
-  232 |   expect<bigint>().type.toBe<false>(); // fail
-      |                              ~~~~~
-  233 |   expect<bigint>().type.toBe<Array<string>>(); // fail
-  234 |   expect<bigint>().type.toBe<number[]>(); // fail
-  235 | });
+  230 |   expect<bigint>().type.toBe<any>(); // fail
+  231 |   expect<bigint>().type.toBe<unknown>(); // fail
+  232 |   expect<bigint>().type.toBe<string>(); // fail
+      |                              ~~~~~~
+  233 |   expect<bigint>().type.toBe<number>(); // fail
+  234 |   expect<bigint>().type.toBe<boolean>(); // fail
+  235 |   expect<bigint>().type.toBe<symbol>(); // fail
 
         at ./__typetests__/structure.tst.ts:232:30 ❭ is bigint?
 
-Error: Type 'bigint' is not the same as type 'string[]'.
+Error: Type 'bigint' is not the same as type 'number'.
 
-  231 |   expect<bigint>().type.toBe<true>(); // fail
-  232 |   expect<bigint>().type.toBe<false>(); // fail
-  233 |   expect<bigint>().type.toBe<Array<string>>(); // fail
-      |                              ~~~~~~~~~~~~~
-  234 |   expect<bigint>().type.toBe<number[]>(); // fail
-  235 | });
-  236 | 
+  231 |   expect<bigint>().type.toBe<unknown>(); // fail
+  232 |   expect<bigint>().type.toBe<string>(); // fail
+  233 |   expect<bigint>().type.toBe<number>(); // fail
+      |                              ~~~~~~
+  234 |   expect<bigint>().type.toBe<boolean>(); // fail
+  235 |   expect<bigint>().type.toBe<symbol>(); // fail
+  236 |   expect<bigint>().type.toBe<object>(); // fail
 
         at ./__typetests__/structure.tst.ts:233:30 ❭ is bigint?
 
-Error: Type 'bigint' is not the same as type 'number[]'.
+Error: Type 'bigint' is not the same as type 'boolean'.
 
-  232 |   expect<bigint>().type.toBe<false>(); // fail
-  233 |   expect<bigint>().type.toBe<Array<string>>(); // fail
-  234 |   expect<bigint>().type.toBe<number[]>(); // fail
-      |                              ~~~~~~~~
-  235 | });
-  236 | 
-  237 | test("is NOT bigint?", () => {
+  232 |   expect<bigint>().type.toBe<string>(); // fail
+  233 |   expect<bigint>().type.toBe<number>(); // fail
+  234 |   expect<bigint>().type.toBe<boolean>(); // fail
+      |                              ~~~~~~~
+  235 |   expect<bigint>().type.toBe<symbol>(); // fail
+  236 |   expect<bigint>().type.toBe<object>(); // fail
+  237 |   expect<bigint>().type.toBe<void>(); // fail
 
         at ./__typetests__/structure.tst.ts:234:30 ❭ is bigint?
 
+Error: Type 'bigint' is not the same as type 'symbol'.
+
+  233 |   expect<bigint>().type.toBe<number>(); // fail
+  234 |   expect<bigint>().type.toBe<boolean>(); // fail
+  235 |   expect<bigint>().type.toBe<symbol>(); // fail
+      |                              ~~~~~~
+  236 |   expect<bigint>().type.toBe<object>(); // fail
+  237 |   expect<bigint>().type.toBe<void>(); // fail
+  238 |   expect<bigint>().type.toBe<undefined>(); // fail
+
+        at ./__typetests__/structure.tst.ts:235:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'object'.
+
+  234 |   expect<bigint>().type.toBe<boolean>(); // fail
+  235 |   expect<bigint>().type.toBe<symbol>(); // fail
+  236 |   expect<bigint>().type.toBe<object>(); // fail
+      |                              ~~~~~~
+  237 |   expect<bigint>().type.toBe<void>(); // fail
+  238 |   expect<bigint>().type.toBe<undefined>(); // fail
+  239 |   expect<bigint>().type.toBe<null>(); // fail
+
+        at ./__typetests__/structure.tst.ts:236:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'void'.
+
+  235 |   expect<bigint>().type.toBe<symbol>(); // fail
+  236 |   expect<bigint>().type.toBe<object>(); // fail
+  237 |   expect<bigint>().type.toBe<void>(); // fail
+      |                              ~~~~
+  238 |   expect<bigint>().type.toBe<undefined>(); // fail
+  239 |   expect<bigint>().type.toBe<null>(); // fail
+  240 |   expect<bigint>().type.toBe<never>(); // fail
+
+        at ./__typetests__/structure.tst.ts:237:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'undefined'.
+
+  236 |   expect<bigint>().type.toBe<object>(); // fail
+  237 |   expect<bigint>().type.toBe<void>(); // fail
+  238 |   expect<bigint>().type.toBe<undefined>(); // fail
+      |                              ~~~~~~~~~
+  239 |   expect<bigint>().type.toBe<null>(); // fail
+  240 |   expect<bigint>().type.toBe<never>(); // fail
+  241 |   expect<bigint>().type.toBe<'abc'>(); // fail
+
+        at ./__typetests__/structure.tst.ts:238:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'null'.
+
+  237 |   expect<bigint>().type.toBe<void>(); // fail
+  238 |   expect<bigint>().type.toBe<undefined>(); // fail
+  239 |   expect<bigint>().type.toBe<null>(); // fail
+      |                              ~~~~
+  240 |   expect<bigint>().type.toBe<never>(); // fail
+  241 |   expect<bigint>().type.toBe<'abc'>(); // fail
+  242 |   expect<bigint>().type.toBe<'def'>(); // fail
+
+        at ./__typetests__/structure.tst.ts:239:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'never'.
+
+  238 |   expect<bigint>().type.toBe<undefined>(); // fail
+  239 |   expect<bigint>().type.toBe<null>(); // fail
+  240 |   expect<bigint>().type.toBe<never>(); // fail
+      |                              ~~~~~
+  241 |   expect<bigint>().type.toBe<'abc'>(); // fail
+  242 |   expect<bigint>().type.toBe<'def'>(); // fail
+  243 |   expect<bigint>().type.toBe<123>(); // fail
+
+        at ./__typetests__/structure.tst.ts:240:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type '"abc"'.
+
+  239 |   expect<bigint>().type.toBe<null>(); // fail
+  240 |   expect<bigint>().type.toBe<never>(); // fail
+  241 |   expect<bigint>().type.toBe<'abc'>(); // fail
+      |                              ~~~~~
+  242 |   expect<bigint>().type.toBe<'def'>(); // fail
+  243 |   expect<bigint>().type.toBe<123>(); // fail
+  244 |   expect<bigint>().type.toBe<456>(); // fail
+
+        at ./__typetests__/structure.tst.ts:241:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type '"def"'.
+
+  240 |   expect<bigint>().type.toBe<never>(); // fail
+  241 |   expect<bigint>().type.toBe<'abc'>(); // fail
+  242 |   expect<bigint>().type.toBe<'def'>(); // fail
+      |                              ~~~~~
+  243 |   expect<bigint>().type.toBe<123>(); // fail
+  244 |   expect<bigint>().type.toBe<456>(); // fail
+  245 |   expect<bigint>().type.toBe<887n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:242:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type '123'.
+
+  241 |   expect<bigint>().type.toBe<'abc'>(); // fail
+  242 |   expect<bigint>().type.toBe<'def'>(); // fail
+  243 |   expect<bigint>().type.toBe<123>(); // fail
+      |                              ~~~
+  244 |   expect<bigint>().type.toBe<456>(); // fail
+  245 |   expect<bigint>().type.toBe<887n>(); // fail
+  246 |   expect<bigint>().type.toBe<998n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:243:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type '456'.
+
+  242 |   expect<bigint>().type.toBe<'def'>(); // fail
+  243 |   expect<bigint>().type.toBe<123>(); // fail
+  244 |   expect<bigint>().type.toBe<456>(); // fail
+      |                              ~~~
+  245 |   expect<bigint>().type.toBe<887n>(); // fail
+  246 |   expect<bigint>().type.toBe<998n>(); // fail
+  247 |   expect<bigint>().type.toBe<true>(); // fail
+
+        at ./__typetests__/structure.tst.ts:244:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type '887n'.
+
+  243 |   expect<bigint>().type.toBe<123>(); // fail
+  244 |   expect<bigint>().type.toBe<456>(); // fail
+  245 |   expect<bigint>().type.toBe<887n>(); // fail
+      |                              ~~~~
+  246 |   expect<bigint>().type.toBe<998n>(); // fail
+  247 |   expect<bigint>().type.toBe<true>(); // fail
+  248 |   expect<bigint>().type.toBe<false>(); // fail
+
+        at ./__typetests__/structure.tst.ts:245:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type '998n'.
+
+  244 |   expect<bigint>().type.toBe<456>(); // fail
+  245 |   expect<bigint>().type.toBe<887n>(); // fail
+  246 |   expect<bigint>().type.toBe<998n>(); // fail
+      |                              ~~~~
+  247 |   expect<bigint>().type.toBe<true>(); // fail
+  248 |   expect<bigint>().type.toBe<false>(); // fail
+  249 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:246:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'true'.
+
+  245 |   expect<bigint>().type.toBe<887n>(); // fail
+  246 |   expect<bigint>().type.toBe<998n>(); // fail
+  247 |   expect<bigint>().type.toBe<true>(); // fail
+      |                              ~~~~
+  248 |   expect<bigint>().type.toBe<false>(); // fail
+  249 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+  250 |   expect<bigint>().type.toBe<number[]>(); // fail
+
+        at ./__typetests__/structure.tst.ts:247:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'false'.
+
+  246 |   expect<bigint>().type.toBe<998n>(); // fail
+  247 |   expect<bigint>().type.toBe<true>(); // fail
+  248 |   expect<bigint>().type.toBe<false>(); // fail
+      |                              ~~~~~
+  249 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+  250 |   expect<bigint>().type.toBe<number[]>(); // fail
+  251 |   expect<bigint>().type.toBe<string | number>(); // fail
+
+        at ./__typetests__/structure.tst.ts:248:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'string[]'.
+
+  247 |   expect<bigint>().type.toBe<true>(); // fail
+  248 |   expect<bigint>().type.toBe<false>(); // fail
+  249 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~
+  250 |   expect<bigint>().type.toBe<number[]>(); // fail
+  251 |   expect<bigint>().type.toBe<string | number>(); // fail
+  252 |   expect<bigint>().type.toBe<string | Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:249:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'number[]'.
+
+  248 |   expect<bigint>().type.toBe<false>(); // fail
+  249 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+  250 |   expect<bigint>().type.toBe<number[]>(); // fail
+      |                              ~~~~~~~~
+  251 |   expect<bigint>().type.toBe<string | number>(); // fail
+  252 |   expect<bigint>().type.toBe<string | Array<string>>(); // fail
+  253 | });
+
+        at ./__typetests__/structure.tst.ts:250:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'string | number'.
+
+  249 |   expect<bigint>().type.toBe<Array<string>>(); // fail
+  250 |   expect<bigint>().type.toBe<number[]>(); // fail
+  251 |   expect<bigint>().type.toBe<string | number>(); // fail
+      |                              ~~~~~~~~~~~~~~~
+  252 |   expect<bigint>().type.toBe<string | Array<string>>(); // fail
+  253 | });
+  254 | 
+
+        at ./__typetests__/structure.tst.ts:251:30 ❭ is bigint?
+
+Error: Type 'bigint' is not the same as type 'string | string[]'.
+
+  250 |   expect<bigint>().type.toBe<number[]>(); // fail
+  251 |   expect<bigint>().type.toBe<string | number>(); // fail
+  252 |   expect<bigint>().type.toBe<string | Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~~~~~~~~~~
+  253 | });
+  254 | 
+  255 | test("is NOT bigint?", () => {
+
+        at ./__typetests__/structure.tst.ts:252:30 ❭ is bigint?
+
 Error: Type 'bigint' is the same as type 'bigint'.
 
-  258 |   expect<bigint>().type.not.toBe<number[]>();
-  259 | 
-  260 |   expect<bigint>().type.not.toBe<bigint>(); // fail
+  278 |   expect<bigint>().type.not.toBe<string | Array<string>>();
+  279 | 
+  280 |   expect<bigint>().type.not.toBe<bigint>(); // fail
       |                                  ~~~~~~
-  261 | });
-  262 | 
-  263 | test("is boolean?", () => {
+  281 | });
+  282 | 
+  283 | test("is boolean?", () => {
 
-        at ./__typetests__/structure.tst.ts:260:34 ❭ is NOT bigint?
+        at ./__typetests__/structure.tst.ts:280:34 ❭ is NOT bigint?
 
 Error: Type 'boolean' is not the same as type 'any'.
 
-  264 |   expect<boolean>().type.toBe<boolean>();
-  265 | 
-  266 |   expect<boolean>().type.toBe<any>(); // fail
+  284 |   expect<boolean>().type.toBe<boolean>();
+  285 | 
+  286 |   expect<boolean>().type.toBe<any>(); // fail
       |                               ~~~
-  267 |   expect<boolean>().type.toBe<unknown>(); // fail
-  268 |   expect<boolean>().type.toBe<string>(); // fail
-  269 |   expect<boolean>().type.toBe<number>(); // fail
-
-        at ./__typetests__/structure.tst.ts:266:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'unknown'.
-
-  265 | 
-  266 |   expect<boolean>().type.toBe<any>(); // fail
-  267 |   expect<boolean>().type.toBe<unknown>(); // fail
-      |                               ~~~~~~~
-  268 |   expect<boolean>().type.toBe<string>(); // fail
-  269 |   expect<boolean>().type.toBe<number>(); // fail
-  270 |   expect<boolean>().type.toBe<bigint>(); // fail
-
-        at ./__typetests__/structure.tst.ts:267:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'string'.
-
-  266 |   expect<boolean>().type.toBe<any>(); // fail
-  267 |   expect<boolean>().type.toBe<unknown>(); // fail
-  268 |   expect<boolean>().type.toBe<string>(); // fail
-      |                               ~~~~~~
-  269 |   expect<boolean>().type.toBe<number>(); // fail
-  270 |   expect<boolean>().type.toBe<bigint>(); // fail
-  271 |   expect<boolean>().type.toBe<symbol>(); // fail
-
-        at ./__typetests__/structure.tst.ts:268:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'number'.
-
-  267 |   expect<boolean>().type.toBe<unknown>(); // fail
-  268 |   expect<boolean>().type.toBe<string>(); // fail
-  269 |   expect<boolean>().type.toBe<number>(); // fail
-      |                               ~~~~~~
-  270 |   expect<boolean>().type.toBe<bigint>(); // fail
-  271 |   expect<boolean>().type.toBe<symbol>(); // fail
-  272 |   expect<boolean>().type.toBe<object>(); // fail
-
-        at ./__typetests__/structure.tst.ts:269:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'bigint'.
-
-  268 |   expect<boolean>().type.toBe<string>(); // fail
-  269 |   expect<boolean>().type.toBe<number>(); // fail
-  270 |   expect<boolean>().type.toBe<bigint>(); // fail
-      |                               ~~~~~~
-  271 |   expect<boolean>().type.toBe<symbol>(); // fail
-  272 |   expect<boolean>().type.toBe<object>(); // fail
-  273 |   expect<boolean>().type.toBe<void>(); // fail
-
-        at ./__typetests__/structure.tst.ts:270:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'symbol'.
-
-  269 |   expect<boolean>().type.toBe<number>(); // fail
-  270 |   expect<boolean>().type.toBe<bigint>(); // fail
-  271 |   expect<boolean>().type.toBe<symbol>(); // fail
-      |                               ~~~~~~
-  272 |   expect<boolean>().type.toBe<object>(); // fail
-  273 |   expect<boolean>().type.toBe<void>(); // fail
-  274 |   expect<boolean>().type.toBe<undefined>(); // fail
-
-        at ./__typetests__/structure.tst.ts:271:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'object'.
-
-  270 |   expect<boolean>().type.toBe<bigint>(); // fail
-  271 |   expect<boolean>().type.toBe<symbol>(); // fail
-  272 |   expect<boolean>().type.toBe<object>(); // fail
-      |                               ~~~~~~
-  273 |   expect<boolean>().type.toBe<void>(); // fail
-  274 |   expect<boolean>().type.toBe<undefined>(); // fail
-  275 |   expect<boolean>().type.toBe<null>(); // fail
-
-        at ./__typetests__/structure.tst.ts:272:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'void'.
-
-  271 |   expect<boolean>().type.toBe<symbol>(); // fail
-  272 |   expect<boolean>().type.toBe<object>(); // fail
-  273 |   expect<boolean>().type.toBe<void>(); // fail
-      |                               ~~~~
-  274 |   expect<boolean>().type.toBe<undefined>(); // fail
-  275 |   expect<boolean>().type.toBe<null>(); // fail
-  276 |   expect<boolean>().type.toBe<never>(); // fail
-
-        at ./__typetests__/structure.tst.ts:273:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'undefined'.
-
-  272 |   expect<boolean>().type.toBe<object>(); // fail
-  273 |   expect<boolean>().type.toBe<void>(); // fail
-  274 |   expect<boolean>().type.toBe<undefined>(); // fail
-      |                               ~~~~~~~~~
-  275 |   expect<boolean>().type.toBe<null>(); // fail
-  276 |   expect<boolean>().type.toBe<never>(); // fail
-  277 |   expect<boolean>().type.toBe<'abc'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:274:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'null'.
-
-  273 |   expect<boolean>().type.toBe<void>(); // fail
-  274 |   expect<boolean>().type.toBe<undefined>(); // fail
-  275 |   expect<boolean>().type.toBe<null>(); // fail
-      |                               ~~~~
-  276 |   expect<boolean>().type.toBe<never>(); // fail
-  277 |   expect<boolean>().type.toBe<'abc'>(); // fail
-  278 |   expect<boolean>().type.toBe<'def'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:275:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'never'.
-
-  274 |   expect<boolean>().type.toBe<undefined>(); // fail
-  275 |   expect<boolean>().type.toBe<null>(); // fail
-  276 |   expect<boolean>().type.toBe<never>(); // fail
-      |                               ~~~~~
-  277 |   expect<boolean>().type.toBe<'abc'>(); // fail
-  278 |   expect<boolean>().type.toBe<'def'>(); // fail
-  279 |   expect<boolean>().type.toBe<123>(); // fail
-
-        at ./__typetests__/structure.tst.ts:276:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type '"abc"'.
-
-  275 |   expect<boolean>().type.toBe<null>(); // fail
-  276 |   expect<boolean>().type.toBe<never>(); // fail
-  277 |   expect<boolean>().type.toBe<'abc'>(); // fail
-      |                               ~~~~~
-  278 |   expect<boolean>().type.toBe<'def'>(); // fail
-  279 |   expect<boolean>().type.toBe<123>(); // fail
-  280 |   expect<boolean>().type.toBe<456>(); // fail
-
-        at ./__typetests__/structure.tst.ts:277:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type '"def"'.
-
-  276 |   expect<boolean>().type.toBe<never>(); // fail
-  277 |   expect<boolean>().type.toBe<'abc'>(); // fail
-  278 |   expect<boolean>().type.toBe<'def'>(); // fail
-      |                               ~~~~~
-  279 |   expect<boolean>().type.toBe<123>(); // fail
-  280 |   expect<boolean>().type.toBe<456>(); // fail
-  281 |   expect<boolean>().type.toBe<887n>(); // fail
-
-        at ./__typetests__/structure.tst.ts:278:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type '123'.
-
-  277 |   expect<boolean>().type.toBe<'abc'>(); // fail
-  278 |   expect<boolean>().type.toBe<'def'>(); // fail
-  279 |   expect<boolean>().type.toBe<123>(); // fail
-      |                               ~~~
-  280 |   expect<boolean>().type.toBe<456>(); // fail
-  281 |   expect<boolean>().type.toBe<887n>(); // fail
-  282 |   expect<boolean>().type.toBe<998n>(); // fail
-
-        at ./__typetests__/structure.tst.ts:279:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type '456'.
-
-  278 |   expect<boolean>().type.toBe<'def'>(); // fail
-  279 |   expect<boolean>().type.toBe<123>(); // fail
-  280 |   expect<boolean>().type.toBe<456>(); // fail
-      |                               ~~~
-  281 |   expect<boolean>().type.toBe<887n>(); // fail
-  282 |   expect<boolean>().type.toBe<998n>(); // fail
-  283 |   expect<boolean>().type.toBe<true>(); // fail
-
-        at ./__typetests__/structure.tst.ts:280:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type '887n'.
-
-  279 |   expect<boolean>().type.toBe<123>(); // fail
-  280 |   expect<boolean>().type.toBe<456>(); // fail
-  281 |   expect<boolean>().type.toBe<887n>(); // fail
-      |                               ~~~~
-  282 |   expect<boolean>().type.toBe<998n>(); // fail
-  283 |   expect<boolean>().type.toBe<true>(); // fail
-  284 |   expect<boolean>().type.toBe<false>(); // fail
-
-        at ./__typetests__/structure.tst.ts:281:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type '998n'.
-
-  280 |   expect<boolean>().type.toBe<456>(); // fail
-  281 |   expect<boolean>().type.toBe<887n>(); // fail
-  282 |   expect<boolean>().type.toBe<998n>(); // fail
-      |                               ~~~~
-  283 |   expect<boolean>().type.toBe<true>(); // fail
-  284 |   expect<boolean>().type.toBe<false>(); // fail
-  285 |   expect<boolean>().type.toBe<Array<string>>(); // fail
-
-        at ./__typetests__/structure.tst.ts:282:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'true'.
-
-  281 |   expect<boolean>().type.toBe<887n>(); // fail
-  282 |   expect<boolean>().type.toBe<998n>(); // fail
-  283 |   expect<boolean>().type.toBe<true>(); // fail
-      |                               ~~~~
-  284 |   expect<boolean>().type.toBe<false>(); // fail
-  285 |   expect<boolean>().type.toBe<Array<string>>(); // fail
-  286 |   expect<boolean>().type.toBe<number[]>(); // fail
-
-        at ./__typetests__/structure.tst.ts:283:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'false'.
-
-  282 |   expect<boolean>().type.toBe<998n>(); // fail
-  283 |   expect<boolean>().type.toBe<true>(); // fail
-  284 |   expect<boolean>().type.toBe<false>(); // fail
-      |                               ~~~~~
-  285 |   expect<boolean>().type.toBe<Array<string>>(); // fail
-  286 |   expect<boolean>().type.toBe<number[]>(); // fail
-  287 | });
-
-        at ./__typetests__/structure.tst.ts:284:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'string[]'.
-
-  283 |   expect<boolean>().type.toBe<true>(); // fail
-  284 |   expect<boolean>().type.toBe<false>(); // fail
-  285 |   expect<boolean>().type.toBe<Array<string>>(); // fail
-      |                               ~~~~~~~~~~~~~
-  286 |   expect<boolean>().type.toBe<number[]>(); // fail
-  287 | });
-  288 | 
-
-        at ./__typetests__/structure.tst.ts:285:31 ❭ is boolean?
-
-Error: Type 'boolean' is not the same as type 'number[]'.
-
-  284 |   expect<boolean>().type.toBe<false>(); // fail
-  285 |   expect<boolean>().type.toBe<Array<string>>(); // fail
-  286 |   expect<boolean>().type.toBe<number[]>(); // fail
-      |                               ~~~~~~~~
-  287 | });
-  288 | 
-  289 | test("is NOT boolean?", () => {
+  287 |   expect<boolean>().type.toBe<unknown>(); // fail
+  288 |   expect<boolean>().type.toBe<string>(); // fail
+  289 |   expect<boolean>().type.toBe<number>(); // fail
 
         at ./__typetests__/structure.tst.ts:286:31 ❭ is boolean?
 
+Error: Type 'boolean' is not the same as type 'unknown'.
+
+  285 | 
+  286 |   expect<boolean>().type.toBe<any>(); // fail
+  287 |   expect<boolean>().type.toBe<unknown>(); // fail
+      |                               ~~~~~~~
+  288 |   expect<boolean>().type.toBe<string>(); // fail
+  289 |   expect<boolean>().type.toBe<number>(); // fail
+  290 |   expect<boolean>().type.toBe<bigint>(); // fail
+
+        at ./__typetests__/structure.tst.ts:287:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'string'.
+
+  286 |   expect<boolean>().type.toBe<any>(); // fail
+  287 |   expect<boolean>().type.toBe<unknown>(); // fail
+  288 |   expect<boolean>().type.toBe<string>(); // fail
+      |                               ~~~~~~
+  289 |   expect<boolean>().type.toBe<number>(); // fail
+  290 |   expect<boolean>().type.toBe<bigint>(); // fail
+  291 |   expect<boolean>().type.toBe<symbol>(); // fail
+
+        at ./__typetests__/structure.tst.ts:288:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'number'.
+
+  287 |   expect<boolean>().type.toBe<unknown>(); // fail
+  288 |   expect<boolean>().type.toBe<string>(); // fail
+  289 |   expect<boolean>().type.toBe<number>(); // fail
+      |                               ~~~~~~
+  290 |   expect<boolean>().type.toBe<bigint>(); // fail
+  291 |   expect<boolean>().type.toBe<symbol>(); // fail
+  292 |   expect<boolean>().type.toBe<object>(); // fail
+
+        at ./__typetests__/structure.tst.ts:289:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'bigint'.
+
+  288 |   expect<boolean>().type.toBe<string>(); // fail
+  289 |   expect<boolean>().type.toBe<number>(); // fail
+  290 |   expect<boolean>().type.toBe<bigint>(); // fail
+      |                               ~~~~~~
+  291 |   expect<boolean>().type.toBe<symbol>(); // fail
+  292 |   expect<boolean>().type.toBe<object>(); // fail
+  293 |   expect<boolean>().type.toBe<void>(); // fail
+
+        at ./__typetests__/structure.tst.ts:290:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'symbol'.
+
+  289 |   expect<boolean>().type.toBe<number>(); // fail
+  290 |   expect<boolean>().type.toBe<bigint>(); // fail
+  291 |   expect<boolean>().type.toBe<symbol>(); // fail
+      |                               ~~~~~~
+  292 |   expect<boolean>().type.toBe<object>(); // fail
+  293 |   expect<boolean>().type.toBe<void>(); // fail
+  294 |   expect<boolean>().type.toBe<undefined>(); // fail
+
+        at ./__typetests__/structure.tst.ts:291:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'object'.
+
+  290 |   expect<boolean>().type.toBe<bigint>(); // fail
+  291 |   expect<boolean>().type.toBe<symbol>(); // fail
+  292 |   expect<boolean>().type.toBe<object>(); // fail
+      |                               ~~~~~~
+  293 |   expect<boolean>().type.toBe<void>(); // fail
+  294 |   expect<boolean>().type.toBe<undefined>(); // fail
+  295 |   expect<boolean>().type.toBe<null>(); // fail
+
+        at ./__typetests__/structure.tst.ts:292:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'void'.
+
+  291 |   expect<boolean>().type.toBe<symbol>(); // fail
+  292 |   expect<boolean>().type.toBe<object>(); // fail
+  293 |   expect<boolean>().type.toBe<void>(); // fail
+      |                               ~~~~
+  294 |   expect<boolean>().type.toBe<undefined>(); // fail
+  295 |   expect<boolean>().type.toBe<null>(); // fail
+  296 |   expect<boolean>().type.toBe<never>(); // fail
+
+        at ./__typetests__/structure.tst.ts:293:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'undefined'.
+
+  292 |   expect<boolean>().type.toBe<object>(); // fail
+  293 |   expect<boolean>().type.toBe<void>(); // fail
+  294 |   expect<boolean>().type.toBe<undefined>(); // fail
+      |                               ~~~~~~~~~
+  295 |   expect<boolean>().type.toBe<null>(); // fail
+  296 |   expect<boolean>().type.toBe<never>(); // fail
+  297 |   expect<boolean>().type.toBe<'abc'>(); // fail
+
+        at ./__typetests__/structure.tst.ts:294:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'null'.
+
+  293 |   expect<boolean>().type.toBe<void>(); // fail
+  294 |   expect<boolean>().type.toBe<undefined>(); // fail
+  295 |   expect<boolean>().type.toBe<null>(); // fail
+      |                               ~~~~
+  296 |   expect<boolean>().type.toBe<never>(); // fail
+  297 |   expect<boolean>().type.toBe<'abc'>(); // fail
+  298 |   expect<boolean>().type.toBe<'def'>(); // fail
+
+        at ./__typetests__/structure.tst.ts:295:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'never'.
+
+  294 |   expect<boolean>().type.toBe<undefined>(); // fail
+  295 |   expect<boolean>().type.toBe<null>(); // fail
+  296 |   expect<boolean>().type.toBe<never>(); // fail
+      |                               ~~~~~
+  297 |   expect<boolean>().type.toBe<'abc'>(); // fail
+  298 |   expect<boolean>().type.toBe<'def'>(); // fail
+  299 |   expect<boolean>().type.toBe<123>(); // fail
+
+        at ./__typetests__/structure.tst.ts:296:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type '"abc"'.
+
+  295 |   expect<boolean>().type.toBe<null>(); // fail
+  296 |   expect<boolean>().type.toBe<never>(); // fail
+  297 |   expect<boolean>().type.toBe<'abc'>(); // fail
+      |                               ~~~~~
+  298 |   expect<boolean>().type.toBe<'def'>(); // fail
+  299 |   expect<boolean>().type.toBe<123>(); // fail
+  300 |   expect<boolean>().type.toBe<456>(); // fail
+
+        at ./__typetests__/structure.tst.ts:297:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type '"def"'.
+
+  296 |   expect<boolean>().type.toBe<never>(); // fail
+  297 |   expect<boolean>().type.toBe<'abc'>(); // fail
+  298 |   expect<boolean>().type.toBe<'def'>(); // fail
+      |                               ~~~~~
+  299 |   expect<boolean>().type.toBe<123>(); // fail
+  300 |   expect<boolean>().type.toBe<456>(); // fail
+  301 |   expect<boolean>().type.toBe<887n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:298:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type '123'.
+
+  297 |   expect<boolean>().type.toBe<'abc'>(); // fail
+  298 |   expect<boolean>().type.toBe<'def'>(); // fail
+  299 |   expect<boolean>().type.toBe<123>(); // fail
+      |                               ~~~
+  300 |   expect<boolean>().type.toBe<456>(); // fail
+  301 |   expect<boolean>().type.toBe<887n>(); // fail
+  302 |   expect<boolean>().type.toBe<998n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:299:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type '456'.
+
+  298 |   expect<boolean>().type.toBe<'def'>(); // fail
+  299 |   expect<boolean>().type.toBe<123>(); // fail
+  300 |   expect<boolean>().type.toBe<456>(); // fail
+      |                               ~~~
+  301 |   expect<boolean>().type.toBe<887n>(); // fail
+  302 |   expect<boolean>().type.toBe<998n>(); // fail
+  303 |   expect<boolean>().type.toBe<true>(); // fail
+
+        at ./__typetests__/structure.tst.ts:300:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type '887n'.
+
+  299 |   expect<boolean>().type.toBe<123>(); // fail
+  300 |   expect<boolean>().type.toBe<456>(); // fail
+  301 |   expect<boolean>().type.toBe<887n>(); // fail
+      |                               ~~~~
+  302 |   expect<boolean>().type.toBe<998n>(); // fail
+  303 |   expect<boolean>().type.toBe<true>(); // fail
+  304 |   expect<boolean>().type.toBe<false>(); // fail
+
+        at ./__typetests__/structure.tst.ts:301:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type '998n'.
+
+  300 |   expect<boolean>().type.toBe<456>(); // fail
+  301 |   expect<boolean>().type.toBe<887n>(); // fail
+  302 |   expect<boolean>().type.toBe<998n>(); // fail
+      |                               ~~~~
+  303 |   expect<boolean>().type.toBe<true>(); // fail
+  304 |   expect<boolean>().type.toBe<false>(); // fail
+  305 |   expect<boolean>().type.toBe<Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:302:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'true'.
+
+  301 |   expect<boolean>().type.toBe<887n>(); // fail
+  302 |   expect<boolean>().type.toBe<998n>(); // fail
+  303 |   expect<boolean>().type.toBe<true>(); // fail
+      |                               ~~~~
+  304 |   expect<boolean>().type.toBe<false>(); // fail
+  305 |   expect<boolean>().type.toBe<Array<string>>(); // fail
+  306 |   expect<boolean>().type.toBe<number[]>(); // fail
+
+        at ./__typetests__/structure.tst.ts:303:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'false'.
+
+  302 |   expect<boolean>().type.toBe<998n>(); // fail
+  303 |   expect<boolean>().type.toBe<true>(); // fail
+  304 |   expect<boolean>().type.toBe<false>(); // fail
+      |                               ~~~~~
+  305 |   expect<boolean>().type.toBe<Array<string>>(); // fail
+  306 |   expect<boolean>().type.toBe<number[]>(); // fail
+  307 |   expect<boolean>().type.toBe<string | number>(); // fail
+
+        at ./__typetests__/structure.tst.ts:304:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'string[]'.
+
+  303 |   expect<boolean>().type.toBe<true>(); // fail
+  304 |   expect<boolean>().type.toBe<false>(); // fail
+  305 |   expect<boolean>().type.toBe<Array<string>>(); // fail
+      |                               ~~~~~~~~~~~~~
+  306 |   expect<boolean>().type.toBe<number[]>(); // fail
+  307 |   expect<boolean>().type.toBe<string | number>(); // fail
+  308 |   expect<boolean>().type.toBe<string | Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:305:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'number[]'.
+
+  304 |   expect<boolean>().type.toBe<false>(); // fail
+  305 |   expect<boolean>().type.toBe<Array<string>>(); // fail
+  306 |   expect<boolean>().type.toBe<number[]>(); // fail
+      |                               ~~~~~~~~
+  307 |   expect<boolean>().type.toBe<string | number>(); // fail
+  308 |   expect<boolean>().type.toBe<string | Array<string>>(); // fail
+  309 | });
+
+        at ./__typetests__/structure.tst.ts:306:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'string | number'.
+
+  305 |   expect<boolean>().type.toBe<Array<string>>(); // fail
+  306 |   expect<boolean>().type.toBe<number[]>(); // fail
+  307 |   expect<boolean>().type.toBe<string | number>(); // fail
+      |                               ~~~~~~~~~~~~~~~
+  308 |   expect<boolean>().type.toBe<string | Array<string>>(); // fail
+  309 | });
+  310 | 
+
+        at ./__typetests__/structure.tst.ts:307:31 ❭ is boolean?
+
+Error: Type 'boolean' is not the same as type 'string | string[]'.
+
+  306 |   expect<boolean>().type.toBe<number[]>(); // fail
+  307 |   expect<boolean>().type.toBe<string | number>(); // fail
+  308 |   expect<boolean>().type.toBe<string | Array<string>>(); // fail
+      |                               ~~~~~~~~~~~~~~~~~~~~~~
+  309 | });
+  310 | 
+  311 | test("is NOT boolean?", () => {
+
+        at ./__typetests__/structure.tst.ts:308:31 ❭ is boolean?
+
 Error: Type 'boolean' is the same as type 'boolean'.
 
-  310 |   expect<boolean>().type.not.toBe<number[]>();
-  311 | 
-  312 |   expect<boolean>().type.not.toBe<boolean>(); // fail
+  334 |   expect<boolean>().type.not.toBe<string | Array<string>>();
+  335 | 
+  336 |   expect<boolean>().type.not.toBe<boolean>(); // fail
       |                                   ~~~~~~~
-  313 | });
-  314 | 
-  315 | test("is symbol?", () => {
+  337 | });
+  338 | 
+  339 | test("is symbol?", () => {
 
-        at ./__typetests__/structure.tst.ts:312:35 ❭ is NOT boolean?
+        at ./__typetests__/structure.tst.ts:336:35 ❭ is NOT boolean?
 
 Error: Type 'symbol' is not the same as type 'any'.
 
-  316 |   expect<symbol>().type.toBe<symbol>();
-  317 | 
-  318 |   expect<symbol>().type.toBe<any>(); // fail
+  340 |   expect<symbol>().type.toBe<symbol>();
+  341 | 
+  342 |   expect<symbol>().type.toBe<any>(); // fail
       |                              ~~~
-  319 |   expect<symbol>().type.toBe<unknown>(); // fail
-  320 |   expect<symbol>().type.toBe<string>(); // fail
-  321 |   expect<symbol>().type.toBe<number>(); // fail
+  343 |   expect<symbol>().type.toBe<unknown>(); // fail
+  344 |   expect<symbol>().type.toBe<string>(); // fail
+  345 |   expect<symbol>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:318:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:342:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'unknown'.
 
-  317 | 
-  318 |   expect<symbol>().type.toBe<any>(); // fail
-  319 |   expect<symbol>().type.toBe<unknown>(); // fail
+  341 | 
+  342 |   expect<symbol>().type.toBe<any>(); // fail
+  343 |   expect<symbol>().type.toBe<unknown>(); // fail
       |                              ~~~~~~~
-  320 |   expect<symbol>().type.toBe<string>(); // fail
-  321 |   expect<symbol>().type.toBe<number>(); // fail
-  322 |   expect<symbol>().type.toBe<bigint>(); // fail
+  344 |   expect<symbol>().type.toBe<string>(); // fail
+  345 |   expect<symbol>().type.toBe<number>(); // fail
+  346 |   expect<symbol>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:319:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:343:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'string'.
 
-  318 |   expect<symbol>().type.toBe<any>(); // fail
-  319 |   expect<symbol>().type.toBe<unknown>(); // fail
-  320 |   expect<symbol>().type.toBe<string>(); // fail
+  342 |   expect<symbol>().type.toBe<any>(); // fail
+  343 |   expect<symbol>().type.toBe<unknown>(); // fail
+  344 |   expect<symbol>().type.toBe<string>(); // fail
       |                              ~~~~~~
-  321 |   expect<symbol>().type.toBe<number>(); // fail
-  322 |   expect<symbol>().type.toBe<bigint>(); // fail
-  323 |   expect<symbol>().type.toBe<boolean>(); // fail
+  345 |   expect<symbol>().type.toBe<number>(); // fail
+  346 |   expect<symbol>().type.toBe<bigint>(); // fail
+  347 |   expect<symbol>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:320:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:344:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'number'.
 
-  319 |   expect<symbol>().type.toBe<unknown>(); // fail
-  320 |   expect<symbol>().type.toBe<string>(); // fail
-  321 |   expect<symbol>().type.toBe<number>(); // fail
+  343 |   expect<symbol>().type.toBe<unknown>(); // fail
+  344 |   expect<symbol>().type.toBe<string>(); // fail
+  345 |   expect<symbol>().type.toBe<number>(); // fail
       |                              ~~~~~~
-  322 |   expect<symbol>().type.toBe<bigint>(); // fail
-  323 |   expect<symbol>().type.toBe<boolean>(); // fail
-  324 |   expect<symbol>().type.toBe<object>(); // fail
+  346 |   expect<symbol>().type.toBe<bigint>(); // fail
+  347 |   expect<symbol>().type.toBe<boolean>(); // fail
+  348 |   expect<symbol>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:321:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:345:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'bigint'.
 
-  320 |   expect<symbol>().type.toBe<string>(); // fail
-  321 |   expect<symbol>().type.toBe<number>(); // fail
-  322 |   expect<symbol>().type.toBe<bigint>(); // fail
+  344 |   expect<symbol>().type.toBe<string>(); // fail
+  345 |   expect<symbol>().type.toBe<number>(); // fail
+  346 |   expect<symbol>().type.toBe<bigint>(); // fail
       |                              ~~~~~~
-  323 |   expect<symbol>().type.toBe<boolean>(); // fail
-  324 |   expect<symbol>().type.toBe<object>(); // fail
-  325 |   expect<symbol>().type.toBe<void>(); // fail
+  347 |   expect<symbol>().type.toBe<boolean>(); // fail
+  348 |   expect<symbol>().type.toBe<object>(); // fail
+  349 |   expect<symbol>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:322:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:346:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'boolean'.
 
-  321 |   expect<symbol>().type.toBe<number>(); // fail
-  322 |   expect<symbol>().type.toBe<bigint>(); // fail
-  323 |   expect<symbol>().type.toBe<boolean>(); // fail
+  345 |   expect<symbol>().type.toBe<number>(); // fail
+  346 |   expect<symbol>().type.toBe<bigint>(); // fail
+  347 |   expect<symbol>().type.toBe<boolean>(); // fail
       |                              ~~~~~~~
-  324 |   expect<symbol>().type.toBe<object>(); // fail
-  325 |   expect<symbol>().type.toBe<void>(); // fail
-  326 |   expect<symbol>().type.toBe<undefined>(); // fail
+  348 |   expect<symbol>().type.toBe<object>(); // fail
+  349 |   expect<symbol>().type.toBe<void>(); // fail
+  350 |   expect<symbol>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:323:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:347:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'object'.
 
-  322 |   expect<symbol>().type.toBe<bigint>(); // fail
-  323 |   expect<symbol>().type.toBe<boolean>(); // fail
-  324 |   expect<symbol>().type.toBe<object>(); // fail
+  346 |   expect<symbol>().type.toBe<bigint>(); // fail
+  347 |   expect<symbol>().type.toBe<boolean>(); // fail
+  348 |   expect<symbol>().type.toBe<object>(); // fail
       |                              ~~~~~~
-  325 |   expect<symbol>().type.toBe<void>(); // fail
-  326 |   expect<symbol>().type.toBe<undefined>(); // fail
-  327 |   expect<symbol>().type.toBe<null>(); // fail
+  349 |   expect<symbol>().type.toBe<void>(); // fail
+  350 |   expect<symbol>().type.toBe<undefined>(); // fail
+  351 |   expect<symbol>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:324:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:348:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'void'.
 
-  323 |   expect<symbol>().type.toBe<boolean>(); // fail
-  324 |   expect<symbol>().type.toBe<object>(); // fail
-  325 |   expect<symbol>().type.toBe<void>(); // fail
+  347 |   expect<symbol>().type.toBe<boolean>(); // fail
+  348 |   expect<symbol>().type.toBe<object>(); // fail
+  349 |   expect<symbol>().type.toBe<void>(); // fail
       |                              ~~~~
-  326 |   expect<symbol>().type.toBe<undefined>(); // fail
-  327 |   expect<symbol>().type.toBe<null>(); // fail
-  328 |   expect<symbol>().type.toBe<never>(); // fail
+  350 |   expect<symbol>().type.toBe<undefined>(); // fail
+  351 |   expect<symbol>().type.toBe<null>(); // fail
+  352 |   expect<symbol>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:325:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:349:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'undefined'.
 
-  324 |   expect<symbol>().type.toBe<object>(); // fail
-  325 |   expect<symbol>().type.toBe<void>(); // fail
-  326 |   expect<symbol>().type.toBe<undefined>(); // fail
+  348 |   expect<symbol>().type.toBe<object>(); // fail
+  349 |   expect<symbol>().type.toBe<void>(); // fail
+  350 |   expect<symbol>().type.toBe<undefined>(); // fail
       |                              ~~~~~~~~~
-  327 |   expect<symbol>().type.toBe<null>(); // fail
-  328 |   expect<symbol>().type.toBe<never>(); // fail
-  329 |   expect<symbol>().type.toBe<'abc'>(); // fail
+  351 |   expect<symbol>().type.toBe<null>(); // fail
+  352 |   expect<symbol>().type.toBe<never>(); // fail
+  353 |   expect<symbol>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:326:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:350:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'null'.
 
-  325 |   expect<symbol>().type.toBe<void>(); // fail
-  326 |   expect<symbol>().type.toBe<undefined>(); // fail
-  327 |   expect<symbol>().type.toBe<null>(); // fail
+  349 |   expect<symbol>().type.toBe<void>(); // fail
+  350 |   expect<symbol>().type.toBe<undefined>(); // fail
+  351 |   expect<symbol>().type.toBe<null>(); // fail
       |                              ~~~~
-  328 |   expect<symbol>().type.toBe<never>(); // fail
-  329 |   expect<symbol>().type.toBe<'abc'>(); // fail
-  330 |   expect<symbol>().type.toBe<'def'>(); // fail
+  352 |   expect<symbol>().type.toBe<never>(); // fail
+  353 |   expect<symbol>().type.toBe<'abc'>(); // fail
+  354 |   expect<symbol>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:327:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:351:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'never'.
 
-  326 |   expect<symbol>().type.toBe<undefined>(); // fail
-  327 |   expect<symbol>().type.toBe<null>(); // fail
-  328 |   expect<symbol>().type.toBe<never>(); // fail
+  350 |   expect<symbol>().type.toBe<undefined>(); // fail
+  351 |   expect<symbol>().type.toBe<null>(); // fail
+  352 |   expect<symbol>().type.toBe<never>(); // fail
       |                              ~~~~~
-  329 |   expect<symbol>().type.toBe<'abc'>(); // fail
-  330 |   expect<symbol>().type.toBe<'def'>(); // fail
-  331 |   expect<symbol>().type.toBe<123>(); // fail
+  353 |   expect<symbol>().type.toBe<'abc'>(); // fail
+  354 |   expect<symbol>().type.toBe<'def'>(); // fail
+  355 |   expect<symbol>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:328:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:352:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type '"abc"'.
 
-  327 |   expect<symbol>().type.toBe<null>(); // fail
-  328 |   expect<symbol>().type.toBe<never>(); // fail
-  329 |   expect<symbol>().type.toBe<'abc'>(); // fail
+  351 |   expect<symbol>().type.toBe<null>(); // fail
+  352 |   expect<symbol>().type.toBe<never>(); // fail
+  353 |   expect<symbol>().type.toBe<'abc'>(); // fail
       |                              ~~~~~
-  330 |   expect<symbol>().type.toBe<'def'>(); // fail
-  331 |   expect<symbol>().type.toBe<123>(); // fail
-  332 |   expect<symbol>().type.toBe<456>(); // fail
+  354 |   expect<symbol>().type.toBe<'def'>(); // fail
+  355 |   expect<symbol>().type.toBe<123>(); // fail
+  356 |   expect<symbol>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:329:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:353:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type '"def"'.
 
-  328 |   expect<symbol>().type.toBe<never>(); // fail
-  329 |   expect<symbol>().type.toBe<'abc'>(); // fail
-  330 |   expect<symbol>().type.toBe<'def'>(); // fail
+  352 |   expect<symbol>().type.toBe<never>(); // fail
+  353 |   expect<symbol>().type.toBe<'abc'>(); // fail
+  354 |   expect<symbol>().type.toBe<'def'>(); // fail
       |                              ~~~~~
-  331 |   expect<symbol>().type.toBe<123>(); // fail
-  332 |   expect<symbol>().type.toBe<456>(); // fail
-  333 |   expect<symbol>().type.toBe<887n>(); // fail
+  355 |   expect<symbol>().type.toBe<123>(); // fail
+  356 |   expect<symbol>().type.toBe<456>(); // fail
+  357 |   expect<symbol>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:330:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:354:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type '123'.
 
-  329 |   expect<symbol>().type.toBe<'abc'>(); // fail
-  330 |   expect<symbol>().type.toBe<'def'>(); // fail
-  331 |   expect<symbol>().type.toBe<123>(); // fail
+  353 |   expect<symbol>().type.toBe<'abc'>(); // fail
+  354 |   expect<symbol>().type.toBe<'def'>(); // fail
+  355 |   expect<symbol>().type.toBe<123>(); // fail
       |                              ~~~
-  332 |   expect<symbol>().type.toBe<456>(); // fail
-  333 |   expect<symbol>().type.toBe<887n>(); // fail
-  334 |   expect<symbol>().type.toBe<998n>(); // fail
+  356 |   expect<symbol>().type.toBe<456>(); // fail
+  357 |   expect<symbol>().type.toBe<887n>(); // fail
+  358 |   expect<symbol>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:331:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:355:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type '456'.
 
-  330 |   expect<symbol>().type.toBe<'def'>(); // fail
-  331 |   expect<symbol>().type.toBe<123>(); // fail
-  332 |   expect<symbol>().type.toBe<456>(); // fail
+  354 |   expect<symbol>().type.toBe<'def'>(); // fail
+  355 |   expect<symbol>().type.toBe<123>(); // fail
+  356 |   expect<symbol>().type.toBe<456>(); // fail
       |                              ~~~
-  333 |   expect<symbol>().type.toBe<887n>(); // fail
-  334 |   expect<symbol>().type.toBe<998n>(); // fail
-  335 |   expect<symbol>().type.toBe<true>(); // fail
+  357 |   expect<symbol>().type.toBe<887n>(); // fail
+  358 |   expect<symbol>().type.toBe<998n>(); // fail
+  359 |   expect<symbol>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:332:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:356:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type '887n'.
 
-  331 |   expect<symbol>().type.toBe<123>(); // fail
-  332 |   expect<symbol>().type.toBe<456>(); // fail
-  333 |   expect<symbol>().type.toBe<887n>(); // fail
+  355 |   expect<symbol>().type.toBe<123>(); // fail
+  356 |   expect<symbol>().type.toBe<456>(); // fail
+  357 |   expect<symbol>().type.toBe<887n>(); // fail
       |                              ~~~~
-  334 |   expect<symbol>().type.toBe<998n>(); // fail
-  335 |   expect<symbol>().type.toBe<true>(); // fail
-  336 |   expect<symbol>().type.toBe<false>(); // fail
+  358 |   expect<symbol>().type.toBe<998n>(); // fail
+  359 |   expect<symbol>().type.toBe<true>(); // fail
+  360 |   expect<symbol>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:333:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:357:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type '998n'.
 
-  332 |   expect<symbol>().type.toBe<456>(); // fail
-  333 |   expect<symbol>().type.toBe<887n>(); // fail
-  334 |   expect<symbol>().type.toBe<998n>(); // fail
+  356 |   expect<symbol>().type.toBe<456>(); // fail
+  357 |   expect<symbol>().type.toBe<887n>(); // fail
+  358 |   expect<symbol>().type.toBe<998n>(); // fail
       |                              ~~~~
-  335 |   expect<symbol>().type.toBe<true>(); // fail
-  336 |   expect<symbol>().type.toBe<false>(); // fail
-  337 |   expect<symbol>().type.toBe<Array<string>>(); // fail
+  359 |   expect<symbol>().type.toBe<true>(); // fail
+  360 |   expect<symbol>().type.toBe<false>(); // fail
+  361 |   expect<symbol>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:334:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:358:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'true'.
 
-  333 |   expect<symbol>().type.toBe<887n>(); // fail
-  334 |   expect<symbol>().type.toBe<998n>(); // fail
-  335 |   expect<symbol>().type.toBe<true>(); // fail
+  357 |   expect<symbol>().type.toBe<887n>(); // fail
+  358 |   expect<symbol>().type.toBe<998n>(); // fail
+  359 |   expect<symbol>().type.toBe<true>(); // fail
       |                              ~~~~
-  336 |   expect<symbol>().type.toBe<false>(); // fail
-  337 |   expect<symbol>().type.toBe<Array<string>>(); // fail
-  338 |   expect<symbol>().type.toBe<number[]>(); // fail
+  360 |   expect<symbol>().type.toBe<false>(); // fail
+  361 |   expect<symbol>().type.toBe<Array<string>>(); // fail
+  362 |   expect<symbol>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:335:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:359:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'false'.
 
-  334 |   expect<symbol>().type.toBe<998n>(); // fail
-  335 |   expect<symbol>().type.toBe<true>(); // fail
-  336 |   expect<symbol>().type.toBe<false>(); // fail
+  358 |   expect<symbol>().type.toBe<998n>(); // fail
+  359 |   expect<symbol>().type.toBe<true>(); // fail
+  360 |   expect<symbol>().type.toBe<false>(); // fail
       |                              ~~~~~
-  337 |   expect<symbol>().type.toBe<Array<string>>(); // fail
-  338 |   expect<symbol>().type.toBe<number[]>(); // fail
-  339 | });
+  361 |   expect<symbol>().type.toBe<Array<string>>(); // fail
+  362 |   expect<symbol>().type.toBe<number[]>(); // fail
+  363 |   expect<symbol>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:336:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:360:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'string[]'.
 
-  335 |   expect<symbol>().type.toBe<true>(); // fail
-  336 |   expect<symbol>().type.toBe<false>(); // fail
-  337 |   expect<symbol>().type.toBe<Array<string>>(); // fail
+  359 |   expect<symbol>().type.toBe<true>(); // fail
+  360 |   expect<symbol>().type.toBe<false>(); // fail
+  361 |   expect<symbol>().type.toBe<Array<string>>(); // fail
       |                              ~~~~~~~~~~~~~
-  338 |   expect<symbol>().type.toBe<number[]>(); // fail
-  339 | });
-  340 | 
+  362 |   expect<symbol>().type.toBe<number[]>(); // fail
+  363 |   expect<symbol>().type.toBe<string | number>(); // fail
+  364 |   expect<symbol>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:337:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:361:30 ❭ is symbol?
 
 Error: Type 'symbol' is not the same as type 'number[]'.
 
-  336 |   expect<symbol>().type.toBe<false>(); // fail
-  337 |   expect<symbol>().type.toBe<Array<string>>(); // fail
-  338 |   expect<symbol>().type.toBe<number[]>(); // fail
+  360 |   expect<symbol>().type.toBe<false>(); // fail
+  361 |   expect<symbol>().type.toBe<Array<string>>(); // fail
+  362 |   expect<symbol>().type.toBe<number[]>(); // fail
       |                              ~~~~~~~~
-  339 | });
-  340 | 
-  341 | test("is NOT symbol?", () => {
+  363 |   expect<symbol>().type.toBe<string | number>(); // fail
+  364 |   expect<symbol>().type.toBe<string | Array<string>>(); // fail
+  365 | });
 
-        at ./__typetests__/structure.tst.ts:338:30 ❭ is symbol?
+        at ./__typetests__/structure.tst.ts:362:30 ❭ is symbol?
+
+Error: Type 'symbol' is not the same as type 'string | number'.
+
+  361 |   expect<symbol>().type.toBe<Array<string>>(); // fail
+  362 |   expect<symbol>().type.toBe<number[]>(); // fail
+  363 |   expect<symbol>().type.toBe<string | number>(); // fail
+      |                              ~~~~~~~~~~~~~~~
+  364 |   expect<symbol>().type.toBe<string | Array<string>>(); // fail
+  365 | });
+  366 | 
+
+        at ./__typetests__/structure.tst.ts:363:30 ❭ is symbol?
+
+Error: Type 'symbol' is not the same as type 'string | string[]'.
+
+  362 |   expect<symbol>().type.toBe<number[]>(); // fail
+  363 |   expect<symbol>().type.toBe<string | number>(); // fail
+  364 |   expect<symbol>().type.toBe<string | Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~~~~~~~~~~
+  365 | });
+  366 | 
+  367 | test("is NOT symbol?", () => {
+
+        at ./__typetests__/structure.tst.ts:364:30 ❭ is symbol?
 
 Error: Type 'symbol' is the same as type 'symbol'.
 
-  362 |   expect<symbol>().type.not.toBe<number[]>();
-  363 | 
-  364 |   expect<symbol>().type.not.toBe<symbol>(); // fail
+  390 |   expect<symbol>().type.not.toBe<string | Array<string>>();
+  391 | 
+  392 |   expect<symbol>().type.not.toBe<symbol>(); // fail
       |                                  ~~~~~~
-  365 | });
-  366 | 
-  367 | test("is object?", () => {
+  393 | });
+  394 | 
+  395 | test("is object?", () => {
 
-        at ./__typetests__/structure.tst.ts:364:34 ❭ is NOT symbol?
+        at ./__typetests__/structure.tst.ts:392:34 ❭ is NOT symbol?
 
 Error: Type 'object' is not the same as type 'any'.
 
-  368 |   expect<object>().type.toBe<object>();
-  369 | 
-  370 |   expect<object>().type.toBe<any>(); // fail
+  396 |   expect<object>().type.toBe<object>();
+  397 | 
+  398 |   expect<object>().type.toBe<any>(); // fail
       |                              ~~~
-  371 |   expect<object>().type.toBe<unknown>(); // fail
-  372 |   expect<object>().type.toBe<string>(); // fail
-  373 |   expect<object>().type.toBe<number>(); // fail
+  399 |   expect<object>().type.toBe<unknown>(); // fail
+  400 |   expect<object>().type.toBe<string>(); // fail
+  401 |   expect<object>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:370:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:398:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'unknown'.
 
-  369 | 
-  370 |   expect<object>().type.toBe<any>(); // fail
-  371 |   expect<object>().type.toBe<unknown>(); // fail
+  397 | 
+  398 |   expect<object>().type.toBe<any>(); // fail
+  399 |   expect<object>().type.toBe<unknown>(); // fail
       |                              ~~~~~~~
-  372 |   expect<object>().type.toBe<string>(); // fail
-  373 |   expect<object>().type.toBe<number>(); // fail
-  374 |   expect<object>().type.toBe<bigint>(); // fail
+  400 |   expect<object>().type.toBe<string>(); // fail
+  401 |   expect<object>().type.toBe<number>(); // fail
+  402 |   expect<object>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:371:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:399:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'string'.
 
-  370 |   expect<object>().type.toBe<any>(); // fail
-  371 |   expect<object>().type.toBe<unknown>(); // fail
-  372 |   expect<object>().type.toBe<string>(); // fail
+  398 |   expect<object>().type.toBe<any>(); // fail
+  399 |   expect<object>().type.toBe<unknown>(); // fail
+  400 |   expect<object>().type.toBe<string>(); // fail
       |                              ~~~~~~
-  373 |   expect<object>().type.toBe<number>(); // fail
-  374 |   expect<object>().type.toBe<bigint>(); // fail
-  375 |   expect<object>().type.toBe<boolean>(); // fail
+  401 |   expect<object>().type.toBe<number>(); // fail
+  402 |   expect<object>().type.toBe<bigint>(); // fail
+  403 |   expect<object>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:372:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:400:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'number'.
 
-  371 |   expect<object>().type.toBe<unknown>(); // fail
-  372 |   expect<object>().type.toBe<string>(); // fail
-  373 |   expect<object>().type.toBe<number>(); // fail
+  399 |   expect<object>().type.toBe<unknown>(); // fail
+  400 |   expect<object>().type.toBe<string>(); // fail
+  401 |   expect<object>().type.toBe<number>(); // fail
       |                              ~~~~~~
-  374 |   expect<object>().type.toBe<bigint>(); // fail
-  375 |   expect<object>().type.toBe<boolean>(); // fail
-  376 |   expect<object>().type.toBe<symbol>(); // fail
+  402 |   expect<object>().type.toBe<bigint>(); // fail
+  403 |   expect<object>().type.toBe<boolean>(); // fail
+  404 |   expect<object>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:373:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:401:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'bigint'.
 
-  372 |   expect<object>().type.toBe<string>(); // fail
-  373 |   expect<object>().type.toBe<number>(); // fail
-  374 |   expect<object>().type.toBe<bigint>(); // fail
+  400 |   expect<object>().type.toBe<string>(); // fail
+  401 |   expect<object>().type.toBe<number>(); // fail
+  402 |   expect<object>().type.toBe<bigint>(); // fail
       |                              ~~~~~~
-  375 |   expect<object>().type.toBe<boolean>(); // fail
-  376 |   expect<object>().type.toBe<symbol>(); // fail
-  377 |   expect<object>().type.toBe<void>(); // fail
+  403 |   expect<object>().type.toBe<boolean>(); // fail
+  404 |   expect<object>().type.toBe<symbol>(); // fail
+  405 |   expect<object>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:374:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:402:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'boolean'.
 
-  373 |   expect<object>().type.toBe<number>(); // fail
-  374 |   expect<object>().type.toBe<bigint>(); // fail
-  375 |   expect<object>().type.toBe<boolean>(); // fail
+  401 |   expect<object>().type.toBe<number>(); // fail
+  402 |   expect<object>().type.toBe<bigint>(); // fail
+  403 |   expect<object>().type.toBe<boolean>(); // fail
       |                              ~~~~~~~
-  376 |   expect<object>().type.toBe<symbol>(); // fail
-  377 |   expect<object>().type.toBe<void>(); // fail
-  378 |   expect<object>().type.toBe<undefined>(); // fail
+  404 |   expect<object>().type.toBe<symbol>(); // fail
+  405 |   expect<object>().type.toBe<void>(); // fail
+  406 |   expect<object>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:375:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:403:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'symbol'.
 
-  374 |   expect<object>().type.toBe<bigint>(); // fail
-  375 |   expect<object>().type.toBe<boolean>(); // fail
-  376 |   expect<object>().type.toBe<symbol>(); // fail
+  402 |   expect<object>().type.toBe<bigint>(); // fail
+  403 |   expect<object>().type.toBe<boolean>(); // fail
+  404 |   expect<object>().type.toBe<symbol>(); // fail
       |                              ~~~~~~
-  377 |   expect<object>().type.toBe<void>(); // fail
-  378 |   expect<object>().type.toBe<undefined>(); // fail
-  379 |   expect<object>().type.toBe<null>(); // fail
+  405 |   expect<object>().type.toBe<void>(); // fail
+  406 |   expect<object>().type.toBe<undefined>(); // fail
+  407 |   expect<object>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:376:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:404:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'void'.
 
-  375 |   expect<object>().type.toBe<boolean>(); // fail
-  376 |   expect<object>().type.toBe<symbol>(); // fail
-  377 |   expect<object>().type.toBe<void>(); // fail
+  403 |   expect<object>().type.toBe<boolean>(); // fail
+  404 |   expect<object>().type.toBe<symbol>(); // fail
+  405 |   expect<object>().type.toBe<void>(); // fail
       |                              ~~~~
-  378 |   expect<object>().type.toBe<undefined>(); // fail
-  379 |   expect<object>().type.toBe<null>(); // fail
-  380 |   expect<object>().type.toBe<never>(); // fail
+  406 |   expect<object>().type.toBe<undefined>(); // fail
+  407 |   expect<object>().type.toBe<null>(); // fail
+  408 |   expect<object>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:377:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:405:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'undefined'.
 
-  376 |   expect<object>().type.toBe<symbol>(); // fail
-  377 |   expect<object>().type.toBe<void>(); // fail
-  378 |   expect<object>().type.toBe<undefined>(); // fail
+  404 |   expect<object>().type.toBe<symbol>(); // fail
+  405 |   expect<object>().type.toBe<void>(); // fail
+  406 |   expect<object>().type.toBe<undefined>(); // fail
       |                              ~~~~~~~~~
-  379 |   expect<object>().type.toBe<null>(); // fail
-  380 |   expect<object>().type.toBe<never>(); // fail
-  381 |   expect<object>().type.toBe<'abc'>(); // fail
+  407 |   expect<object>().type.toBe<null>(); // fail
+  408 |   expect<object>().type.toBe<never>(); // fail
+  409 |   expect<object>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:378:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:406:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'null'.
 
-  377 |   expect<object>().type.toBe<void>(); // fail
-  378 |   expect<object>().type.toBe<undefined>(); // fail
-  379 |   expect<object>().type.toBe<null>(); // fail
+  405 |   expect<object>().type.toBe<void>(); // fail
+  406 |   expect<object>().type.toBe<undefined>(); // fail
+  407 |   expect<object>().type.toBe<null>(); // fail
       |                              ~~~~
-  380 |   expect<object>().type.toBe<never>(); // fail
-  381 |   expect<object>().type.toBe<'abc'>(); // fail
-  382 |   expect<object>().type.toBe<'def'>(); // fail
+  408 |   expect<object>().type.toBe<never>(); // fail
+  409 |   expect<object>().type.toBe<'abc'>(); // fail
+  410 |   expect<object>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:379:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:407:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'never'.
 
-  378 |   expect<object>().type.toBe<undefined>(); // fail
-  379 |   expect<object>().type.toBe<null>(); // fail
-  380 |   expect<object>().type.toBe<never>(); // fail
+  406 |   expect<object>().type.toBe<undefined>(); // fail
+  407 |   expect<object>().type.toBe<null>(); // fail
+  408 |   expect<object>().type.toBe<never>(); // fail
       |                              ~~~~~
-  381 |   expect<object>().type.toBe<'abc'>(); // fail
-  382 |   expect<object>().type.toBe<'def'>(); // fail
-  383 |   expect<object>().type.toBe<123>(); // fail
+  409 |   expect<object>().type.toBe<'abc'>(); // fail
+  410 |   expect<object>().type.toBe<'def'>(); // fail
+  411 |   expect<object>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:380:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:408:30 ❭ is object?
 
 Error: Type 'object' is not the same as type '"abc"'.
 
-  379 |   expect<object>().type.toBe<null>(); // fail
-  380 |   expect<object>().type.toBe<never>(); // fail
-  381 |   expect<object>().type.toBe<'abc'>(); // fail
+  407 |   expect<object>().type.toBe<null>(); // fail
+  408 |   expect<object>().type.toBe<never>(); // fail
+  409 |   expect<object>().type.toBe<'abc'>(); // fail
       |                              ~~~~~
-  382 |   expect<object>().type.toBe<'def'>(); // fail
-  383 |   expect<object>().type.toBe<123>(); // fail
-  384 |   expect<object>().type.toBe<456>(); // fail
+  410 |   expect<object>().type.toBe<'def'>(); // fail
+  411 |   expect<object>().type.toBe<123>(); // fail
+  412 |   expect<object>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:381:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:409:30 ❭ is object?
 
 Error: Type 'object' is not the same as type '"def"'.
 
-  380 |   expect<object>().type.toBe<never>(); // fail
-  381 |   expect<object>().type.toBe<'abc'>(); // fail
-  382 |   expect<object>().type.toBe<'def'>(); // fail
+  408 |   expect<object>().type.toBe<never>(); // fail
+  409 |   expect<object>().type.toBe<'abc'>(); // fail
+  410 |   expect<object>().type.toBe<'def'>(); // fail
       |                              ~~~~~
-  383 |   expect<object>().type.toBe<123>(); // fail
-  384 |   expect<object>().type.toBe<456>(); // fail
-  385 |   expect<object>().type.toBe<887n>(); // fail
+  411 |   expect<object>().type.toBe<123>(); // fail
+  412 |   expect<object>().type.toBe<456>(); // fail
+  413 |   expect<object>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:382:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:410:30 ❭ is object?
 
 Error: Type 'object' is not the same as type '123'.
 
-  381 |   expect<object>().type.toBe<'abc'>(); // fail
-  382 |   expect<object>().type.toBe<'def'>(); // fail
-  383 |   expect<object>().type.toBe<123>(); // fail
+  409 |   expect<object>().type.toBe<'abc'>(); // fail
+  410 |   expect<object>().type.toBe<'def'>(); // fail
+  411 |   expect<object>().type.toBe<123>(); // fail
       |                              ~~~
-  384 |   expect<object>().type.toBe<456>(); // fail
-  385 |   expect<object>().type.toBe<887n>(); // fail
-  386 |   expect<object>().type.toBe<998n>(); // fail
+  412 |   expect<object>().type.toBe<456>(); // fail
+  413 |   expect<object>().type.toBe<887n>(); // fail
+  414 |   expect<object>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:383:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:411:30 ❭ is object?
 
 Error: Type 'object' is not the same as type '456'.
 
-  382 |   expect<object>().type.toBe<'def'>(); // fail
-  383 |   expect<object>().type.toBe<123>(); // fail
-  384 |   expect<object>().type.toBe<456>(); // fail
+  410 |   expect<object>().type.toBe<'def'>(); // fail
+  411 |   expect<object>().type.toBe<123>(); // fail
+  412 |   expect<object>().type.toBe<456>(); // fail
       |                              ~~~
-  385 |   expect<object>().type.toBe<887n>(); // fail
-  386 |   expect<object>().type.toBe<998n>(); // fail
-  387 |   expect<object>().type.toBe<true>(); // fail
+  413 |   expect<object>().type.toBe<887n>(); // fail
+  414 |   expect<object>().type.toBe<998n>(); // fail
+  415 |   expect<object>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:384:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:412:30 ❭ is object?
 
 Error: Type 'object' is not the same as type '887n'.
 
-  383 |   expect<object>().type.toBe<123>(); // fail
-  384 |   expect<object>().type.toBe<456>(); // fail
-  385 |   expect<object>().type.toBe<887n>(); // fail
+  411 |   expect<object>().type.toBe<123>(); // fail
+  412 |   expect<object>().type.toBe<456>(); // fail
+  413 |   expect<object>().type.toBe<887n>(); // fail
       |                              ~~~~
-  386 |   expect<object>().type.toBe<998n>(); // fail
-  387 |   expect<object>().type.toBe<true>(); // fail
-  388 |   expect<object>().type.toBe<false>(); // fail
+  414 |   expect<object>().type.toBe<998n>(); // fail
+  415 |   expect<object>().type.toBe<true>(); // fail
+  416 |   expect<object>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:385:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:413:30 ❭ is object?
 
 Error: Type 'object' is not the same as type '998n'.
 
-  384 |   expect<object>().type.toBe<456>(); // fail
-  385 |   expect<object>().type.toBe<887n>(); // fail
-  386 |   expect<object>().type.toBe<998n>(); // fail
+  412 |   expect<object>().type.toBe<456>(); // fail
+  413 |   expect<object>().type.toBe<887n>(); // fail
+  414 |   expect<object>().type.toBe<998n>(); // fail
       |                              ~~~~
-  387 |   expect<object>().type.toBe<true>(); // fail
-  388 |   expect<object>().type.toBe<false>(); // fail
-  389 |   expect<object>().type.toBe<Array<string>>(); // fail
+  415 |   expect<object>().type.toBe<true>(); // fail
+  416 |   expect<object>().type.toBe<false>(); // fail
+  417 |   expect<object>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:386:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:414:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'true'.
 
-  385 |   expect<object>().type.toBe<887n>(); // fail
-  386 |   expect<object>().type.toBe<998n>(); // fail
-  387 |   expect<object>().type.toBe<true>(); // fail
+  413 |   expect<object>().type.toBe<887n>(); // fail
+  414 |   expect<object>().type.toBe<998n>(); // fail
+  415 |   expect<object>().type.toBe<true>(); // fail
       |                              ~~~~
-  388 |   expect<object>().type.toBe<false>(); // fail
-  389 |   expect<object>().type.toBe<Array<string>>(); // fail
-  390 |   expect<object>().type.toBe<number[]>(); // fail
+  416 |   expect<object>().type.toBe<false>(); // fail
+  417 |   expect<object>().type.toBe<Array<string>>(); // fail
+  418 |   expect<object>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:387:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:415:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'false'.
 
-  386 |   expect<object>().type.toBe<998n>(); // fail
-  387 |   expect<object>().type.toBe<true>(); // fail
-  388 |   expect<object>().type.toBe<false>(); // fail
+  414 |   expect<object>().type.toBe<998n>(); // fail
+  415 |   expect<object>().type.toBe<true>(); // fail
+  416 |   expect<object>().type.toBe<false>(); // fail
       |                              ~~~~~
-  389 |   expect<object>().type.toBe<Array<string>>(); // fail
-  390 |   expect<object>().type.toBe<number[]>(); // fail
-  391 | });
+  417 |   expect<object>().type.toBe<Array<string>>(); // fail
+  418 |   expect<object>().type.toBe<number[]>(); // fail
+  419 |   expect<object>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:388:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:416:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'string[]'.
 
-  387 |   expect<object>().type.toBe<true>(); // fail
-  388 |   expect<object>().type.toBe<false>(); // fail
-  389 |   expect<object>().type.toBe<Array<string>>(); // fail
+  415 |   expect<object>().type.toBe<true>(); // fail
+  416 |   expect<object>().type.toBe<false>(); // fail
+  417 |   expect<object>().type.toBe<Array<string>>(); // fail
       |                              ~~~~~~~~~~~~~
-  390 |   expect<object>().type.toBe<number[]>(); // fail
-  391 | });
-  392 | 
+  418 |   expect<object>().type.toBe<number[]>(); // fail
+  419 |   expect<object>().type.toBe<string | number>(); // fail
+  420 |   expect<object>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:389:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:417:30 ❭ is object?
 
 Error: Type 'object' is not the same as type 'number[]'.
 
-  388 |   expect<object>().type.toBe<false>(); // fail
-  389 |   expect<object>().type.toBe<Array<string>>(); // fail
-  390 |   expect<object>().type.toBe<number[]>(); // fail
+  416 |   expect<object>().type.toBe<false>(); // fail
+  417 |   expect<object>().type.toBe<Array<string>>(); // fail
+  418 |   expect<object>().type.toBe<number[]>(); // fail
       |                              ~~~~~~~~
-  391 | });
-  392 | 
-  393 | test("is NOT object?", () => {
+  419 |   expect<object>().type.toBe<string | number>(); // fail
+  420 |   expect<object>().type.toBe<string | Array<string>>(); // fail
+  421 | });
 
-        at ./__typetests__/structure.tst.ts:390:30 ❭ is object?
+        at ./__typetests__/structure.tst.ts:418:30 ❭ is object?
+
+Error: Type 'object' is not the same as type 'string | number'.
+
+  417 |   expect<object>().type.toBe<Array<string>>(); // fail
+  418 |   expect<object>().type.toBe<number[]>(); // fail
+  419 |   expect<object>().type.toBe<string | number>(); // fail
+      |                              ~~~~~~~~~~~~~~~
+  420 |   expect<object>().type.toBe<string | Array<string>>(); // fail
+  421 | });
+  422 | 
+
+        at ./__typetests__/structure.tst.ts:419:30 ❭ is object?
+
+Error: Type 'object' is not the same as type 'string | string[]'.
+
+  418 |   expect<object>().type.toBe<number[]>(); // fail
+  419 |   expect<object>().type.toBe<string | number>(); // fail
+  420 |   expect<object>().type.toBe<string | Array<string>>(); // fail
+      |                              ~~~~~~~~~~~~~~~~~~~~~~
+  421 | });
+  422 | 
+  423 | test("is NOT object?", () => {
+
+        at ./__typetests__/structure.tst.ts:420:30 ❭ is object?
 
 Error: Type 'object' is the same as type 'object'.
 
-  414 |   expect<object>().type.not.toBe<number[]>();
-  415 | 
-  416 |   expect<object>().type.not.toBe<object>(); // fail
+  446 |   expect<object>().type.not.toBe<string | Array<string>>();
+  447 | 
+  448 |   expect<object>().type.not.toBe<object>(); // fail
       |                                  ~~~~~~
-  417 | });
-  418 | 
-  419 | test("is void?", () => {
+  449 | });
+  450 | 
+  451 | test("is void?", () => {
 
-        at ./__typetests__/structure.tst.ts:416:34 ❭ is NOT object?
+        at ./__typetests__/structure.tst.ts:448:34 ❭ is NOT object?
 
 Error: Type 'void' is not the same as type 'any'.
 
-  420 |   expect<void>().type.toBe<void>();
-  421 | 
-  422 |   expect<void>().type.toBe<any>(); // fail
+  452 |   expect<void>().type.toBe<void>();
+  453 | 
+  454 |   expect<void>().type.toBe<any>(); // fail
       |                            ~~~
-  423 |   expect<void>().type.toBe<unknown>(); // fail
-  424 |   expect<void>().type.toBe<string>(); // fail
-  425 |   expect<void>().type.toBe<number>(); // fail
+  455 |   expect<void>().type.toBe<unknown>(); // fail
+  456 |   expect<void>().type.toBe<string>(); // fail
+  457 |   expect<void>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:422:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:454:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'unknown'.
 
-  421 | 
-  422 |   expect<void>().type.toBe<any>(); // fail
-  423 |   expect<void>().type.toBe<unknown>(); // fail
+  453 | 
+  454 |   expect<void>().type.toBe<any>(); // fail
+  455 |   expect<void>().type.toBe<unknown>(); // fail
       |                            ~~~~~~~
-  424 |   expect<void>().type.toBe<string>(); // fail
-  425 |   expect<void>().type.toBe<number>(); // fail
-  426 |   expect<void>().type.toBe<bigint>(); // fail
+  456 |   expect<void>().type.toBe<string>(); // fail
+  457 |   expect<void>().type.toBe<number>(); // fail
+  458 |   expect<void>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:423:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:455:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'string'.
 
-  422 |   expect<void>().type.toBe<any>(); // fail
-  423 |   expect<void>().type.toBe<unknown>(); // fail
-  424 |   expect<void>().type.toBe<string>(); // fail
+  454 |   expect<void>().type.toBe<any>(); // fail
+  455 |   expect<void>().type.toBe<unknown>(); // fail
+  456 |   expect<void>().type.toBe<string>(); // fail
       |                            ~~~~~~
-  425 |   expect<void>().type.toBe<number>(); // fail
-  426 |   expect<void>().type.toBe<bigint>(); // fail
-  427 |   expect<void>().type.toBe<boolean>(); // fail
+  457 |   expect<void>().type.toBe<number>(); // fail
+  458 |   expect<void>().type.toBe<bigint>(); // fail
+  459 |   expect<void>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:424:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:456:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'number'.
 
-  423 |   expect<void>().type.toBe<unknown>(); // fail
-  424 |   expect<void>().type.toBe<string>(); // fail
-  425 |   expect<void>().type.toBe<number>(); // fail
+  455 |   expect<void>().type.toBe<unknown>(); // fail
+  456 |   expect<void>().type.toBe<string>(); // fail
+  457 |   expect<void>().type.toBe<number>(); // fail
       |                            ~~~~~~
-  426 |   expect<void>().type.toBe<bigint>(); // fail
-  427 |   expect<void>().type.toBe<boolean>(); // fail
-  428 |   expect<void>().type.toBe<symbol>(); // fail
+  458 |   expect<void>().type.toBe<bigint>(); // fail
+  459 |   expect<void>().type.toBe<boolean>(); // fail
+  460 |   expect<void>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:425:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:457:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'bigint'.
 
-  424 |   expect<void>().type.toBe<string>(); // fail
-  425 |   expect<void>().type.toBe<number>(); // fail
-  426 |   expect<void>().type.toBe<bigint>(); // fail
+  456 |   expect<void>().type.toBe<string>(); // fail
+  457 |   expect<void>().type.toBe<number>(); // fail
+  458 |   expect<void>().type.toBe<bigint>(); // fail
       |                            ~~~~~~
-  427 |   expect<void>().type.toBe<boolean>(); // fail
-  428 |   expect<void>().type.toBe<symbol>(); // fail
-  429 |   expect<void>().type.toBe<object>(); // fail
+  459 |   expect<void>().type.toBe<boolean>(); // fail
+  460 |   expect<void>().type.toBe<symbol>(); // fail
+  461 |   expect<void>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:426:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:458:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'boolean'.
 
-  425 |   expect<void>().type.toBe<number>(); // fail
-  426 |   expect<void>().type.toBe<bigint>(); // fail
-  427 |   expect<void>().type.toBe<boolean>(); // fail
+  457 |   expect<void>().type.toBe<number>(); // fail
+  458 |   expect<void>().type.toBe<bigint>(); // fail
+  459 |   expect<void>().type.toBe<boolean>(); // fail
       |                            ~~~~~~~
-  428 |   expect<void>().type.toBe<symbol>(); // fail
-  429 |   expect<void>().type.toBe<object>(); // fail
-  430 |   expect<void>().type.toBe<undefined>(); // fail
+  460 |   expect<void>().type.toBe<symbol>(); // fail
+  461 |   expect<void>().type.toBe<object>(); // fail
+  462 |   expect<void>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:427:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:459:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'symbol'.
 
-  426 |   expect<void>().type.toBe<bigint>(); // fail
-  427 |   expect<void>().type.toBe<boolean>(); // fail
-  428 |   expect<void>().type.toBe<symbol>(); // fail
+  458 |   expect<void>().type.toBe<bigint>(); // fail
+  459 |   expect<void>().type.toBe<boolean>(); // fail
+  460 |   expect<void>().type.toBe<symbol>(); // fail
       |                            ~~~~~~
-  429 |   expect<void>().type.toBe<object>(); // fail
-  430 |   expect<void>().type.toBe<undefined>(); // fail
-  431 |   expect<void>().type.toBe<null>(); // fail
+  461 |   expect<void>().type.toBe<object>(); // fail
+  462 |   expect<void>().type.toBe<undefined>(); // fail
+  463 |   expect<void>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:428:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:460:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'object'.
 
-  427 |   expect<void>().type.toBe<boolean>(); // fail
-  428 |   expect<void>().type.toBe<symbol>(); // fail
-  429 |   expect<void>().type.toBe<object>(); // fail
+  459 |   expect<void>().type.toBe<boolean>(); // fail
+  460 |   expect<void>().type.toBe<symbol>(); // fail
+  461 |   expect<void>().type.toBe<object>(); // fail
       |                            ~~~~~~
-  430 |   expect<void>().type.toBe<undefined>(); // fail
-  431 |   expect<void>().type.toBe<null>(); // fail
-  432 |   expect<void>().type.toBe<never>(); // fail
+  462 |   expect<void>().type.toBe<undefined>(); // fail
+  463 |   expect<void>().type.toBe<null>(); // fail
+  464 |   expect<void>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:429:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:461:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'undefined'.
 
-  428 |   expect<void>().type.toBe<symbol>(); // fail
-  429 |   expect<void>().type.toBe<object>(); // fail
-  430 |   expect<void>().type.toBe<undefined>(); // fail
+  460 |   expect<void>().type.toBe<symbol>(); // fail
+  461 |   expect<void>().type.toBe<object>(); // fail
+  462 |   expect<void>().type.toBe<undefined>(); // fail
       |                            ~~~~~~~~~
-  431 |   expect<void>().type.toBe<null>(); // fail
-  432 |   expect<void>().type.toBe<never>(); // fail
-  433 |   expect<void>().type.toBe<'abc'>(); // fail
+  463 |   expect<void>().type.toBe<null>(); // fail
+  464 |   expect<void>().type.toBe<never>(); // fail
+  465 |   expect<void>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:430:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:462:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'null'.
 
-  429 |   expect<void>().type.toBe<object>(); // fail
-  430 |   expect<void>().type.toBe<undefined>(); // fail
-  431 |   expect<void>().type.toBe<null>(); // fail
+  461 |   expect<void>().type.toBe<object>(); // fail
+  462 |   expect<void>().type.toBe<undefined>(); // fail
+  463 |   expect<void>().type.toBe<null>(); // fail
       |                            ~~~~
-  432 |   expect<void>().type.toBe<never>(); // fail
-  433 |   expect<void>().type.toBe<'abc'>(); // fail
-  434 |   expect<void>().type.toBe<'def'>(); // fail
+  464 |   expect<void>().type.toBe<never>(); // fail
+  465 |   expect<void>().type.toBe<'abc'>(); // fail
+  466 |   expect<void>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:431:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:463:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'never'.
 
-  430 |   expect<void>().type.toBe<undefined>(); // fail
-  431 |   expect<void>().type.toBe<null>(); // fail
-  432 |   expect<void>().type.toBe<never>(); // fail
+  462 |   expect<void>().type.toBe<undefined>(); // fail
+  463 |   expect<void>().type.toBe<null>(); // fail
+  464 |   expect<void>().type.toBe<never>(); // fail
       |                            ~~~~~
-  433 |   expect<void>().type.toBe<'abc'>(); // fail
-  434 |   expect<void>().type.toBe<'def'>(); // fail
-  435 |   expect<void>().type.toBe<123>(); // fail
+  465 |   expect<void>().type.toBe<'abc'>(); // fail
+  466 |   expect<void>().type.toBe<'def'>(); // fail
+  467 |   expect<void>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:432:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:464:28 ❭ is void?
 
 Error: Type 'void' is not the same as type '"abc"'.
 
-  431 |   expect<void>().type.toBe<null>(); // fail
-  432 |   expect<void>().type.toBe<never>(); // fail
-  433 |   expect<void>().type.toBe<'abc'>(); // fail
+  463 |   expect<void>().type.toBe<null>(); // fail
+  464 |   expect<void>().type.toBe<never>(); // fail
+  465 |   expect<void>().type.toBe<'abc'>(); // fail
       |                            ~~~~~
-  434 |   expect<void>().type.toBe<'def'>(); // fail
-  435 |   expect<void>().type.toBe<123>(); // fail
-  436 |   expect<void>().type.toBe<456>(); // fail
+  466 |   expect<void>().type.toBe<'def'>(); // fail
+  467 |   expect<void>().type.toBe<123>(); // fail
+  468 |   expect<void>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:433:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:465:28 ❭ is void?
 
 Error: Type 'void' is not the same as type '"def"'.
 
-  432 |   expect<void>().type.toBe<never>(); // fail
-  433 |   expect<void>().type.toBe<'abc'>(); // fail
-  434 |   expect<void>().type.toBe<'def'>(); // fail
+  464 |   expect<void>().type.toBe<never>(); // fail
+  465 |   expect<void>().type.toBe<'abc'>(); // fail
+  466 |   expect<void>().type.toBe<'def'>(); // fail
       |                            ~~~~~
-  435 |   expect<void>().type.toBe<123>(); // fail
-  436 |   expect<void>().type.toBe<456>(); // fail
-  437 |   expect<void>().type.toBe<887n>(); // fail
+  467 |   expect<void>().type.toBe<123>(); // fail
+  468 |   expect<void>().type.toBe<456>(); // fail
+  469 |   expect<void>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:434:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:466:28 ❭ is void?
 
 Error: Type 'void' is not the same as type '123'.
 
-  433 |   expect<void>().type.toBe<'abc'>(); // fail
-  434 |   expect<void>().type.toBe<'def'>(); // fail
-  435 |   expect<void>().type.toBe<123>(); // fail
+  465 |   expect<void>().type.toBe<'abc'>(); // fail
+  466 |   expect<void>().type.toBe<'def'>(); // fail
+  467 |   expect<void>().type.toBe<123>(); // fail
       |                            ~~~
-  436 |   expect<void>().type.toBe<456>(); // fail
-  437 |   expect<void>().type.toBe<887n>(); // fail
-  438 |   expect<void>().type.toBe<998n>(); // fail
+  468 |   expect<void>().type.toBe<456>(); // fail
+  469 |   expect<void>().type.toBe<887n>(); // fail
+  470 |   expect<void>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:435:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:467:28 ❭ is void?
 
 Error: Type 'void' is not the same as type '456'.
 
-  434 |   expect<void>().type.toBe<'def'>(); // fail
-  435 |   expect<void>().type.toBe<123>(); // fail
-  436 |   expect<void>().type.toBe<456>(); // fail
+  466 |   expect<void>().type.toBe<'def'>(); // fail
+  467 |   expect<void>().type.toBe<123>(); // fail
+  468 |   expect<void>().type.toBe<456>(); // fail
       |                            ~~~
-  437 |   expect<void>().type.toBe<887n>(); // fail
-  438 |   expect<void>().type.toBe<998n>(); // fail
-  439 |   expect<void>().type.toBe<true>(); // fail
+  469 |   expect<void>().type.toBe<887n>(); // fail
+  470 |   expect<void>().type.toBe<998n>(); // fail
+  471 |   expect<void>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:436:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:468:28 ❭ is void?
 
 Error: Type 'void' is not the same as type '887n'.
 
-  435 |   expect<void>().type.toBe<123>(); // fail
-  436 |   expect<void>().type.toBe<456>(); // fail
-  437 |   expect<void>().type.toBe<887n>(); // fail
+  467 |   expect<void>().type.toBe<123>(); // fail
+  468 |   expect<void>().type.toBe<456>(); // fail
+  469 |   expect<void>().type.toBe<887n>(); // fail
       |                            ~~~~
-  438 |   expect<void>().type.toBe<998n>(); // fail
-  439 |   expect<void>().type.toBe<true>(); // fail
-  440 |   expect<void>().type.toBe<false>(); // fail
+  470 |   expect<void>().type.toBe<998n>(); // fail
+  471 |   expect<void>().type.toBe<true>(); // fail
+  472 |   expect<void>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:437:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:469:28 ❭ is void?
 
 Error: Type 'void' is not the same as type '998n'.
 
-  436 |   expect<void>().type.toBe<456>(); // fail
-  437 |   expect<void>().type.toBe<887n>(); // fail
-  438 |   expect<void>().type.toBe<998n>(); // fail
+  468 |   expect<void>().type.toBe<456>(); // fail
+  469 |   expect<void>().type.toBe<887n>(); // fail
+  470 |   expect<void>().type.toBe<998n>(); // fail
       |                            ~~~~
-  439 |   expect<void>().type.toBe<true>(); // fail
-  440 |   expect<void>().type.toBe<false>(); // fail
-  441 |   expect<void>().type.toBe<Array<string>>(); // fail
+  471 |   expect<void>().type.toBe<true>(); // fail
+  472 |   expect<void>().type.toBe<false>(); // fail
+  473 |   expect<void>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:438:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:470:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'true'.
 
-  437 |   expect<void>().type.toBe<887n>(); // fail
-  438 |   expect<void>().type.toBe<998n>(); // fail
-  439 |   expect<void>().type.toBe<true>(); // fail
+  469 |   expect<void>().type.toBe<887n>(); // fail
+  470 |   expect<void>().type.toBe<998n>(); // fail
+  471 |   expect<void>().type.toBe<true>(); // fail
       |                            ~~~~
-  440 |   expect<void>().type.toBe<false>(); // fail
-  441 |   expect<void>().type.toBe<Array<string>>(); // fail
-  442 |   expect<void>().type.toBe<number[]>(); // fail
+  472 |   expect<void>().type.toBe<false>(); // fail
+  473 |   expect<void>().type.toBe<Array<string>>(); // fail
+  474 |   expect<void>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:439:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:471:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'false'.
 
-  438 |   expect<void>().type.toBe<998n>(); // fail
-  439 |   expect<void>().type.toBe<true>(); // fail
-  440 |   expect<void>().type.toBe<false>(); // fail
+  470 |   expect<void>().type.toBe<998n>(); // fail
+  471 |   expect<void>().type.toBe<true>(); // fail
+  472 |   expect<void>().type.toBe<false>(); // fail
       |                            ~~~~~
-  441 |   expect<void>().type.toBe<Array<string>>(); // fail
-  442 |   expect<void>().type.toBe<number[]>(); // fail
-  443 | });
+  473 |   expect<void>().type.toBe<Array<string>>(); // fail
+  474 |   expect<void>().type.toBe<number[]>(); // fail
+  475 |   expect<void>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:440:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:472:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'string[]'.
 
-  439 |   expect<void>().type.toBe<true>(); // fail
-  440 |   expect<void>().type.toBe<false>(); // fail
-  441 |   expect<void>().type.toBe<Array<string>>(); // fail
+  471 |   expect<void>().type.toBe<true>(); // fail
+  472 |   expect<void>().type.toBe<false>(); // fail
+  473 |   expect<void>().type.toBe<Array<string>>(); // fail
       |                            ~~~~~~~~~~~~~
-  442 |   expect<void>().type.toBe<number[]>(); // fail
-  443 | });
-  444 | 
+  474 |   expect<void>().type.toBe<number[]>(); // fail
+  475 |   expect<void>().type.toBe<string | number>(); // fail
+  476 |   expect<void>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:441:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:473:28 ❭ is void?
 
 Error: Type 'void' is not the same as type 'number[]'.
 
-  440 |   expect<void>().type.toBe<false>(); // fail
-  441 |   expect<void>().type.toBe<Array<string>>(); // fail
-  442 |   expect<void>().type.toBe<number[]>(); // fail
+  472 |   expect<void>().type.toBe<false>(); // fail
+  473 |   expect<void>().type.toBe<Array<string>>(); // fail
+  474 |   expect<void>().type.toBe<number[]>(); // fail
       |                            ~~~~~~~~
-  443 | });
-  444 | 
-  445 | test("is NOT void?", () => {
+  475 |   expect<void>().type.toBe<string | number>(); // fail
+  476 |   expect<void>().type.toBe<string | Array<string>>(); // fail
+  477 | });
 
-        at ./__typetests__/structure.tst.ts:442:28 ❭ is void?
+        at ./__typetests__/structure.tst.ts:474:28 ❭ is void?
+
+Error: Type 'void' is not the same as type 'string | number'.
+
+  473 |   expect<void>().type.toBe<Array<string>>(); // fail
+  474 |   expect<void>().type.toBe<number[]>(); // fail
+  475 |   expect<void>().type.toBe<string | number>(); // fail
+      |                            ~~~~~~~~~~~~~~~
+  476 |   expect<void>().type.toBe<string | Array<string>>(); // fail
+  477 | });
+  478 | 
+
+        at ./__typetests__/structure.tst.ts:475:28 ❭ is void?
+
+Error: Type 'void' is not the same as type 'string | string[]'.
+
+  474 |   expect<void>().type.toBe<number[]>(); // fail
+  475 |   expect<void>().type.toBe<string | number>(); // fail
+  476 |   expect<void>().type.toBe<string | Array<string>>(); // fail
+      |                            ~~~~~~~~~~~~~~~~~~~~~~
+  477 | });
+  478 | 
+  479 | test("is NOT void?", () => {
+
+        at ./__typetests__/structure.tst.ts:476:28 ❭ is void?
 
 Error: Type 'void' is the same as type 'void'.
 
-  466 |   expect<void>().type.not.toBe<number[]>();
-  467 | 
-  468 |   expect<void>().type.not.toBe<void>(); // fail
+  502 |   expect<void>().type.not.toBe<string | Array<string>>();
+  503 | 
+  504 |   expect<void>().type.not.toBe<void>(); // fail
       |                                ~~~~
-  469 | });
-  470 | 
-  471 | test("is undefined?", () => {
+  505 | });
+  506 | 
+  507 | test("is undefined?", () => {
 
-        at ./__typetests__/structure.tst.ts:468:32 ❭ is NOT void?
+        at ./__typetests__/structure.tst.ts:504:32 ❭ is NOT void?
 
 Error: Type 'undefined' is not the same as type 'any'.
 
-  472 |   expect<undefined>().type.toBe<undefined>();
-  473 | 
-  474 |   expect<undefined>().type.toBe<any>(); // fail
+  508 |   expect<undefined>().type.toBe<undefined>();
+  509 | 
+  510 |   expect<undefined>().type.toBe<any>(); // fail
       |                                 ~~~
-  475 |   expect<undefined>().type.toBe<unknown>(); // fail
-  476 |   expect<undefined>().type.toBe<string>(); // fail
-  477 |   expect<undefined>().type.toBe<number>(); // fail
+  511 |   expect<undefined>().type.toBe<unknown>(); // fail
+  512 |   expect<undefined>().type.toBe<string>(); // fail
+  513 |   expect<undefined>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:474:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:510:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'unknown'.
 
-  473 | 
-  474 |   expect<undefined>().type.toBe<any>(); // fail
-  475 |   expect<undefined>().type.toBe<unknown>(); // fail
+  509 | 
+  510 |   expect<undefined>().type.toBe<any>(); // fail
+  511 |   expect<undefined>().type.toBe<unknown>(); // fail
       |                                 ~~~~~~~
-  476 |   expect<undefined>().type.toBe<string>(); // fail
-  477 |   expect<undefined>().type.toBe<number>(); // fail
-  478 |   expect<undefined>().type.toBe<bigint>(); // fail
+  512 |   expect<undefined>().type.toBe<string>(); // fail
+  513 |   expect<undefined>().type.toBe<number>(); // fail
+  514 |   expect<undefined>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:475:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:511:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'string'.
 
-  474 |   expect<undefined>().type.toBe<any>(); // fail
-  475 |   expect<undefined>().type.toBe<unknown>(); // fail
-  476 |   expect<undefined>().type.toBe<string>(); // fail
+  510 |   expect<undefined>().type.toBe<any>(); // fail
+  511 |   expect<undefined>().type.toBe<unknown>(); // fail
+  512 |   expect<undefined>().type.toBe<string>(); // fail
       |                                 ~~~~~~
-  477 |   expect<undefined>().type.toBe<number>(); // fail
-  478 |   expect<undefined>().type.toBe<bigint>(); // fail
-  479 |   expect<undefined>().type.toBe<boolean>(); // fail
+  513 |   expect<undefined>().type.toBe<number>(); // fail
+  514 |   expect<undefined>().type.toBe<bigint>(); // fail
+  515 |   expect<undefined>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:476:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:512:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'number'.
 
-  475 |   expect<undefined>().type.toBe<unknown>(); // fail
-  476 |   expect<undefined>().type.toBe<string>(); // fail
-  477 |   expect<undefined>().type.toBe<number>(); // fail
+  511 |   expect<undefined>().type.toBe<unknown>(); // fail
+  512 |   expect<undefined>().type.toBe<string>(); // fail
+  513 |   expect<undefined>().type.toBe<number>(); // fail
       |                                 ~~~~~~
-  478 |   expect<undefined>().type.toBe<bigint>(); // fail
-  479 |   expect<undefined>().type.toBe<boolean>(); // fail
-  480 |   expect<undefined>().type.toBe<symbol>(); // fail
+  514 |   expect<undefined>().type.toBe<bigint>(); // fail
+  515 |   expect<undefined>().type.toBe<boolean>(); // fail
+  516 |   expect<undefined>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:477:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:513:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'bigint'.
 
-  476 |   expect<undefined>().type.toBe<string>(); // fail
-  477 |   expect<undefined>().type.toBe<number>(); // fail
-  478 |   expect<undefined>().type.toBe<bigint>(); // fail
+  512 |   expect<undefined>().type.toBe<string>(); // fail
+  513 |   expect<undefined>().type.toBe<number>(); // fail
+  514 |   expect<undefined>().type.toBe<bigint>(); // fail
       |                                 ~~~~~~
-  479 |   expect<undefined>().type.toBe<boolean>(); // fail
-  480 |   expect<undefined>().type.toBe<symbol>(); // fail
-  481 |   expect<undefined>().type.toBe<object>(); // fail
+  515 |   expect<undefined>().type.toBe<boolean>(); // fail
+  516 |   expect<undefined>().type.toBe<symbol>(); // fail
+  517 |   expect<undefined>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:478:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:514:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'boolean'.
 
-  477 |   expect<undefined>().type.toBe<number>(); // fail
-  478 |   expect<undefined>().type.toBe<bigint>(); // fail
-  479 |   expect<undefined>().type.toBe<boolean>(); // fail
+  513 |   expect<undefined>().type.toBe<number>(); // fail
+  514 |   expect<undefined>().type.toBe<bigint>(); // fail
+  515 |   expect<undefined>().type.toBe<boolean>(); // fail
       |                                 ~~~~~~~
-  480 |   expect<undefined>().type.toBe<symbol>(); // fail
-  481 |   expect<undefined>().type.toBe<object>(); // fail
-  482 |   expect<undefined>().type.toBe<void>(); // fail
+  516 |   expect<undefined>().type.toBe<symbol>(); // fail
+  517 |   expect<undefined>().type.toBe<object>(); // fail
+  518 |   expect<undefined>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:479:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:515:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'symbol'.
 
-  478 |   expect<undefined>().type.toBe<bigint>(); // fail
-  479 |   expect<undefined>().type.toBe<boolean>(); // fail
-  480 |   expect<undefined>().type.toBe<symbol>(); // fail
+  514 |   expect<undefined>().type.toBe<bigint>(); // fail
+  515 |   expect<undefined>().type.toBe<boolean>(); // fail
+  516 |   expect<undefined>().type.toBe<symbol>(); // fail
       |                                 ~~~~~~
-  481 |   expect<undefined>().type.toBe<object>(); // fail
-  482 |   expect<undefined>().type.toBe<void>(); // fail
-  483 |   expect<undefined>().type.toBe<null>(); // fail
+  517 |   expect<undefined>().type.toBe<object>(); // fail
+  518 |   expect<undefined>().type.toBe<void>(); // fail
+  519 |   expect<undefined>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:480:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:516:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'object'.
 
-  479 |   expect<undefined>().type.toBe<boolean>(); // fail
-  480 |   expect<undefined>().type.toBe<symbol>(); // fail
-  481 |   expect<undefined>().type.toBe<object>(); // fail
+  515 |   expect<undefined>().type.toBe<boolean>(); // fail
+  516 |   expect<undefined>().type.toBe<symbol>(); // fail
+  517 |   expect<undefined>().type.toBe<object>(); // fail
       |                                 ~~~~~~
-  482 |   expect<undefined>().type.toBe<void>(); // fail
-  483 |   expect<undefined>().type.toBe<null>(); // fail
-  484 |   expect<undefined>().type.toBe<never>(); // fail
+  518 |   expect<undefined>().type.toBe<void>(); // fail
+  519 |   expect<undefined>().type.toBe<null>(); // fail
+  520 |   expect<undefined>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:481:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:517:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'void'.
 
-  480 |   expect<undefined>().type.toBe<symbol>(); // fail
-  481 |   expect<undefined>().type.toBe<object>(); // fail
-  482 |   expect<undefined>().type.toBe<void>(); // fail
+  516 |   expect<undefined>().type.toBe<symbol>(); // fail
+  517 |   expect<undefined>().type.toBe<object>(); // fail
+  518 |   expect<undefined>().type.toBe<void>(); // fail
       |                                 ~~~~
-  483 |   expect<undefined>().type.toBe<null>(); // fail
-  484 |   expect<undefined>().type.toBe<never>(); // fail
-  485 |   expect<undefined>().type.toBe<'abc'>(); // fail
+  519 |   expect<undefined>().type.toBe<null>(); // fail
+  520 |   expect<undefined>().type.toBe<never>(); // fail
+  521 |   expect<undefined>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:482:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:518:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'null'.
 
-  481 |   expect<undefined>().type.toBe<object>(); // fail
-  482 |   expect<undefined>().type.toBe<void>(); // fail
-  483 |   expect<undefined>().type.toBe<null>(); // fail
+  517 |   expect<undefined>().type.toBe<object>(); // fail
+  518 |   expect<undefined>().type.toBe<void>(); // fail
+  519 |   expect<undefined>().type.toBe<null>(); // fail
       |                                 ~~~~
-  484 |   expect<undefined>().type.toBe<never>(); // fail
-  485 |   expect<undefined>().type.toBe<'abc'>(); // fail
-  486 |   expect<undefined>().type.toBe<'def'>(); // fail
+  520 |   expect<undefined>().type.toBe<never>(); // fail
+  521 |   expect<undefined>().type.toBe<'abc'>(); // fail
+  522 |   expect<undefined>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:483:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:519:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'never'.
 
-  482 |   expect<undefined>().type.toBe<void>(); // fail
-  483 |   expect<undefined>().type.toBe<null>(); // fail
-  484 |   expect<undefined>().type.toBe<never>(); // fail
+  518 |   expect<undefined>().type.toBe<void>(); // fail
+  519 |   expect<undefined>().type.toBe<null>(); // fail
+  520 |   expect<undefined>().type.toBe<never>(); // fail
       |                                 ~~~~~
-  485 |   expect<undefined>().type.toBe<'abc'>(); // fail
-  486 |   expect<undefined>().type.toBe<'def'>(); // fail
-  487 |   expect<undefined>().type.toBe<123>(); // fail
+  521 |   expect<undefined>().type.toBe<'abc'>(); // fail
+  522 |   expect<undefined>().type.toBe<'def'>(); // fail
+  523 |   expect<undefined>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:484:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:520:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type '"abc"'.
 
-  483 |   expect<undefined>().type.toBe<null>(); // fail
-  484 |   expect<undefined>().type.toBe<never>(); // fail
-  485 |   expect<undefined>().type.toBe<'abc'>(); // fail
+  519 |   expect<undefined>().type.toBe<null>(); // fail
+  520 |   expect<undefined>().type.toBe<never>(); // fail
+  521 |   expect<undefined>().type.toBe<'abc'>(); // fail
       |                                 ~~~~~
-  486 |   expect<undefined>().type.toBe<'def'>(); // fail
-  487 |   expect<undefined>().type.toBe<123>(); // fail
-  488 |   expect<undefined>().type.toBe<456>(); // fail
+  522 |   expect<undefined>().type.toBe<'def'>(); // fail
+  523 |   expect<undefined>().type.toBe<123>(); // fail
+  524 |   expect<undefined>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:485:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:521:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type '"def"'.
 
-  484 |   expect<undefined>().type.toBe<never>(); // fail
-  485 |   expect<undefined>().type.toBe<'abc'>(); // fail
-  486 |   expect<undefined>().type.toBe<'def'>(); // fail
+  520 |   expect<undefined>().type.toBe<never>(); // fail
+  521 |   expect<undefined>().type.toBe<'abc'>(); // fail
+  522 |   expect<undefined>().type.toBe<'def'>(); // fail
       |                                 ~~~~~
-  487 |   expect<undefined>().type.toBe<123>(); // fail
-  488 |   expect<undefined>().type.toBe<456>(); // fail
-  489 |   expect<undefined>().type.toBe<887n>(); // fail
+  523 |   expect<undefined>().type.toBe<123>(); // fail
+  524 |   expect<undefined>().type.toBe<456>(); // fail
+  525 |   expect<undefined>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:486:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:522:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type '123'.
 
-  485 |   expect<undefined>().type.toBe<'abc'>(); // fail
-  486 |   expect<undefined>().type.toBe<'def'>(); // fail
-  487 |   expect<undefined>().type.toBe<123>(); // fail
+  521 |   expect<undefined>().type.toBe<'abc'>(); // fail
+  522 |   expect<undefined>().type.toBe<'def'>(); // fail
+  523 |   expect<undefined>().type.toBe<123>(); // fail
       |                                 ~~~
-  488 |   expect<undefined>().type.toBe<456>(); // fail
-  489 |   expect<undefined>().type.toBe<887n>(); // fail
-  490 |   expect<undefined>().type.toBe<998n>(); // fail
+  524 |   expect<undefined>().type.toBe<456>(); // fail
+  525 |   expect<undefined>().type.toBe<887n>(); // fail
+  526 |   expect<undefined>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:487:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:523:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type '456'.
 
-  486 |   expect<undefined>().type.toBe<'def'>(); // fail
-  487 |   expect<undefined>().type.toBe<123>(); // fail
-  488 |   expect<undefined>().type.toBe<456>(); // fail
+  522 |   expect<undefined>().type.toBe<'def'>(); // fail
+  523 |   expect<undefined>().type.toBe<123>(); // fail
+  524 |   expect<undefined>().type.toBe<456>(); // fail
       |                                 ~~~
-  489 |   expect<undefined>().type.toBe<887n>(); // fail
-  490 |   expect<undefined>().type.toBe<998n>(); // fail
-  491 |   expect<undefined>().type.toBe<true>(); // fail
+  525 |   expect<undefined>().type.toBe<887n>(); // fail
+  526 |   expect<undefined>().type.toBe<998n>(); // fail
+  527 |   expect<undefined>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:488:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:524:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type '887n'.
 
-  487 |   expect<undefined>().type.toBe<123>(); // fail
-  488 |   expect<undefined>().type.toBe<456>(); // fail
-  489 |   expect<undefined>().type.toBe<887n>(); // fail
+  523 |   expect<undefined>().type.toBe<123>(); // fail
+  524 |   expect<undefined>().type.toBe<456>(); // fail
+  525 |   expect<undefined>().type.toBe<887n>(); // fail
       |                                 ~~~~
-  490 |   expect<undefined>().type.toBe<998n>(); // fail
-  491 |   expect<undefined>().type.toBe<true>(); // fail
-  492 |   expect<undefined>().type.toBe<false>(); // fail
+  526 |   expect<undefined>().type.toBe<998n>(); // fail
+  527 |   expect<undefined>().type.toBe<true>(); // fail
+  528 |   expect<undefined>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:489:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:525:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type '998n'.
 
-  488 |   expect<undefined>().type.toBe<456>(); // fail
-  489 |   expect<undefined>().type.toBe<887n>(); // fail
-  490 |   expect<undefined>().type.toBe<998n>(); // fail
+  524 |   expect<undefined>().type.toBe<456>(); // fail
+  525 |   expect<undefined>().type.toBe<887n>(); // fail
+  526 |   expect<undefined>().type.toBe<998n>(); // fail
       |                                 ~~~~
-  491 |   expect<undefined>().type.toBe<true>(); // fail
-  492 |   expect<undefined>().type.toBe<false>(); // fail
-  493 |   expect<undefined>().type.toBe<Array<string>>(); // fail
+  527 |   expect<undefined>().type.toBe<true>(); // fail
+  528 |   expect<undefined>().type.toBe<false>(); // fail
+  529 |   expect<undefined>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:490:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:526:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'true'.
 
-  489 |   expect<undefined>().type.toBe<887n>(); // fail
-  490 |   expect<undefined>().type.toBe<998n>(); // fail
-  491 |   expect<undefined>().type.toBe<true>(); // fail
+  525 |   expect<undefined>().type.toBe<887n>(); // fail
+  526 |   expect<undefined>().type.toBe<998n>(); // fail
+  527 |   expect<undefined>().type.toBe<true>(); // fail
       |                                 ~~~~
-  492 |   expect<undefined>().type.toBe<false>(); // fail
-  493 |   expect<undefined>().type.toBe<Array<string>>(); // fail
-  494 |   expect<undefined>().type.toBe<number[]>(); // fail
+  528 |   expect<undefined>().type.toBe<false>(); // fail
+  529 |   expect<undefined>().type.toBe<Array<string>>(); // fail
+  530 |   expect<undefined>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:491:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:527:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'false'.
 
-  490 |   expect<undefined>().type.toBe<998n>(); // fail
-  491 |   expect<undefined>().type.toBe<true>(); // fail
-  492 |   expect<undefined>().type.toBe<false>(); // fail
+  526 |   expect<undefined>().type.toBe<998n>(); // fail
+  527 |   expect<undefined>().type.toBe<true>(); // fail
+  528 |   expect<undefined>().type.toBe<false>(); // fail
       |                                 ~~~~~
-  493 |   expect<undefined>().type.toBe<Array<string>>(); // fail
-  494 |   expect<undefined>().type.toBe<number[]>(); // fail
-  495 | });
+  529 |   expect<undefined>().type.toBe<Array<string>>(); // fail
+  530 |   expect<undefined>().type.toBe<number[]>(); // fail
+  531 |   expect<undefined>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:492:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:528:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'string[]'.
 
-  491 |   expect<undefined>().type.toBe<true>(); // fail
-  492 |   expect<undefined>().type.toBe<false>(); // fail
-  493 |   expect<undefined>().type.toBe<Array<string>>(); // fail
+  527 |   expect<undefined>().type.toBe<true>(); // fail
+  528 |   expect<undefined>().type.toBe<false>(); // fail
+  529 |   expect<undefined>().type.toBe<Array<string>>(); // fail
       |                                 ~~~~~~~~~~~~~
-  494 |   expect<undefined>().type.toBe<number[]>(); // fail
-  495 | });
-  496 | 
+  530 |   expect<undefined>().type.toBe<number[]>(); // fail
+  531 |   expect<undefined>().type.toBe<string | number>(); // fail
+  532 |   expect<undefined>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:493:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:529:33 ❭ is undefined?
 
 Error: Type 'undefined' is not the same as type 'number[]'.
 
-  492 |   expect<undefined>().type.toBe<false>(); // fail
-  493 |   expect<undefined>().type.toBe<Array<string>>(); // fail
-  494 |   expect<undefined>().type.toBe<number[]>(); // fail
+  528 |   expect<undefined>().type.toBe<false>(); // fail
+  529 |   expect<undefined>().type.toBe<Array<string>>(); // fail
+  530 |   expect<undefined>().type.toBe<number[]>(); // fail
       |                                 ~~~~~~~~
-  495 | });
-  496 | 
-  497 | test("is NOT undefined?", () => {
+  531 |   expect<undefined>().type.toBe<string | number>(); // fail
+  532 |   expect<undefined>().type.toBe<string | Array<string>>(); // fail
+  533 | });
 
-        at ./__typetests__/structure.tst.ts:494:33 ❭ is undefined?
+        at ./__typetests__/structure.tst.ts:530:33 ❭ is undefined?
+
+Error: Type 'undefined' is not the same as type 'string | number'.
+
+  529 |   expect<undefined>().type.toBe<Array<string>>(); // fail
+  530 |   expect<undefined>().type.toBe<number[]>(); // fail
+  531 |   expect<undefined>().type.toBe<string | number>(); // fail
+      |                                 ~~~~~~~~~~~~~~~
+  532 |   expect<undefined>().type.toBe<string | Array<string>>(); // fail
+  533 | });
+  534 | 
+
+        at ./__typetests__/structure.tst.ts:531:33 ❭ is undefined?
+
+Error: Type 'undefined' is not the same as type 'string | string[]'.
+
+  530 |   expect<undefined>().type.toBe<number[]>(); // fail
+  531 |   expect<undefined>().type.toBe<string | number>(); // fail
+  532 |   expect<undefined>().type.toBe<string | Array<string>>(); // fail
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~
+  533 | });
+  534 | 
+  535 | test("is NOT undefined?", () => {
+
+        at ./__typetests__/structure.tst.ts:532:33 ❭ is undefined?
 
 Error: Type 'undefined' is the same as type 'undefined'.
 
-  518 |   expect<undefined>().type.not.toBe<number[]>();
-  519 | 
-  520 |   expect<undefined>().type.not.toBe<undefined>(); // fail
+  558 |   expect<undefined>().type.not.toBe<string | Array<string>>();
+  559 | 
+  560 |   expect<undefined>().type.not.toBe<undefined>(); // fail
       |                                     ~~~~~~~~~
-  521 | });
-  522 | 
-  523 | test("is null?", () => {
+  561 | });
+  562 | 
+  563 | test("is null?", () => {
 
-        at ./__typetests__/structure.tst.ts:520:37 ❭ is NOT undefined?
+        at ./__typetests__/structure.tst.ts:560:37 ❭ is NOT undefined?
 
 Error: Type 'null' is not the same as type 'any'.
 
-  524 |   expect<null>().type.toBe<null>();
-  525 | 
-  526 |   expect<null>().type.toBe<any>(); // fail
+  564 |   expect<null>().type.toBe<null>();
+  565 | 
+  566 |   expect<null>().type.toBe<any>(); // fail
       |                            ~~~
-  527 |   expect<null>().type.toBe<unknown>(); // fail
-  528 |   expect<null>().type.toBe<string>(); // fail
-  529 |   expect<null>().type.toBe<number>(); // fail
+  567 |   expect<null>().type.toBe<unknown>(); // fail
+  568 |   expect<null>().type.toBe<string>(); // fail
+  569 |   expect<null>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:526:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:566:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'unknown'.
 
-  525 | 
-  526 |   expect<null>().type.toBe<any>(); // fail
-  527 |   expect<null>().type.toBe<unknown>(); // fail
+  565 | 
+  566 |   expect<null>().type.toBe<any>(); // fail
+  567 |   expect<null>().type.toBe<unknown>(); // fail
       |                            ~~~~~~~
-  528 |   expect<null>().type.toBe<string>(); // fail
-  529 |   expect<null>().type.toBe<number>(); // fail
-  530 |   expect<null>().type.toBe<bigint>(); // fail
+  568 |   expect<null>().type.toBe<string>(); // fail
+  569 |   expect<null>().type.toBe<number>(); // fail
+  570 |   expect<null>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:527:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:567:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'string'.
 
-  526 |   expect<null>().type.toBe<any>(); // fail
-  527 |   expect<null>().type.toBe<unknown>(); // fail
-  528 |   expect<null>().type.toBe<string>(); // fail
+  566 |   expect<null>().type.toBe<any>(); // fail
+  567 |   expect<null>().type.toBe<unknown>(); // fail
+  568 |   expect<null>().type.toBe<string>(); // fail
       |                            ~~~~~~
-  529 |   expect<null>().type.toBe<number>(); // fail
-  530 |   expect<null>().type.toBe<bigint>(); // fail
-  531 |   expect<null>().type.toBe<boolean>(); // fail
+  569 |   expect<null>().type.toBe<number>(); // fail
+  570 |   expect<null>().type.toBe<bigint>(); // fail
+  571 |   expect<null>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:528:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:568:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'number'.
 
-  527 |   expect<null>().type.toBe<unknown>(); // fail
-  528 |   expect<null>().type.toBe<string>(); // fail
-  529 |   expect<null>().type.toBe<number>(); // fail
+  567 |   expect<null>().type.toBe<unknown>(); // fail
+  568 |   expect<null>().type.toBe<string>(); // fail
+  569 |   expect<null>().type.toBe<number>(); // fail
       |                            ~~~~~~
-  530 |   expect<null>().type.toBe<bigint>(); // fail
-  531 |   expect<null>().type.toBe<boolean>(); // fail
-  532 |   expect<null>().type.toBe<symbol>(); // fail
+  570 |   expect<null>().type.toBe<bigint>(); // fail
+  571 |   expect<null>().type.toBe<boolean>(); // fail
+  572 |   expect<null>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:529:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:569:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'bigint'.
 
-  528 |   expect<null>().type.toBe<string>(); // fail
-  529 |   expect<null>().type.toBe<number>(); // fail
-  530 |   expect<null>().type.toBe<bigint>(); // fail
+  568 |   expect<null>().type.toBe<string>(); // fail
+  569 |   expect<null>().type.toBe<number>(); // fail
+  570 |   expect<null>().type.toBe<bigint>(); // fail
       |                            ~~~~~~
-  531 |   expect<null>().type.toBe<boolean>(); // fail
-  532 |   expect<null>().type.toBe<symbol>(); // fail
-  533 |   expect<null>().type.toBe<object>(); // fail
+  571 |   expect<null>().type.toBe<boolean>(); // fail
+  572 |   expect<null>().type.toBe<symbol>(); // fail
+  573 |   expect<null>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:530:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:570:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'boolean'.
 
-  529 |   expect<null>().type.toBe<number>(); // fail
-  530 |   expect<null>().type.toBe<bigint>(); // fail
-  531 |   expect<null>().type.toBe<boolean>(); // fail
+  569 |   expect<null>().type.toBe<number>(); // fail
+  570 |   expect<null>().type.toBe<bigint>(); // fail
+  571 |   expect<null>().type.toBe<boolean>(); // fail
       |                            ~~~~~~~
-  532 |   expect<null>().type.toBe<symbol>(); // fail
-  533 |   expect<null>().type.toBe<object>(); // fail
-  534 |   expect<null>().type.toBe<void>(); // fail
+  572 |   expect<null>().type.toBe<symbol>(); // fail
+  573 |   expect<null>().type.toBe<object>(); // fail
+  574 |   expect<null>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:531:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:571:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'symbol'.
 
-  530 |   expect<null>().type.toBe<bigint>(); // fail
-  531 |   expect<null>().type.toBe<boolean>(); // fail
-  532 |   expect<null>().type.toBe<symbol>(); // fail
+  570 |   expect<null>().type.toBe<bigint>(); // fail
+  571 |   expect<null>().type.toBe<boolean>(); // fail
+  572 |   expect<null>().type.toBe<symbol>(); // fail
       |                            ~~~~~~
-  533 |   expect<null>().type.toBe<object>(); // fail
-  534 |   expect<null>().type.toBe<void>(); // fail
-  535 |   expect<null>().type.toBe<undefined>(); // fail
+  573 |   expect<null>().type.toBe<object>(); // fail
+  574 |   expect<null>().type.toBe<void>(); // fail
+  575 |   expect<null>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:532:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:572:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'object'.
 
-  531 |   expect<null>().type.toBe<boolean>(); // fail
-  532 |   expect<null>().type.toBe<symbol>(); // fail
-  533 |   expect<null>().type.toBe<object>(); // fail
+  571 |   expect<null>().type.toBe<boolean>(); // fail
+  572 |   expect<null>().type.toBe<symbol>(); // fail
+  573 |   expect<null>().type.toBe<object>(); // fail
       |                            ~~~~~~
-  534 |   expect<null>().type.toBe<void>(); // fail
-  535 |   expect<null>().type.toBe<undefined>(); // fail
-  536 |   expect<null>().type.toBe<never>(); // fail
+  574 |   expect<null>().type.toBe<void>(); // fail
+  575 |   expect<null>().type.toBe<undefined>(); // fail
+  576 |   expect<null>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:533:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:573:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'void'.
 
-  532 |   expect<null>().type.toBe<symbol>(); // fail
-  533 |   expect<null>().type.toBe<object>(); // fail
-  534 |   expect<null>().type.toBe<void>(); // fail
+  572 |   expect<null>().type.toBe<symbol>(); // fail
+  573 |   expect<null>().type.toBe<object>(); // fail
+  574 |   expect<null>().type.toBe<void>(); // fail
       |                            ~~~~
-  535 |   expect<null>().type.toBe<undefined>(); // fail
-  536 |   expect<null>().type.toBe<never>(); // fail
-  537 |   expect<null>().type.toBe<'abc'>(); // fail
+  575 |   expect<null>().type.toBe<undefined>(); // fail
+  576 |   expect<null>().type.toBe<never>(); // fail
+  577 |   expect<null>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:534:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:574:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'undefined'.
 
-  533 |   expect<null>().type.toBe<object>(); // fail
-  534 |   expect<null>().type.toBe<void>(); // fail
-  535 |   expect<null>().type.toBe<undefined>(); // fail
+  573 |   expect<null>().type.toBe<object>(); // fail
+  574 |   expect<null>().type.toBe<void>(); // fail
+  575 |   expect<null>().type.toBe<undefined>(); // fail
       |                            ~~~~~~~~~
-  536 |   expect<null>().type.toBe<never>(); // fail
-  537 |   expect<null>().type.toBe<'abc'>(); // fail
-  538 |   expect<null>().type.toBe<'def'>(); // fail
+  576 |   expect<null>().type.toBe<never>(); // fail
+  577 |   expect<null>().type.toBe<'abc'>(); // fail
+  578 |   expect<null>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:535:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:575:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'never'.
 
-  534 |   expect<null>().type.toBe<void>(); // fail
-  535 |   expect<null>().type.toBe<undefined>(); // fail
-  536 |   expect<null>().type.toBe<never>(); // fail
+  574 |   expect<null>().type.toBe<void>(); // fail
+  575 |   expect<null>().type.toBe<undefined>(); // fail
+  576 |   expect<null>().type.toBe<never>(); // fail
       |                            ~~~~~
-  537 |   expect<null>().type.toBe<'abc'>(); // fail
-  538 |   expect<null>().type.toBe<'def'>(); // fail
-  539 |   expect<null>().type.toBe<123>(); // fail
+  577 |   expect<null>().type.toBe<'abc'>(); // fail
+  578 |   expect<null>().type.toBe<'def'>(); // fail
+  579 |   expect<null>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:536:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:576:28 ❭ is null?
 
 Error: Type 'null' is not the same as type '"abc"'.
 
-  535 |   expect<null>().type.toBe<undefined>(); // fail
-  536 |   expect<null>().type.toBe<never>(); // fail
-  537 |   expect<null>().type.toBe<'abc'>(); // fail
+  575 |   expect<null>().type.toBe<undefined>(); // fail
+  576 |   expect<null>().type.toBe<never>(); // fail
+  577 |   expect<null>().type.toBe<'abc'>(); // fail
       |                            ~~~~~
-  538 |   expect<null>().type.toBe<'def'>(); // fail
-  539 |   expect<null>().type.toBe<123>(); // fail
-  540 |   expect<null>().type.toBe<456>(); // fail
+  578 |   expect<null>().type.toBe<'def'>(); // fail
+  579 |   expect<null>().type.toBe<123>(); // fail
+  580 |   expect<null>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:537:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:577:28 ❭ is null?
 
 Error: Type 'null' is not the same as type '"def"'.
 
-  536 |   expect<null>().type.toBe<never>(); // fail
-  537 |   expect<null>().type.toBe<'abc'>(); // fail
-  538 |   expect<null>().type.toBe<'def'>(); // fail
+  576 |   expect<null>().type.toBe<never>(); // fail
+  577 |   expect<null>().type.toBe<'abc'>(); // fail
+  578 |   expect<null>().type.toBe<'def'>(); // fail
       |                            ~~~~~
-  539 |   expect<null>().type.toBe<123>(); // fail
-  540 |   expect<null>().type.toBe<456>(); // fail
-  541 |   expect<null>().type.toBe<887n>(); // fail
+  579 |   expect<null>().type.toBe<123>(); // fail
+  580 |   expect<null>().type.toBe<456>(); // fail
+  581 |   expect<null>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:538:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:578:28 ❭ is null?
 
 Error: Type 'null' is not the same as type '123'.
 
-  537 |   expect<null>().type.toBe<'abc'>(); // fail
-  538 |   expect<null>().type.toBe<'def'>(); // fail
-  539 |   expect<null>().type.toBe<123>(); // fail
+  577 |   expect<null>().type.toBe<'abc'>(); // fail
+  578 |   expect<null>().type.toBe<'def'>(); // fail
+  579 |   expect<null>().type.toBe<123>(); // fail
       |                            ~~~
-  540 |   expect<null>().type.toBe<456>(); // fail
-  541 |   expect<null>().type.toBe<887n>(); // fail
-  542 |   expect<null>().type.toBe<998n>(); // fail
+  580 |   expect<null>().type.toBe<456>(); // fail
+  581 |   expect<null>().type.toBe<887n>(); // fail
+  582 |   expect<null>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:539:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:579:28 ❭ is null?
 
 Error: Type 'null' is not the same as type '456'.
 
-  538 |   expect<null>().type.toBe<'def'>(); // fail
-  539 |   expect<null>().type.toBe<123>(); // fail
-  540 |   expect<null>().type.toBe<456>(); // fail
+  578 |   expect<null>().type.toBe<'def'>(); // fail
+  579 |   expect<null>().type.toBe<123>(); // fail
+  580 |   expect<null>().type.toBe<456>(); // fail
       |                            ~~~
-  541 |   expect<null>().type.toBe<887n>(); // fail
-  542 |   expect<null>().type.toBe<998n>(); // fail
-  543 |   expect<null>().type.toBe<true>(); // fail
+  581 |   expect<null>().type.toBe<887n>(); // fail
+  582 |   expect<null>().type.toBe<998n>(); // fail
+  583 |   expect<null>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:540:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:580:28 ❭ is null?
 
 Error: Type 'null' is not the same as type '887n'.
 
-  539 |   expect<null>().type.toBe<123>(); // fail
-  540 |   expect<null>().type.toBe<456>(); // fail
-  541 |   expect<null>().type.toBe<887n>(); // fail
+  579 |   expect<null>().type.toBe<123>(); // fail
+  580 |   expect<null>().type.toBe<456>(); // fail
+  581 |   expect<null>().type.toBe<887n>(); // fail
       |                            ~~~~
-  542 |   expect<null>().type.toBe<998n>(); // fail
-  543 |   expect<null>().type.toBe<true>(); // fail
-  544 |   expect<null>().type.toBe<false>(); // fail
+  582 |   expect<null>().type.toBe<998n>(); // fail
+  583 |   expect<null>().type.toBe<true>(); // fail
+  584 |   expect<null>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:541:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:581:28 ❭ is null?
 
 Error: Type 'null' is not the same as type '998n'.
 
-  540 |   expect<null>().type.toBe<456>(); // fail
-  541 |   expect<null>().type.toBe<887n>(); // fail
-  542 |   expect<null>().type.toBe<998n>(); // fail
+  580 |   expect<null>().type.toBe<456>(); // fail
+  581 |   expect<null>().type.toBe<887n>(); // fail
+  582 |   expect<null>().type.toBe<998n>(); // fail
       |                            ~~~~
-  543 |   expect<null>().type.toBe<true>(); // fail
-  544 |   expect<null>().type.toBe<false>(); // fail
-  545 |   expect<null>().type.toBe<Array<string>>(); // fail
+  583 |   expect<null>().type.toBe<true>(); // fail
+  584 |   expect<null>().type.toBe<false>(); // fail
+  585 |   expect<null>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:542:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:582:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'true'.
 
-  541 |   expect<null>().type.toBe<887n>(); // fail
-  542 |   expect<null>().type.toBe<998n>(); // fail
-  543 |   expect<null>().type.toBe<true>(); // fail
+  581 |   expect<null>().type.toBe<887n>(); // fail
+  582 |   expect<null>().type.toBe<998n>(); // fail
+  583 |   expect<null>().type.toBe<true>(); // fail
       |                            ~~~~
-  544 |   expect<null>().type.toBe<false>(); // fail
-  545 |   expect<null>().type.toBe<Array<string>>(); // fail
-  546 |   expect<null>().type.toBe<number[]>(); // fail
+  584 |   expect<null>().type.toBe<false>(); // fail
+  585 |   expect<null>().type.toBe<Array<string>>(); // fail
+  586 |   expect<null>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:543:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:583:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'false'.
 
-  542 |   expect<null>().type.toBe<998n>(); // fail
-  543 |   expect<null>().type.toBe<true>(); // fail
-  544 |   expect<null>().type.toBe<false>(); // fail
+  582 |   expect<null>().type.toBe<998n>(); // fail
+  583 |   expect<null>().type.toBe<true>(); // fail
+  584 |   expect<null>().type.toBe<false>(); // fail
       |                            ~~~~~
-  545 |   expect<null>().type.toBe<Array<string>>(); // fail
-  546 |   expect<null>().type.toBe<number[]>(); // fail
-  547 | });
+  585 |   expect<null>().type.toBe<Array<string>>(); // fail
+  586 |   expect<null>().type.toBe<number[]>(); // fail
+  587 |   expect<null>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:544:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:584:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'string[]'.
 
-  543 |   expect<null>().type.toBe<true>(); // fail
-  544 |   expect<null>().type.toBe<false>(); // fail
-  545 |   expect<null>().type.toBe<Array<string>>(); // fail
+  583 |   expect<null>().type.toBe<true>(); // fail
+  584 |   expect<null>().type.toBe<false>(); // fail
+  585 |   expect<null>().type.toBe<Array<string>>(); // fail
       |                            ~~~~~~~~~~~~~
-  546 |   expect<null>().type.toBe<number[]>(); // fail
-  547 | });
-  548 | 
+  586 |   expect<null>().type.toBe<number[]>(); // fail
+  587 |   expect<null>().type.toBe<string | number>(); // fail
+  588 |   expect<null>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:545:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:585:28 ❭ is null?
 
 Error: Type 'null' is not the same as type 'number[]'.
 
-  544 |   expect<null>().type.toBe<false>(); // fail
-  545 |   expect<null>().type.toBe<Array<string>>(); // fail
-  546 |   expect<null>().type.toBe<number[]>(); // fail
+  584 |   expect<null>().type.toBe<false>(); // fail
+  585 |   expect<null>().type.toBe<Array<string>>(); // fail
+  586 |   expect<null>().type.toBe<number[]>(); // fail
       |                            ~~~~~~~~
-  547 | });
-  548 | 
-  549 | test("is NOT null?", () => {
+  587 |   expect<null>().type.toBe<string | number>(); // fail
+  588 |   expect<null>().type.toBe<string | Array<string>>(); // fail
+  589 | });
 
-        at ./__typetests__/structure.tst.ts:546:28 ❭ is null?
+        at ./__typetests__/structure.tst.ts:586:28 ❭ is null?
+
+Error: Type 'null' is not the same as type 'string | number'.
+
+  585 |   expect<null>().type.toBe<Array<string>>(); // fail
+  586 |   expect<null>().type.toBe<number[]>(); // fail
+  587 |   expect<null>().type.toBe<string | number>(); // fail
+      |                            ~~~~~~~~~~~~~~~
+  588 |   expect<null>().type.toBe<string | Array<string>>(); // fail
+  589 | });
+  590 | 
+
+        at ./__typetests__/structure.tst.ts:587:28 ❭ is null?
+
+Error: Type 'null' is not the same as type 'string | string[]'.
+
+  586 |   expect<null>().type.toBe<number[]>(); // fail
+  587 |   expect<null>().type.toBe<string | number>(); // fail
+  588 |   expect<null>().type.toBe<string | Array<string>>(); // fail
+      |                            ~~~~~~~~~~~~~~~~~~~~~~
+  589 | });
+  590 | 
+  591 | test("is NOT null?", () => {
+
+        at ./__typetests__/structure.tst.ts:588:28 ❭ is null?
 
 Error: Type 'null' is the same as type 'null'.
 
-  570 |   expect<null>().type.not.toBe<number[]>();
-  571 | 
-  572 |   expect<null>().type.not.toBe<null>(); // fail
+  614 |   expect<null>().type.not.toBe<string | Array<string>>();
+  615 | 
+  616 |   expect<null>().type.not.toBe<null>(); // fail
       |                                ~~~~
-  573 | });
-  574 | 
-  575 | test("is never?", () => {
+  617 | });
+  618 | 
+  619 | test("is never?", () => {
 
-        at ./__typetests__/structure.tst.ts:572:32 ❭ is NOT null?
+        at ./__typetests__/structure.tst.ts:616:32 ❭ is NOT null?
 
 Error: Type 'never' is not the same as type 'any'.
 
-  576 |   expect<never>().type.toBe<never>();
-  577 | 
-  578 |   expect<never>().type.toBe<any>(); // fail
+  620 |   expect<never>().type.toBe<never>();
+  621 | 
+  622 |   expect<never>().type.toBe<any>(); // fail
       |                             ~~~
-  579 |   expect<never>().type.toBe<unknown>(); // fail
-  580 |   expect<never>().type.toBe<string>(); // fail
-  581 |   expect<never>().type.toBe<number>(); // fail
+  623 |   expect<never>().type.toBe<unknown>(); // fail
+  624 |   expect<never>().type.toBe<string>(); // fail
+  625 |   expect<never>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:578:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:622:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'unknown'.
 
-  577 | 
-  578 |   expect<never>().type.toBe<any>(); // fail
-  579 |   expect<never>().type.toBe<unknown>(); // fail
+  621 | 
+  622 |   expect<never>().type.toBe<any>(); // fail
+  623 |   expect<never>().type.toBe<unknown>(); // fail
       |                             ~~~~~~~
-  580 |   expect<never>().type.toBe<string>(); // fail
-  581 |   expect<never>().type.toBe<number>(); // fail
-  582 |   expect<never>().type.toBe<bigint>(); // fail
+  624 |   expect<never>().type.toBe<string>(); // fail
+  625 |   expect<never>().type.toBe<number>(); // fail
+  626 |   expect<never>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:579:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:623:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'string'.
 
-  578 |   expect<never>().type.toBe<any>(); // fail
-  579 |   expect<never>().type.toBe<unknown>(); // fail
-  580 |   expect<never>().type.toBe<string>(); // fail
+  622 |   expect<never>().type.toBe<any>(); // fail
+  623 |   expect<never>().type.toBe<unknown>(); // fail
+  624 |   expect<never>().type.toBe<string>(); // fail
       |                             ~~~~~~
-  581 |   expect<never>().type.toBe<number>(); // fail
-  582 |   expect<never>().type.toBe<bigint>(); // fail
-  583 |   expect<never>().type.toBe<boolean>(); // fail
+  625 |   expect<never>().type.toBe<number>(); // fail
+  626 |   expect<never>().type.toBe<bigint>(); // fail
+  627 |   expect<never>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:580:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:624:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'number'.
 
-  579 |   expect<never>().type.toBe<unknown>(); // fail
-  580 |   expect<never>().type.toBe<string>(); // fail
-  581 |   expect<never>().type.toBe<number>(); // fail
+  623 |   expect<never>().type.toBe<unknown>(); // fail
+  624 |   expect<never>().type.toBe<string>(); // fail
+  625 |   expect<never>().type.toBe<number>(); // fail
       |                             ~~~~~~
-  582 |   expect<never>().type.toBe<bigint>(); // fail
-  583 |   expect<never>().type.toBe<boolean>(); // fail
-  584 |   expect<never>().type.toBe<symbol>(); // fail
+  626 |   expect<never>().type.toBe<bigint>(); // fail
+  627 |   expect<never>().type.toBe<boolean>(); // fail
+  628 |   expect<never>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:581:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:625:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'bigint'.
 
-  580 |   expect<never>().type.toBe<string>(); // fail
-  581 |   expect<never>().type.toBe<number>(); // fail
-  582 |   expect<never>().type.toBe<bigint>(); // fail
+  624 |   expect<never>().type.toBe<string>(); // fail
+  625 |   expect<never>().type.toBe<number>(); // fail
+  626 |   expect<never>().type.toBe<bigint>(); // fail
       |                             ~~~~~~
-  583 |   expect<never>().type.toBe<boolean>(); // fail
-  584 |   expect<never>().type.toBe<symbol>(); // fail
-  585 |   expect<never>().type.toBe<object>(); // fail
+  627 |   expect<never>().type.toBe<boolean>(); // fail
+  628 |   expect<never>().type.toBe<symbol>(); // fail
+  629 |   expect<never>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:582:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:626:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'boolean'.
 
-  581 |   expect<never>().type.toBe<number>(); // fail
-  582 |   expect<never>().type.toBe<bigint>(); // fail
-  583 |   expect<never>().type.toBe<boolean>(); // fail
+  625 |   expect<never>().type.toBe<number>(); // fail
+  626 |   expect<never>().type.toBe<bigint>(); // fail
+  627 |   expect<never>().type.toBe<boolean>(); // fail
       |                             ~~~~~~~
-  584 |   expect<never>().type.toBe<symbol>(); // fail
-  585 |   expect<never>().type.toBe<object>(); // fail
-  586 |   expect<never>().type.toBe<void>(); // fail
+  628 |   expect<never>().type.toBe<symbol>(); // fail
+  629 |   expect<never>().type.toBe<object>(); // fail
+  630 |   expect<never>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:583:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:627:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'symbol'.
 
-  582 |   expect<never>().type.toBe<bigint>(); // fail
-  583 |   expect<never>().type.toBe<boolean>(); // fail
-  584 |   expect<never>().type.toBe<symbol>(); // fail
+  626 |   expect<never>().type.toBe<bigint>(); // fail
+  627 |   expect<never>().type.toBe<boolean>(); // fail
+  628 |   expect<never>().type.toBe<symbol>(); // fail
       |                             ~~~~~~
-  585 |   expect<never>().type.toBe<object>(); // fail
-  586 |   expect<never>().type.toBe<void>(); // fail
-  587 |   expect<never>().type.toBe<undefined>(); // fail
+  629 |   expect<never>().type.toBe<object>(); // fail
+  630 |   expect<never>().type.toBe<void>(); // fail
+  631 |   expect<never>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:584:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:628:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'object'.
 
-  583 |   expect<never>().type.toBe<boolean>(); // fail
-  584 |   expect<never>().type.toBe<symbol>(); // fail
-  585 |   expect<never>().type.toBe<object>(); // fail
+  627 |   expect<never>().type.toBe<boolean>(); // fail
+  628 |   expect<never>().type.toBe<symbol>(); // fail
+  629 |   expect<never>().type.toBe<object>(); // fail
       |                             ~~~~~~
-  586 |   expect<never>().type.toBe<void>(); // fail
-  587 |   expect<never>().type.toBe<undefined>(); // fail
-  588 |   expect<never>().type.toBe<null>(); // fail
+  630 |   expect<never>().type.toBe<void>(); // fail
+  631 |   expect<never>().type.toBe<undefined>(); // fail
+  632 |   expect<never>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:585:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:629:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'void'.
 
-  584 |   expect<never>().type.toBe<symbol>(); // fail
-  585 |   expect<never>().type.toBe<object>(); // fail
-  586 |   expect<never>().type.toBe<void>(); // fail
+  628 |   expect<never>().type.toBe<symbol>(); // fail
+  629 |   expect<never>().type.toBe<object>(); // fail
+  630 |   expect<never>().type.toBe<void>(); // fail
       |                             ~~~~
-  587 |   expect<never>().type.toBe<undefined>(); // fail
-  588 |   expect<never>().type.toBe<null>(); // fail
-  589 |   expect<never>().type.toBe<'abc'>(); // fail
+  631 |   expect<never>().type.toBe<undefined>(); // fail
+  632 |   expect<never>().type.toBe<null>(); // fail
+  633 |   expect<never>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:586:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:630:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'undefined'.
 
-  585 |   expect<never>().type.toBe<object>(); // fail
-  586 |   expect<never>().type.toBe<void>(); // fail
-  587 |   expect<never>().type.toBe<undefined>(); // fail
+  629 |   expect<never>().type.toBe<object>(); // fail
+  630 |   expect<never>().type.toBe<void>(); // fail
+  631 |   expect<never>().type.toBe<undefined>(); // fail
       |                             ~~~~~~~~~
-  588 |   expect<never>().type.toBe<null>(); // fail
-  589 |   expect<never>().type.toBe<'abc'>(); // fail
-  590 |   expect<never>().type.toBe<'def'>(); // fail
+  632 |   expect<never>().type.toBe<null>(); // fail
+  633 |   expect<never>().type.toBe<'abc'>(); // fail
+  634 |   expect<never>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:587:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:631:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'null'.
 
-  586 |   expect<never>().type.toBe<void>(); // fail
-  587 |   expect<never>().type.toBe<undefined>(); // fail
-  588 |   expect<never>().type.toBe<null>(); // fail
+  630 |   expect<never>().type.toBe<void>(); // fail
+  631 |   expect<never>().type.toBe<undefined>(); // fail
+  632 |   expect<never>().type.toBe<null>(); // fail
       |                             ~~~~
-  589 |   expect<never>().type.toBe<'abc'>(); // fail
-  590 |   expect<never>().type.toBe<'def'>(); // fail
-  591 |   expect<never>().type.toBe<123>(); // fail
+  633 |   expect<never>().type.toBe<'abc'>(); // fail
+  634 |   expect<never>().type.toBe<'def'>(); // fail
+  635 |   expect<never>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:588:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:632:29 ❭ is never?
 
 Error: Type 'never' is not the same as type '"abc"'.
 
-  587 |   expect<never>().type.toBe<undefined>(); // fail
-  588 |   expect<never>().type.toBe<null>(); // fail
-  589 |   expect<never>().type.toBe<'abc'>(); // fail
+  631 |   expect<never>().type.toBe<undefined>(); // fail
+  632 |   expect<never>().type.toBe<null>(); // fail
+  633 |   expect<never>().type.toBe<'abc'>(); // fail
       |                             ~~~~~
-  590 |   expect<never>().type.toBe<'def'>(); // fail
-  591 |   expect<never>().type.toBe<123>(); // fail
-  592 |   expect<never>().type.toBe<456>(); // fail
+  634 |   expect<never>().type.toBe<'def'>(); // fail
+  635 |   expect<never>().type.toBe<123>(); // fail
+  636 |   expect<never>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:589:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:633:29 ❭ is never?
 
 Error: Type 'never' is not the same as type '"def"'.
 
-  588 |   expect<never>().type.toBe<null>(); // fail
-  589 |   expect<never>().type.toBe<'abc'>(); // fail
-  590 |   expect<never>().type.toBe<'def'>(); // fail
+  632 |   expect<never>().type.toBe<null>(); // fail
+  633 |   expect<never>().type.toBe<'abc'>(); // fail
+  634 |   expect<never>().type.toBe<'def'>(); // fail
       |                             ~~~~~
-  591 |   expect<never>().type.toBe<123>(); // fail
-  592 |   expect<never>().type.toBe<456>(); // fail
-  593 |   expect<never>().type.toBe<887n>(); // fail
+  635 |   expect<never>().type.toBe<123>(); // fail
+  636 |   expect<never>().type.toBe<456>(); // fail
+  637 |   expect<never>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:590:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:634:29 ❭ is never?
 
 Error: Type 'never' is not the same as type '123'.
 
-  589 |   expect<never>().type.toBe<'abc'>(); // fail
-  590 |   expect<never>().type.toBe<'def'>(); // fail
-  591 |   expect<never>().type.toBe<123>(); // fail
+  633 |   expect<never>().type.toBe<'abc'>(); // fail
+  634 |   expect<never>().type.toBe<'def'>(); // fail
+  635 |   expect<never>().type.toBe<123>(); // fail
       |                             ~~~
-  592 |   expect<never>().type.toBe<456>(); // fail
-  593 |   expect<never>().type.toBe<887n>(); // fail
-  594 |   expect<never>().type.toBe<998n>(); // fail
+  636 |   expect<never>().type.toBe<456>(); // fail
+  637 |   expect<never>().type.toBe<887n>(); // fail
+  638 |   expect<never>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:591:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:635:29 ❭ is never?
 
 Error: Type 'never' is not the same as type '456'.
 
-  590 |   expect<never>().type.toBe<'def'>(); // fail
-  591 |   expect<never>().type.toBe<123>(); // fail
-  592 |   expect<never>().type.toBe<456>(); // fail
+  634 |   expect<never>().type.toBe<'def'>(); // fail
+  635 |   expect<never>().type.toBe<123>(); // fail
+  636 |   expect<never>().type.toBe<456>(); // fail
       |                             ~~~
-  593 |   expect<never>().type.toBe<887n>(); // fail
-  594 |   expect<never>().type.toBe<998n>(); // fail
-  595 |   expect<never>().type.toBe<true>(); // fail
+  637 |   expect<never>().type.toBe<887n>(); // fail
+  638 |   expect<never>().type.toBe<998n>(); // fail
+  639 |   expect<never>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:592:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:636:29 ❭ is never?
 
 Error: Type 'never' is not the same as type '887n'.
 
-  591 |   expect<never>().type.toBe<123>(); // fail
-  592 |   expect<never>().type.toBe<456>(); // fail
-  593 |   expect<never>().type.toBe<887n>(); // fail
+  635 |   expect<never>().type.toBe<123>(); // fail
+  636 |   expect<never>().type.toBe<456>(); // fail
+  637 |   expect<never>().type.toBe<887n>(); // fail
       |                             ~~~~
-  594 |   expect<never>().type.toBe<998n>(); // fail
-  595 |   expect<never>().type.toBe<true>(); // fail
-  596 |   expect<never>().type.toBe<false>(); // fail
+  638 |   expect<never>().type.toBe<998n>(); // fail
+  639 |   expect<never>().type.toBe<true>(); // fail
+  640 |   expect<never>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:593:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:637:29 ❭ is never?
 
 Error: Type 'never' is not the same as type '998n'.
 
-  592 |   expect<never>().type.toBe<456>(); // fail
-  593 |   expect<never>().type.toBe<887n>(); // fail
-  594 |   expect<never>().type.toBe<998n>(); // fail
+  636 |   expect<never>().type.toBe<456>(); // fail
+  637 |   expect<never>().type.toBe<887n>(); // fail
+  638 |   expect<never>().type.toBe<998n>(); // fail
       |                             ~~~~
-  595 |   expect<never>().type.toBe<true>(); // fail
-  596 |   expect<never>().type.toBe<false>(); // fail
-  597 |   expect<never>().type.toBe<Array<string>>(); // fail
+  639 |   expect<never>().type.toBe<true>(); // fail
+  640 |   expect<never>().type.toBe<false>(); // fail
+  641 |   expect<never>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:594:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:638:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'true'.
 
-  593 |   expect<never>().type.toBe<887n>(); // fail
-  594 |   expect<never>().type.toBe<998n>(); // fail
-  595 |   expect<never>().type.toBe<true>(); // fail
+  637 |   expect<never>().type.toBe<887n>(); // fail
+  638 |   expect<never>().type.toBe<998n>(); // fail
+  639 |   expect<never>().type.toBe<true>(); // fail
       |                             ~~~~
-  596 |   expect<never>().type.toBe<false>(); // fail
-  597 |   expect<never>().type.toBe<Array<string>>(); // fail
-  598 |   expect<never>().type.toBe<number[]>(); // fail
+  640 |   expect<never>().type.toBe<false>(); // fail
+  641 |   expect<never>().type.toBe<Array<string>>(); // fail
+  642 |   expect<never>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:595:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:639:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'false'.
 
-  594 |   expect<never>().type.toBe<998n>(); // fail
-  595 |   expect<never>().type.toBe<true>(); // fail
-  596 |   expect<never>().type.toBe<false>(); // fail
+  638 |   expect<never>().type.toBe<998n>(); // fail
+  639 |   expect<never>().type.toBe<true>(); // fail
+  640 |   expect<never>().type.toBe<false>(); // fail
       |                             ~~~~~
-  597 |   expect<never>().type.toBe<Array<string>>(); // fail
-  598 |   expect<never>().type.toBe<number[]>(); // fail
-  599 | });
+  641 |   expect<never>().type.toBe<Array<string>>(); // fail
+  642 |   expect<never>().type.toBe<number[]>(); // fail
+  643 |   expect<never>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:596:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:640:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'string[]'.
 
-  595 |   expect<never>().type.toBe<true>(); // fail
-  596 |   expect<never>().type.toBe<false>(); // fail
-  597 |   expect<never>().type.toBe<Array<string>>(); // fail
+  639 |   expect<never>().type.toBe<true>(); // fail
+  640 |   expect<never>().type.toBe<false>(); // fail
+  641 |   expect<never>().type.toBe<Array<string>>(); // fail
       |                             ~~~~~~~~~~~~~
-  598 |   expect<never>().type.toBe<number[]>(); // fail
-  599 | });
-  600 | 
+  642 |   expect<never>().type.toBe<number[]>(); // fail
+  643 |   expect<never>().type.toBe<string | number>(); // fail
+  644 |   expect<never>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:597:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:641:29 ❭ is never?
 
 Error: Type 'never' is not the same as type 'number[]'.
 
-  596 |   expect<never>().type.toBe<false>(); // fail
-  597 |   expect<never>().type.toBe<Array<string>>(); // fail
-  598 |   expect<never>().type.toBe<number[]>(); // fail
+  640 |   expect<never>().type.toBe<false>(); // fail
+  641 |   expect<never>().type.toBe<Array<string>>(); // fail
+  642 |   expect<never>().type.toBe<number[]>(); // fail
       |                             ~~~~~~~~
-  599 | });
-  600 | 
-  601 | test("is NOT never?", () => {
+  643 |   expect<never>().type.toBe<string | number>(); // fail
+  644 |   expect<never>().type.toBe<string | Array<string>>(); // fail
+  645 | });
 
-        at ./__typetests__/structure.tst.ts:598:29 ❭ is never?
+        at ./__typetests__/structure.tst.ts:642:29 ❭ is never?
+
+Error: Type 'never' is not the same as type 'string | number'.
+
+  641 |   expect<never>().type.toBe<Array<string>>(); // fail
+  642 |   expect<never>().type.toBe<number[]>(); // fail
+  643 |   expect<never>().type.toBe<string | number>(); // fail
+      |                             ~~~~~~~~~~~~~~~
+  644 |   expect<never>().type.toBe<string | Array<string>>(); // fail
+  645 | });
+  646 | 
+
+        at ./__typetests__/structure.tst.ts:643:29 ❭ is never?
+
+Error: Type 'never' is not the same as type 'string | string[]'.
+
+  642 |   expect<never>().type.toBe<number[]>(); // fail
+  643 |   expect<never>().type.toBe<string | number>(); // fail
+  644 |   expect<never>().type.toBe<string | Array<string>>(); // fail
+      |                             ~~~~~~~~~~~~~~~~~~~~~~
+  645 | });
+  646 | 
+  647 | test("is NOT never?", () => {
+
+        at ./__typetests__/structure.tst.ts:644:29 ❭ is never?
 
 Error: Type 'never' is the same as type 'never'.
 
-  622 |   expect<never>().type.not.toBe<number[]>();
-  623 | 
-  624 |   expect<never>().type.not.toBe<never>(); // fail
+  670 |   expect<never>().type.not.toBe<string | Array<string>>();
+  671 | 
+  672 |   expect<never>().type.not.toBe<never>(); // fail
       |                                 ~~~~~
-  625 | });
-  626 | 
-  627 | test("is 'abc'?", () => {
+  673 | });
+  674 | 
+  675 | test("is 'abc'?", () => {
 
-        at ./__typetests__/structure.tst.ts:624:33 ❭ is NOT never?
+        at ./__typetests__/structure.tst.ts:672:33 ❭ is NOT never?
 
 Error: Type '"abc"' is not the same as type 'any'.
 
-  628 |   expect<'abc'>().type.toBe<'abc'>();
-  629 | 
-  630 |   expect<'abc'>().type.toBe<any>(); // fail
+  676 |   expect<'abc'>().type.toBe<'abc'>();
+  677 | 
+  678 |   expect<'abc'>().type.toBe<any>(); // fail
       |                             ~~~
-  631 |   expect<'abc'>().type.toBe<unknown>(); // fail
-  632 |   expect<'abc'>().type.toBe<string>(); // fail
-  633 |   expect<'abc'>().type.toBe<number>(); // fail
+  679 |   expect<'abc'>().type.toBe<unknown>(); // fail
+  680 |   expect<'abc'>().type.toBe<string>(); // fail
+  681 |   expect<'abc'>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:630:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:678:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'unknown'.
 
-  629 | 
-  630 |   expect<'abc'>().type.toBe<any>(); // fail
-  631 |   expect<'abc'>().type.toBe<unknown>(); // fail
+  677 | 
+  678 |   expect<'abc'>().type.toBe<any>(); // fail
+  679 |   expect<'abc'>().type.toBe<unknown>(); // fail
       |                             ~~~~~~~
-  632 |   expect<'abc'>().type.toBe<string>(); // fail
-  633 |   expect<'abc'>().type.toBe<number>(); // fail
-  634 |   expect<'abc'>().type.toBe<bigint>(); // fail
+  680 |   expect<'abc'>().type.toBe<string>(); // fail
+  681 |   expect<'abc'>().type.toBe<number>(); // fail
+  682 |   expect<'abc'>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:631:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:679:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'string'.
 
-  630 |   expect<'abc'>().type.toBe<any>(); // fail
-  631 |   expect<'abc'>().type.toBe<unknown>(); // fail
-  632 |   expect<'abc'>().type.toBe<string>(); // fail
+  678 |   expect<'abc'>().type.toBe<any>(); // fail
+  679 |   expect<'abc'>().type.toBe<unknown>(); // fail
+  680 |   expect<'abc'>().type.toBe<string>(); // fail
       |                             ~~~~~~
-  633 |   expect<'abc'>().type.toBe<number>(); // fail
-  634 |   expect<'abc'>().type.toBe<bigint>(); // fail
-  635 |   expect<'abc'>().type.toBe<boolean>(); // fail
+  681 |   expect<'abc'>().type.toBe<number>(); // fail
+  682 |   expect<'abc'>().type.toBe<bigint>(); // fail
+  683 |   expect<'abc'>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:632:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:680:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'number'.
 
-  631 |   expect<'abc'>().type.toBe<unknown>(); // fail
-  632 |   expect<'abc'>().type.toBe<string>(); // fail
-  633 |   expect<'abc'>().type.toBe<number>(); // fail
+  679 |   expect<'abc'>().type.toBe<unknown>(); // fail
+  680 |   expect<'abc'>().type.toBe<string>(); // fail
+  681 |   expect<'abc'>().type.toBe<number>(); // fail
       |                             ~~~~~~
-  634 |   expect<'abc'>().type.toBe<bigint>(); // fail
-  635 |   expect<'abc'>().type.toBe<boolean>(); // fail
-  636 |   expect<'abc'>().type.toBe<symbol>(); // fail
+  682 |   expect<'abc'>().type.toBe<bigint>(); // fail
+  683 |   expect<'abc'>().type.toBe<boolean>(); // fail
+  684 |   expect<'abc'>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:633:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:681:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'bigint'.
 
-  632 |   expect<'abc'>().type.toBe<string>(); // fail
-  633 |   expect<'abc'>().type.toBe<number>(); // fail
-  634 |   expect<'abc'>().type.toBe<bigint>(); // fail
+  680 |   expect<'abc'>().type.toBe<string>(); // fail
+  681 |   expect<'abc'>().type.toBe<number>(); // fail
+  682 |   expect<'abc'>().type.toBe<bigint>(); // fail
       |                             ~~~~~~
-  635 |   expect<'abc'>().type.toBe<boolean>(); // fail
-  636 |   expect<'abc'>().type.toBe<symbol>(); // fail
-  637 |   expect<'abc'>().type.toBe<object>(); // fail
+  683 |   expect<'abc'>().type.toBe<boolean>(); // fail
+  684 |   expect<'abc'>().type.toBe<symbol>(); // fail
+  685 |   expect<'abc'>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:634:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:682:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'boolean'.
 
-  633 |   expect<'abc'>().type.toBe<number>(); // fail
-  634 |   expect<'abc'>().type.toBe<bigint>(); // fail
-  635 |   expect<'abc'>().type.toBe<boolean>(); // fail
+  681 |   expect<'abc'>().type.toBe<number>(); // fail
+  682 |   expect<'abc'>().type.toBe<bigint>(); // fail
+  683 |   expect<'abc'>().type.toBe<boolean>(); // fail
       |                             ~~~~~~~
-  636 |   expect<'abc'>().type.toBe<symbol>(); // fail
-  637 |   expect<'abc'>().type.toBe<object>(); // fail
-  638 |   expect<'abc'>().type.toBe<void>(); // fail
+  684 |   expect<'abc'>().type.toBe<symbol>(); // fail
+  685 |   expect<'abc'>().type.toBe<object>(); // fail
+  686 |   expect<'abc'>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:635:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:683:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'symbol'.
 
-  634 |   expect<'abc'>().type.toBe<bigint>(); // fail
-  635 |   expect<'abc'>().type.toBe<boolean>(); // fail
-  636 |   expect<'abc'>().type.toBe<symbol>(); // fail
+  682 |   expect<'abc'>().type.toBe<bigint>(); // fail
+  683 |   expect<'abc'>().type.toBe<boolean>(); // fail
+  684 |   expect<'abc'>().type.toBe<symbol>(); // fail
       |                             ~~~~~~
-  637 |   expect<'abc'>().type.toBe<object>(); // fail
-  638 |   expect<'abc'>().type.toBe<void>(); // fail
-  639 |   expect<'abc'>().type.toBe<undefined>(); // fail
+  685 |   expect<'abc'>().type.toBe<object>(); // fail
+  686 |   expect<'abc'>().type.toBe<void>(); // fail
+  687 |   expect<'abc'>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:636:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:684:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'object'.
 
-  635 |   expect<'abc'>().type.toBe<boolean>(); // fail
-  636 |   expect<'abc'>().type.toBe<symbol>(); // fail
-  637 |   expect<'abc'>().type.toBe<object>(); // fail
+  683 |   expect<'abc'>().type.toBe<boolean>(); // fail
+  684 |   expect<'abc'>().type.toBe<symbol>(); // fail
+  685 |   expect<'abc'>().type.toBe<object>(); // fail
       |                             ~~~~~~
-  638 |   expect<'abc'>().type.toBe<void>(); // fail
-  639 |   expect<'abc'>().type.toBe<undefined>(); // fail
-  640 |   expect<'abc'>().type.toBe<null>(); // fail
+  686 |   expect<'abc'>().type.toBe<void>(); // fail
+  687 |   expect<'abc'>().type.toBe<undefined>(); // fail
+  688 |   expect<'abc'>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:637:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:685:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'void'.
 
-  636 |   expect<'abc'>().type.toBe<symbol>(); // fail
-  637 |   expect<'abc'>().type.toBe<object>(); // fail
-  638 |   expect<'abc'>().type.toBe<void>(); // fail
+  684 |   expect<'abc'>().type.toBe<symbol>(); // fail
+  685 |   expect<'abc'>().type.toBe<object>(); // fail
+  686 |   expect<'abc'>().type.toBe<void>(); // fail
       |                             ~~~~
-  639 |   expect<'abc'>().type.toBe<undefined>(); // fail
-  640 |   expect<'abc'>().type.toBe<null>(); // fail
-  641 |   expect<'abc'>().type.toBe<never>(); // fail
+  687 |   expect<'abc'>().type.toBe<undefined>(); // fail
+  688 |   expect<'abc'>().type.toBe<null>(); // fail
+  689 |   expect<'abc'>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:638:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:686:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'undefined'.
 
-  637 |   expect<'abc'>().type.toBe<object>(); // fail
-  638 |   expect<'abc'>().type.toBe<void>(); // fail
-  639 |   expect<'abc'>().type.toBe<undefined>(); // fail
+  685 |   expect<'abc'>().type.toBe<object>(); // fail
+  686 |   expect<'abc'>().type.toBe<void>(); // fail
+  687 |   expect<'abc'>().type.toBe<undefined>(); // fail
       |                             ~~~~~~~~~
-  640 |   expect<'abc'>().type.toBe<null>(); // fail
-  641 |   expect<'abc'>().type.toBe<never>(); // fail
-  642 |   expect<'abc'>().type.toBe<'def'>(); // fail
+  688 |   expect<'abc'>().type.toBe<null>(); // fail
+  689 |   expect<'abc'>().type.toBe<never>(); // fail
+  690 |   expect<'abc'>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:639:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:687:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'null'.
 
-  638 |   expect<'abc'>().type.toBe<void>(); // fail
-  639 |   expect<'abc'>().type.toBe<undefined>(); // fail
-  640 |   expect<'abc'>().type.toBe<null>(); // fail
+  686 |   expect<'abc'>().type.toBe<void>(); // fail
+  687 |   expect<'abc'>().type.toBe<undefined>(); // fail
+  688 |   expect<'abc'>().type.toBe<null>(); // fail
       |                             ~~~~
-  641 |   expect<'abc'>().type.toBe<never>(); // fail
-  642 |   expect<'abc'>().type.toBe<'def'>(); // fail
-  643 |   expect<'abc'>().type.toBe<123>(); // fail
+  689 |   expect<'abc'>().type.toBe<never>(); // fail
+  690 |   expect<'abc'>().type.toBe<'def'>(); // fail
+  691 |   expect<'abc'>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:640:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:688:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'never'.
 
-  639 |   expect<'abc'>().type.toBe<undefined>(); // fail
-  640 |   expect<'abc'>().type.toBe<null>(); // fail
-  641 |   expect<'abc'>().type.toBe<never>(); // fail
+  687 |   expect<'abc'>().type.toBe<undefined>(); // fail
+  688 |   expect<'abc'>().type.toBe<null>(); // fail
+  689 |   expect<'abc'>().type.toBe<never>(); // fail
       |                             ~~~~~
-  642 |   expect<'abc'>().type.toBe<'def'>(); // fail
-  643 |   expect<'abc'>().type.toBe<123>(); // fail
-  644 |   expect<'abc'>().type.toBe<456>(); // fail
+  690 |   expect<'abc'>().type.toBe<'def'>(); // fail
+  691 |   expect<'abc'>().type.toBe<123>(); // fail
+  692 |   expect<'abc'>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:641:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:689:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type '"def"'.
 
-  640 |   expect<'abc'>().type.toBe<null>(); // fail
-  641 |   expect<'abc'>().type.toBe<never>(); // fail
-  642 |   expect<'abc'>().type.toBe<'def'>(); // fail
+  688 |   expect<'abc'>().type.toBe<null>(); // fail
+  689 |   expect<'abc'>().type.toBe<never>(); // fail
+  690 |   expect<'abc'>().type.toBe<'def'>(); // fail
       |                             ~~~~~
-  643 |   expect<'abc'>().type.toBe<123>(); // fail
-  644 |   expect<'abc'>().type.toBe<456>(); // fail
-  645 |   expect<'abc'>().type.toBe<887n>(); // fail
+  691 |   expect<'abc'>().type.toBe<123>(); // fail
+  692 |   expect<'abc'>().type.toBe<456>(); // fail
+  693 |   expect<'abc'>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:642:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:690:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type '123'.
 
-  641 |   expect<'abc'>().type.toBe<never>(); // fail
-  642 |   expect<'abc'>().type.toBe<'def'>(); // fail
-  643 |   expect<'abc'>().type.toBe<123>(); // fail
+  689 |   expect<'abc'>().type.toBe<never>(); // fail
+  690 |   expect<'abc'>().type.toBe<'def'>(); // fail
+  691 |   expect<'abc'>().type.toBe<123>(); // fail
       |                             ~~~
-  644 |   expect<'abc'>().type.toBe<456>(); // fail
-  645 |   expect<'abc'>().type.toBe<887n>(); // fail
-  646 |   expect<'abc'>().type.toBe<998n>(); // fail
+  692 |   expect<'abc'>().type.toBe<456>(); // fail
+  693 |   expect<'abc'>().type.toBe<887n>(); // fail
+  694 |   expect<'abc'>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:643:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:691:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type '456'.
 
-  642 |   expect<'abc'>().type.toBe<'def'>(); // fail
-  643 |   expect<'abc'>().type.toBe<123>(); // fail
-  644 |   expect<'abc'>().type.toBe<456>(); // fail
+  690 |   expect<'abc'>().type.toBe<'def'>(); // fail
+  691 |   expect<'abc'>().type.toBe<123>(); // fail
+  692 |   expect<'abc'>().type.toBe<456>(); // fail
       |                             ~~~
-  645 |   expect<'abc'>().type.toBe<887n>(); // fail
-  646 |   expect<'abc'>().type.toBe<998n>(); // fail
-  647 |   expect<'abc'>().type.toBe<true>(); // fail
+  693 |   expect<'abc'>().type.toBe<887n>(); // fail
+  694 |   expect<'abc'>().type.toBe<998n>(); // fail
+  695 |   expect<'abc'>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:644:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:692:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type '887n'.
 
-  643 |   expect<'abc'>().type.toBe<123>(); // fail
-  644 |   expect<'abc'>().type.toBe<456>(); // fail
-  645 |   expect<'abc'>().type.toBe<887n>(); // fail
+  691 |   expect<'abc'>().type.toBe<123>(); // fail
+  692 |   expect<'abc'>().type.toBe<456>(); // fail
+  693 |   expect<'abc'>().type.toBe<887n>(); // fail
       |                             ~~~~
-  646 |   expect<'abc'>().type.toBe<998n>(); // fail
-  647 |   expect<'abc'>().type.toBe<true>(); // fail
-  648 |   expect<'abc'>().type.toBe<false>(); // fail
+  694 |   expect<'abc'>().type.toBe<998n>(); // fail
+  695 |   expect<'abc'>().type.toBe<true>(); // fail
+  696 |   expect<'abc'>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:645:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:693:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type '998n'.
 
-  644 |   expect<'abc'>().type.toBe<456>(); // fail
-  645 |   expect<'abc'>().type.toBe<887n>(); // fail
-  646 |   expect<'abc'>().type.toBe<998n>(); // fail
+  692 |   expect<'abc'>().type.toBe<456>(); // fail
+  693 |   expect<'abc'>().type.toBe<887n>(); // fail
+  694 |   expect<'abc'>().type.toBe<998n>(); // fail
       |                             ~~~~
-  647 |   expect<'abc'>().type.toBe<true>(); // fail
-  648 |   expect<'abc'>().type.toBe<false>(); // fail
-  649 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
+  695 |   expect<'abc'>().type.toBe<true>(); // fail
+  696 |   expect<'abc'>().type.toBe<false>(); // fail
+  697 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:646:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:694:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'true'.
 
-  645 |   expect<'abc'>().type.toBe<887n>(); // fail
-  646 |   expect<'abc'>().type.toBe<998n>(); // fail
-  647 |   expect<'abc'>().type.toBe<true>(); // fail
+  693 |   expect<'abc'>().type.toBe<887n>(); // fail
+  694 |   expect<'abc'>().type.toBe<998n>(); // fail
+  695 |   expect<'abc'>().type.toBe<true>(); // fail
       |                             ~~~~
-  648 |   expect<'abc'>().type.toBe<false>(); // fail
-  649 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
-  650 |   expect<'abc'>().type.toBe<number[]>(); // fail
+  696 |   expect<'abc'>().type.toBe<false>(); // fail
+  697 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
+  698 |   expect<'abc'>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:647:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:695:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'false'.
 
-  646 |   expect<'abc'>().type.toBe<998n>(); // fail
-  647 |   expect<'abc'>().type.toBe<true>(); // fail
-  648 |   expect<'abc'>().type.toBe<false>(); // fail
+  694 |   expect<'abc'>().type.toBe<998n>(); // fail
+  695 |   expect<'abc'>().type.toBe<true>(); // fail
+  696 |   expect<'abc'>().type.toBe<false>(); // fail
       |                             ~~~~~
-  649 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
-  650 |   expect<'abc'>().type.toBe<number[]>(); // fail
-  651 | });
+  697 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
+  698 |   expect<'abc'>().type.toBe<number[]>(); // fail
+  699 |   expect<'abc'>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:648:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:696:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'string[]'.
 
-  647 |   expect<'abc'>().type.toBe<true>(); // fail
-  648 |   expect<'abc'>().type.toBe<false>(); // fail
-  649 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
+  695 |   expect<'abc'>().type.toBe<true>(); // fail
+  696 |   expect<'abc'>().type.toBe<false>(); // fail
+  697 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
       |                             ~~~~~~~~~~~~~
-  650 |   expect<'abc'>().type.toBe<number[]>(); // fail
-  651 | });
-  652 | 
+  698 |   expect<'abc'>().type.toBe<number[]>(); // fail
+  699 |   expect<'abc'>().type.toBe<string | number>(); // fail
+  700 |   expect<'abc'>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:649:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:697:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is not the same as type 'number[]'.
 
-  648 |   expect<'abc'>().type.toBe<false>(); // fail
-  649 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
-  650 |   expect<'abc'>().type.toBe<number[]>(); // fail
+  696 |   expect<'abc'>().type.toBe<false>(); // fail
+  697 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
+  698 |   expect<'abc'>().type.toBe<number[]>(); // fail
       |                             ~~~~~~~~
-  651 | });
-  652 | 
-  653 | test("is NOT 'abc'?", () => {
+  699 |   expect<'abc'>().type.toBe<string | number>(); // fail
+  700 |   expect<'abc'>().type.toBe<string | Array<string>>(); // fail
+  701 | });
 
-        at ./__typetests__/structure.tst.ts:650:29 ❭ is 'abc'?
+        at ./__typetests__/structure.tst.ts:698:29 ❭ is 'abc'?
+
+Error: Type '"abc"' is not the same as type 'string | number'.
+
+  697 |   expect<'abc'>().type.toBe<Array<string>>(); // fail
+  698 |   expect<'abc'>().type.toBe<number[]>(); // fail
+  699 |   expect<'abc'>().type.toBe<string | number>(); // fail
+      |                             ~~~~~~~~~~~~~~~
+  700 |   expect<'abc'>().type.toBe<string | Array<string>>(); // fail
+  701 | });
+  702 | 
+
+        at ./__typetests__/structure.tst.ts:699:29 ❭ is 'abc'?
+
+Error: Type '"abc"' is not the same as type 'string | string[]'.
+
+  698 |   expect<'abc'>().type.toBe<number[]>(); // fail
+  699 |   expect<'abc'>().type.toBe<string | number>(); // fail
+  700 |   expect<'abc'>().type.toBe<string | Array<string>>(); // fail
+      |                             ~~~~~~~~~~~~~~~~~~~~~~
+  701 | });
+  702 | 
+  703 | test("is NOT 'abc'?", () => {
+
+        at ./__typetests__/structure.tst.ts:700:29 ❭ is 'abc'?
 
 Error: Type '"abc"' is the same as type '"abc"'.
 
-  674 |   expect<'abc'>().type.not.toBe<number[]>();
-  675 | 
-  676 |   expect<'abc'>().type.not.toBe<'abc'>(); // fail
-      |                                 ~~~~~
-  677 | });
-  678 | 
-  679 | test("is 'def'?", () => {
-
-        at ./__typetests__/structure.tst.ts:676:33 ❭ is NOT 'abc'?
-
-Error: Type '"def"' is not the same as type 'any'.
-
-  680 |   expect<'def'>().type.toBe<'def'>();
-  681 | 
-  682 |   expect<'def'>().type.toBe<any>(); // fail
-      |                             ~~~
-  683 |   expect<'def'>().type.toBe<unknown>(); // fail
-  684 |   expect<'def'>().type.toBe<string>(); // fail
-  685 |   expect<'def'>().type.toBe<number>(); // fail
-
-        at ./__typetests__/structure.tst.ts:682:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'unknown'.
-
-  681 | 
-  682 |   expect<'def'>().type.toBe<any>(); // fail
-  683 |   expect<'def'>().type.toBe<unknown>(); // fail
-      |                             ~~~~~~~
-  684 |   expect<'def'>().type.toBe<string>(); // fail
-  685 |   expect<'def'>().type.toBe<number>(); // fail
-  686 |   expect<'def'>().type.toBe<bigint>(); // fail
-
-        at ./__typetests__/structure.tst.ts:683:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'string'.
-
-  682 |   expect<'def'>().type.toBe<any>(); // fail
-  683 |   expect<'def'>().type.toBe<unknown>(); // fail
-  684 |   expect<'def'>().type.toBe<string>(); // fail
-      |                             ~~~~~~
-  685 |   expect<'def'>().type.toBe<number>(); // fail
-  686 |   expect<'def'>().type.toBe<bigint>(); // fail
-  687 |   expect<'def'>().type.toBe<boolean>(); // fail
-
-        at ./__typetests__/structure.tst.ts:684:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'number'.
-
-  683 |   expect<'def'>().type.toBe<unknown>(); // fail
-  684 |   expect<'def'>().type.toBe<string>(); // fail
-  685 |   expect<'def'>().type.toBe<number>(); // fail
-      |                             ~~~~~~
-  686 |   expect<'def'>().type.toBe<bigint>(); // fail
-  687 |   expect<'def'>().type.toBe<boolean>(); // fail
-  688 |   expect<'def'>().type.toBe<symbol>(); // fail
-
-        at ./__typetests__/structure.tst.ts:685:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'bigint'.
-
-  684 |   expect<'def'>().type.toBe<string>(); // fail
-  685 |   expect<'def'>().type.toBe<number>(); // fail
-  686 |   expect<'def'>().type.toBe<bigint>(); // fail
-      |                             ~~~~~~
-  687 |   expect<'def'>().type.toBe<boolean>(); // fail
-  688 |   expect<'def'>().type.toBe<symbol>(); // fail
-  689 |   expect<'def'>().type.toBe<object>(); // fail
-
-        at ./__typetests__/structure.tst.ts:686:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'boolean'.
-
-  685 |   expect<'def'>().type.toBe<number>(); // fail
-  686 |   expect<'def'>().type.toBe<bigint>(); // fail
-  687 |   expect<'def'>().type.toBe<boolean>(); // fail
-      |                             ~~~~~~~
-  688 |   expect<'def'>().type.toBe<symbol>(); // fail
-  689 |   expect<'def'>().type.toBe<object>(); // fail
-  690 |   expect<'def'>().type.toBe<void>(); // fail
-
-        at ./__typetests__/structure.tst.ts:687:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'symbol'.
-
-  686 |   expect<'def'>().type.toBe<bigint>(); // fail
-  687 |   expect<'def'>().type.toBe<boolean>(); // fail
-  688 |   expect<'def'>().type.toBe<symbol>(); // fail
-      |                             ~~~~~~
-  689 |   expect<'def'>().type.toBe<object>(); // fail
-  690 |   expect<'def'>().type.toBe<void>(); // fail
-  691 |   expect<'def'>().type.toBe<undefined>(); // fail
-
-        at ./__typetests__/structure.tst.ts:688:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'object'.
-
-  687 |   expect<'def'>().type.toBe<boolean>(); // fail
-  688 |   expect<'def'>().type.toBe<symbol>(); // fail
-  689 |   expect<'def'>().type.toBe<object>(); // fail
-      |                             ~~~~~~
-  690 |   expect<'def'>().type.toBe<void>(); // fail
-  691 |   expect<'def'>().type.toBe<undefined>(); // fail
-  692 |   expect<'def'>().type.toBe<null>(); // fail
-
-        at ./__typetests__/structure.tst.ts:689:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'void'.
-
-  688 |   expect<'def'>().type.toBe<symbol>(); // fail
-  689 |   expect<'def'>().type.toBe<object>(); // fail
-  690 |   expect<'def'>().type.toBe<void>(); // fail
-      |                             ~~~~
-  691 |   expect<'def'>().type.toBe<undefined>(); // fail
-  692 |   expect<'def'>().type.toBe<null>(); // fail
-  693 |   expect<'def'>().type.toBe<never>(); // fail
-
-        at ./__typetests__/structure.tst.ts:690:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'undefined'.
-
-  689 |   expect<'def'>().type.toBe<object>(); // fail
-  690 |   expect<'def'>().type.toBe<void>(); // fail
-  691 |   expect<'def'>().type.toBe<undefined>(); // fail
-      |                             ~~~~~~~~~
-  692 |   expect<'def'>().type.toBe<null>(); // fail
-  693 |   expect<'def'>().type.toBe<never>(); // fail
-  694 |   expect<'def'>().type.toBe<'abc'>(); // fail
-
-        at ./__typetests__/structure.tst.ts:691:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'null'.
-
-  690 |   expect<'def'>().type.toBe<void>(); // fail
-  691 |   expect<'def'>().type.toBe<undefined>(); // fail
-  692 |   expect<'def'>().type.toBe<null>(); // fail
-      |                             ~~~~
-  693 |   expect<'def'>().type.toBe<never>(); // fail
-  694 |   expect<'def'>().type.toBe<'abc'>(); // fail
-  695 |   expect<'def'>().type.toBe<123>(); // fail
-
-        at ./__typetests__/structure.tst.ts:692:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'never'.
-
-  691 |   expect<'def'>().type.toBe<undefined>(); // fail
-  692 |   expect<'def'>().type.toBe<null>(); // fail
-  693 |   expect<'def'>().type.toBe<never>(); // fail
-      |                             ~~~~~
-  694 |   expect<'def'>().type.toBe<'abc'>(); // fail
-  695 |   expect<'def'>().type.toBe<123>(); // fail
-  696 |   expect<'def'>().type.toBe<456>(); // fail
-
-        at ./__typetests__/structure.tst.ts:693:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type '"abc"'.
-
-  692 |   expect<'def'>().type.toBe<null>(); // fail
-  693 |   expect<'def'>().type.toBe<never>(); // fail
-  694 |   expect<'def'>().type.toBe<'abc'>(); // fail
-      |                             ~~~~~
-  695 |   expect<'def'>().type.toBe<123>(); // fail
-  696 |   expect<'def'>().type.toBe<456>(); // fail
-  697 |   expect<'def'>().type.toBe<887n>(); // fail
-
-        at ./__typetests__/structure.tst.ts:694:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type '123'.
-
-  693 |   expect<'def'>().type.toBe<never>(); // fail
-  694 |   expect<'def'>().type.toBe<'abc'>(); // fail
-  695 |   expect<'def'>().type.toBe<123>(); // fail
-      |                             ~~~
-  696 |   expect<'def'>().type.toBe<456>(); // fail
-  697 |   expect<'def'>().type.toBe<887n>(); // fail
-  698 |   expect<'def'>().type.toBe<998n>(); // fail
-
-        at ./__typetests__/structure.tst.ts:695:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type '456'.
-
-  694 |   expect<'def'>().type.toBe<'abc'>(); // fail
-  695 |   expect<'def'>().type.toBe<123>(); // fail
-  696 |   expect<'def'>().type.toBe<456>(); // fail
-      |                             ~~~
-  697 |   expect<'def'>().type.toBe<887n>(); // fail
-  698 |   expect<'def'>().type.toBe<998n>(); // fail
-  699 |   expect<'def'>().type.toBe<true>(); // fail
-
-        at ./__typetests__/structure.tst.ts:696:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type '887n'.
-
-  695 |   expect<'def'>().type.toBe<123>(); // fail
-  696 |   expect<'def'>().type.toBe<456>(); // fail
-  697 |   expect<'def'>().type.toBe<887n>(); // fail
-      |                             ~~~~
-  698 |   expect<'def'>().type.toBe<998n>(); // fail
-  699 |   expect<'def'>().type.toBe<true>(); // fail
-  700 |   expect<'def'>().type.toBe<false>(); // fail
-
-        at ./__typetests__/structure.tst.ts:697:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type '998n'.
-
-  696 |   expect<'def'>().type.toBe<456>(); // fail
-  697 |   expect<'def'>().type.toBe<887n>(); // fail
-  698 |   expect<'def'>().type.toBe<998n>(); // fail
-      |                             ~~~~
-  699 |   expect<'def'>().type.toBe<true>(); // fail
-  700 |   expect<'def'>().type.toBe<false>(); // fail
-  701 |   expect<'def'>().type.toBe<Array<string>>(); // fail
-
-        at ./__typetests__/structure.tst.ts:698:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'true'.
-
-  697 |   expect<'def'>().type.toBe<887n>(); // fail
-  698 |   expect<'def'>().type.toBe<998n>(); // fail
-  699 |   expect<'def'>().type.toBe<true>(); // fail
-      |                             ~~~~
-  700 |   expect<'def'>().type.toBe<false>(); // fail
-  701 |   expect<'def'>().type.toBe<Array<string>>(); // fail
-  702 |   expect<'def'>().type.toBe<number[]>(); // fail
-
-        at ./__typetests__/structure.tst.ts:699:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'false'.
-
-  698 |   expect<'def'>().type.toBe<998n>(); // fail
-  699 |   expect<'def'>().type.toBe<true>(); // fail
-  700 |   expect<'def'>().type.toBe<false>(); // fail
-      |                             ~~~~~
-  701 |   expect<'def'>().type.toBe<Array<string>>(); // fail
-  702 |   expect<'def'>().type.toBe<number[]>(); // fail
-  703 | });
-
-        at ./__typetests__/structure.tst.ts:700:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'string[]'.
-
-  699 |   expect<'def'>().type.toBe<true>(); // fail
-  700 |   expect<'def'>().type.toBe<false>(); // fail
-  701 |   expect<'def'>().type.toBe<Array<string>>(); // fail
-      |                             ~~~~~~~~~~~~~
-  702 |   expect<'def'>().type.toBe<number[]>(); // fail
-  703 | });
-  704 | 
-
-        at ./__typetests__/structure.tst.ts:701:29 ❭ is 'def'?
-
-Error: Type '"def"' is not the same as type 'number[]'.
-
-  700 |   expect<'def'>().type.toBe<false>(); // fail
-  701 |   expect<'def'>().type.toBe<Array<string>>(); // fail
-  702 |   expect<'def'>().type.toBe<number[]>(); // fail
-      |                             ~~~~~~~~
-  703 | });
-  704 | 
-  705 | test("is NOT 'def'?", () => {
-
-        at ./__typetests__/structure.tst.ts:702:29 ❭ is 'def'?
-
-Error: Type '"def"' is the same as type '"def"'.
-
-  726 |   expect<'def'>().type.not.toBe<number[]>();
+  726 |   expect<'abc'>().type.not.toBe<string | Array<string>>();
   727 | 
-  728 |   expect<'def'>().type.not.toBe<'def'>(); // fail
+  728 |   expect<'abc'>().type.not.toBe<'abc'>(); // fail
       |                                 ~~~~~
   729 | });
   730 | 
-  731 | test("is 123?", () => {
+  731 | test("is 'def'?", () => {
 
-        at ./__typetests__/structure.tst.ts:728:33 ❭ is NOT 'def'?
+        at ./__typetests__/structure.tst.ts:728:33 ❭ is NOT 'abc'?
+
+Error: Type '"def"' is not the same as type 'any'.
+
+  732 |   expect<'def'>().type.toBe<'def'>();
+  733 | 
+  734 |   expect<'def'>().type.toBe<any>(); // fail
+      |                             ~~~
+  735 |   expect<'def'>().type.toBe<unknown>(); // fail
+  736 |   expect<'def'>().type.toBe<string>(); // fail
+  737 |   expect<'def'>().type.toBe<number>(); // fail
+
+        at ./__typetests__/structure.tst.ts:734:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'unknown'.
+
+  733 | 
+  734 |   expect<'def'>().type.toBe<any>(); // fail
+  735 |   expect<'def'>().type.toBe<unknown>(); // fail
+      |                             ~~~~~~~
+  736 |   expect<'def'>().type.toBe<string>(); // fail
+  737 |   expect<'def'>().type.toBe<number>(); // fail
+  738 |   expect<'def'>().type.toBe<bigint>(); // fail
+
+        at ./__typetests__/structure.tst.ts:735:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'string'.
+
+  734 |   expect<'def'>().type.toBe<any>(); // fail
+  735 |   expect<'def'>().type.toBe<unknown>(); // fail
+  736 |   expect<'def'>().type.toBe<string>(); // fail
+      |                             ~~~~~~
+  737 |   expect<'def'>().type.toBe<number>(); // fail
+  738 |   expect<'def'>().type.toBe<bigint>(); // fail
+  739 |   expect<'def'>().type.toBe<boolean>(); // fail
+
+        at ./__typetests__/structure.tst.ts:736:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'number'.
+
+  735 |   expect<'def'>().type.toBe<unknown>(); // fail
+  736 |   expect<'def'>().type.toBe<string>(); // fail
+  737 |   expect<'def'>().type.toBe<number>(); // fail
+      |                             ~~~~~~
+  738 |   expect<'def'>().type.toBe<bigint>(); // fail
+  739 |   expect<'def'>().type.toBe<boolean>(); // fail
+  740 |   expect<'def'>().type.toBe<symbol>(); // fail
+
+        at ./__typetests__/structure.tst.ts:737:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'bigint'.
+
+  736 |   expect<'def'>().type.toBe<string>(); // fail
+  737 |   expect<'def'>().type.toBe<number>(); // fail
+  738 |   expect<'def'>().type.toBe<bigint>(); // fail
+      |                             ~~~~~~
+  739 |   expect<'def'>().type.toBe<boolean>(); // fail
+  740 |   expect<'def'>().type.toBe<symbol>(); // fail
+  741 |   expect<'def'>().type.toBe<object>(); // fail
+
+        at ./__typetests__/structure.tst.ts:738:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'boolean'.
+
+  737 |   expect<'def'>().type.toBe<number>(); // fail
+  738 |   expect<'def'>().type.toBe<bigint>(); // fail
+  739 |   expect<'def'>().type.toBe<boolean>(); // fail
+      |                             ~~~~~~~
+  740 |   expect<'def'>().type.toBe<symbol>(); // fail
+  741 |   expect<'def'>().type.toBe<object>(); // fail
+  742 |   expect<'def'>().type.toBe<void>(); // fail
+
+        at ./__typetests__/structure.tst.ts:739:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'symbol'.
+
+  738 |   expect<'def'>().type.toBe<bigint>(); // fail
+  739 |   expect<'def'>().type.toBe<boolean>(); // fail
+  740 |   expect<'def'>().type.toBe<symbol>(); // fail
+      |                             ~~~~~~
+  741 |   expect<'def'>().type.toBe<object>(); // fail
+  742 |   expect<'def'>().type.toBe<void>(); // fail
+  743 |   expect<'def'>().type.toBe<undefined>(); // fail
+
+        at ./__typetests__/structure.tst.ts:740:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'object'.
+
+  739 |   expect<'def'>().type.toBe<boolean>(); // fail
+  740 |   expect<'def'>().type.toBe<symbol>(); // fail
+  741 |   expect<'def'>().type.toBe<object>(); // fail
+      |                             ~~~~~~
+  742 |   expect<'def'>().type.toBe<void>(); // fail
+  743 |   expect<'def'>().type.toBe<undefined>(); // fail
+  744 |   expect<'def'>().type.toBe<null>(); // fail
+
+        at ./__typetests__/structure.tst.ts:741:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'void'.
+
+  740 |   expect<'def'>().type.toBe<symbol>(); // fail
+  741 |   expect<'def'>().type.toBe<object>(); // fail
+  742 |   expect<'def'>().type.toBe<void>(); // fail
+      |                             ~~~~
+  743 |   expect<'def'>().type.toBe<undefined>(); // fail
+  744 |   expect<'def'>().type.toBe<null>(); // fail
+  745 |   expect<'def'>().type.toBe<never>(); // fail
+
+        at ./__typetests__/structure.tst.ts:742:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'undefined'.
+
+  741 |   expect<'def'>().type.toBe<object>(); // fail
+  742 |   expect<'def'>().type.toBe<void>(); // fail
+  743 |   expect<'def'>().type.toBe<undefined>(); // fail
+      |                             ~~~~~~~~~
+  744 |   expect<'def'>().type.toBe<null>(); // fail
+  745 |   expect<'def'>().type.toBe<never>(); // fail
+  746 |   expect<'def'>().type.toBe<'abc'>(); // fail
+
+        at ./__typetests__/structure.tst.ts:743:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'null'.
+
+  742 |   expect<'def'>().type.toBe<void>(); // fail
+  743 |   expect<'def'>().type.toBe<undefined>(); // fail
+  744 |   expect<'def'>().type.toBe<null>(); // fail
+      |                             ~~~~
+  745 |   expect<'def'>().type.toBe<never>(); // fail
+  746 |   expect<'def'>().type.toBe<'abc'>(); // fail
+  747 |   expect<'def'>().type.toBe<123>(); // fail
+
+        at ./__typetests__/structure.tst.ts:744:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'never'.
+
+  743 |   expect<'def'>().type.toBe<undefined>(); // fail
+  744 |   expect<'def'>().type.toBe<null>(); // fail
+  745 |   expect<'def'>().type.toBe<never>(); // fail
+      |                             ~~~~~
+  746 |   expect<'def'>().type.toBe<'abc'>(); // fail
+  747 |   expect<'def'>().type.toBe<123>(); // fail
+  748 |   expect<'def'>().type.toBe<456>(); // fail
+
+        at ./__typetests__/structure.tst.ts:745:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type '"abc"'.
+
+  744 |   expect<'def'>().type.toBe<null>(); // fail
+  745 |   expect<'def'>().type.toBe<never>(); // fail
+  746 |   expect<'def'>().type.toBe<'abc'>(); // fail
+      |                             ~~~~~
+  747 |   expect<'def'>().type.toBe<123>(); // fail
+  748 |   expect<'def'>().type.toBe<456>(); // fail
+  749 |   expect<'def'>().type.toBe<887n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:746:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type '123'.
+
+  745 |   expect<'def'>().type.toBe<never>(); // fail
+  746 |   expect<'def'>().type.toBe<'abc'>(); // fail
+  747 |   expect<'def'>().type.toBe<123>(); // fail
+      |                             ~~~
+  748 |   expect<'def'>().type.toBe<456>(); // fail
+  749 |   expect<'def'>().type.toBe<887n>(); // fail
+  750 |   expect<'def'>().type.toBe<998n>(); // fail
+
+        at ./__typetests__/structure.tst.ts:747:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type '456'.
+
+  746 |   expect<'def'>().type.toBe<'abc'>(); // fail
+  747 |   expect<'def'>().type.toBe<123>(); // fail
+  748 |   expect<'def'>().type.toBe<456>(); // fail
+      |                             ~~~
+  749 |   expect<'def'>().type.toBe<887n>(); // fail
+  750 |   expect<'def'>().type.toBe<998n>(); // fail
+  751 |   expect<'def'>().type.toBe<true>(); // fail
+
+        at ./__typetests__/structure.tst.ts:748:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type '887n'.
+
+  747 |   expect<'def'>().type.toBe<123>(); // fail
+  748 |   expect<'def'>().type.toBe<456>(); // fail
+  749 |   expect<'def'>().type.toBe<887n>(); // fail
+      |                             ~~~~
+  750 |   expect<'def'>().type.toBe<998n>(); // fail
+  751 |   expect<'def'>().type.toBe<true>(); // fail
+  752 |   expect<'def'>().type.toBe<false>(); // fail
+
+        at ./__typetests__/structure.tst.ts:749:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type '998n'.
+
+  748 |   expect<'def'>().type.toBe<456>(); // fail
+  749 |   expect<'def'>().type.toBe<887n>(); // fail
+  750 |   expect<'def'>().type.toBe<998n>(); // fail
+      |                             ~~~~
+  751 |   expect<'def'>().type.toBe<true>(); // fail
+  752 |   expect<'def'>().type.toBe<false>(); // fail
+  753 |   expect<'def'>().type.toBe<Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:750:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'true'.
+
+  749 |   expect<'def'>().type.toBe<887n>(); // fail
+  750 |   expect<'def'>().type.toBe<998n>(); // fail
+  751 |   expect<'def'>().type.toBe<true>(); // fail
+      |                             ~~~~
+  752 |   expect<'def'>().type.toBe<false>(); // fail
+  753 |   expect<'def'>().type.toBe<Array<string>>(); // fail
+  754 |   expect<'def'>().type.toBe<number[]>(); // fail
+
+        at ./__typetests__/structure.tst.ts:751:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'false'.
+
+  750 |   expect<'def'>().type.toBe<998n>(); // fail
+  751 |   expect<'def'>().type.toBe<true>(); // fail
+  752 |   expect<'def'>().type.toBe<false>(); // fail
+      |                             ~~~~~
+  753 |   expect<'def'>().type.toBe<Array<string>>(); // fail
+  754 |   expect<'def'>().type.toBe<number[]>(); // fail
+  755 |   expect<'def'>().type.toBe<string | number>(); // fail
+
+        at ./__typetests__/structure.tst.ts:752:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'string[]'.
+
+  751 |   expect<'def'>().type.toBe<true>(); // fail
+  752 |   expect<'def'>().type.toBe<false>(); // fail
+  753 |   expect<'def'>().type.toBe<Array<string>>(); // fail
+      |                             ~~~~~~~~~~~~~
+  754 |   expect<'def'>().type.toBe<number[]>(); // fail
+  755 |   expect<'def'>().type.toBe<string | number>(); // fail
+  756 |   expect<'def'>().type.toBe<string | Array<string>>(); // fail
+
+        at ./__typetests__/structure.tst.ts:753:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'number[]'.
+
+  752 |   expect<'def'>().type.toBe<false>(); // fail
+  753 |   expect<'def'>().type.toBe<Array<string>>(); // fail
+  754 |   expect<'def'>().type.toBe<number[]>(); // fail
+      |                             ~~~~~~~~
+  755 |   expect<'def'>().type.toBe<string | number>(); // fail
+  756 |   expect<'def'>().type.toBe<string | Array<string>>(); // fail
+  757 | });
+
+        at ./__typetests__/structure.tst.ts:754:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'string | number'.
+
+  753 |   expect<'def'>().type.toBe<Array<string>>(); // fail
+  754 |   expect<'def'>().type.toBe<number[]>(); // fail
+  755 |   expect<'def'>().type.toBe<string | number>(); // fail
+      |                             ~~~~~~~~~~~~~~~
+  756 |   expect<'def'>().type.toBe<string | Array<string>>(); // fail
+  757 | });
+  758 | 
+
+        at ./__typetests__/structure.tst.ts:755:29 ❭ is 'def'?
+
+Error: Type '"def"' is not the same as type 'string | string[]'.
+
+  754 |   expect<'def'>().type.toBe<number[]>(); // fail
+  755 |   expect<'def'>().type.toBe<string | number>(); // fail
+  756 |   expect<'def'>().type.toBe<string | Array<string>>(); // fail
+      |                             ~~~~~~~~~~~~~~~~~~~~~~
+  757 | });
+  758 | 
+  759 | test("is NOT 'def'?", () => {
+
+        at ./__typetests__/structure.tst.ts:756:29 ❭ is 'def'?
+
+Error: Type '"def"' is the same as type '"def"'.
+
+  782 |   expect<'def'>().type.not.toBe<string | Array<string>>();
+  783 | 
+  784 |   expect<'def'>().type.not.toBe<'def'>(); // fail
+      |                                 ~~~~~
+  785 | });
+  786 | 
+  787 | test("is 123?", () => {
+
+        at ./__typetests__/structure.tst.ts:784:33 ❭ is NOT 'def'?
 
 Error: Type '123' is not the same as type 'any'.
 
-  732 |   expect<123>().type.toBe<123>();
-  733 | 
-  734 |   expect<123>().type.toBe<any>(); // fail
+  788 |   expect<123>().type.toBe<123>();
+  789 | 
+  790 |   expect<123>().type.toBe<any>(); // fail
       |                           ~~~
-  735 |   expect<123>().type.toBe<unknown>(); // fail
-  736 |   expect<123>().type.toBe<string>(); // fail
-  737 |   expect<123>().type.toBe<number>(); // fail
+  791 |   expect<123>().type.toBe<unknown>(); // fail
+  792 |   expect<123>().type.toBe<string>(); // fail
+  793 |   expect<123>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:734:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:790:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'unknown'.
 
-  733 | 
-  734 |   expect<123>().type.toBe<any>(); // fail
-  735 |   expect<123>().type.toBe<unknown>(); // fail
+  789 | 
+  790 |   expect<123>().type.toBe<any>(); // fail
+  791 |   expect<123>().type.toBe<unknown>(); // fail
       |                           ~~~~~~~
-  736 |   expect<123>().type.toBe<string>(); // fail
-  737 |   expect<123>().type.toBe<number>(); // fail
-  738 |   expect<123>().type.toBe<bigint>(); // fail
+  792 |   expect<123>().type.toBe<string>(); // fail
+  793 |   expect<123>().type.toBe<number>(); // fail
+  794 |   expect<123>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:735:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:791:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'string'.
 
-  734 |   expect<123>().type.toBe<any>(); // fail
-  735 |   expect<123>().type.toBe<unknown>(); // fail
-  736 |   expect<123>().type.toBe<string>(); // fail
+  790 |   expect<123>().type.toBe<any>(); // fail
+  791 |   expect<123>().type.toBe<unknown>(); // fail
+  792 |   expect<123>().type.toBe<string>(); // fail
       |                           ~~~~~~
-  737 |   expect<123>().type.toBe<number>(); // fail
-  738 |   expect<123>().type.toBe<bigint>(); // fail
-  739 |   expect<123>().type.toBe<boolean>(); // fail
+  793 |   expect<123>().type.toBe<number>(); // fail
+  794 |   expect<123>().type.toBe<bigint>(); // fail
+  795 |   expect<123>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:736:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:792:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'number'.
 
-  735 |   expect<123>().type.toBe<unknown>(); // fail
-  736 |   expect<123>().type.toBe<string>(); // fail
-  737 |   expect<123>().type.toBe<number>(); // fail
+  791 |   expect<123>().type.toBe<unknown>(); // fail
+  792 |   expect<123>().type.toBe<string>(); // fail
+  793 |   expect<123>().type.toBe<number>(); // fail
       |                           ~~~~~~
-  738 |   expect<123>().type.toBe<bigint>(); // fail
-  739 |   expect<123>().type.toBe<boolean>(); // fail
-  740 |   expect<123>().type.toBe<symbol>(); // fail
+  794 |   expect<123>().type.toBe<bigint>(); // fail
+  795 |   expect<123>().type.toBe<boolean>(); // fail
+  796 |   expect<123>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:737:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:793:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'bigint'.
 
-  736 |   expect<123>().type.toBe<string>(); // fail
-  737 |   expect<123>().type.toBe<number>(); // fail
-  738 |   expect<123>().type.toBe<bigint>(); // fail
+  792 |   expect<123>().type.toBe<string>(); // fail
+  793 |   expect<123>().type.toBe<number>(); // fail
+  794 |   expect<123>().type.toBe<bigint>(); // fail
       |                           ~~~~~~
-  739 |   expect<123>().type.toBe<boolean>(); // fail
-  740 |   expect<123>().type.toBe<symbol>(); // fail
-  741 |   expect<123>().type.toBe<object>(); // fail
+  795 |   expect<123>().type.toBe<boolean>(); // fail
+  796 |   expect<123>().type.toBe<symbol>(); // fail
+  797 |   expect<123>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:738:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:794:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'boolean'.
 
-  737 |   expect<123>().type.toBe<number>(); // fail
-  738 |   expect<123>().type.toBe<bigint>(); // fail
-  739 |   expect<123>().type.toBe<boolean>(); // fail
+  793 |   expect<123>().type.toBe<number>(); // fail
+  794 |   expect<123>().type.toBe<bigint>(); // fail
+  795 |   expect<123>().type.toBe<boolean>(); // fail
       |                           ~~~~~~~
-  740 |   expect<123>().type.toBe<symbol>(); // fail
-  741 |   expect<123>().type.toBe<object>(); // fail
-  742 |   expect<123>().type.toBe<void>(); // fail
+  796 |   expect<123>().type.toBe<symbol>(); // fail
+  797 |   expect<123>().type.toBe<object>(); // fail
+  798 |   expect<123>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:739:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:795:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'symbol'.
 
-  738 |   expect<123>().type.toBe<bigint>(); // fail
-  739 |   expect<123>().type.toBe<boolean>(); // fail
-  740 |   expect<123>().type.toBe<symbol>(); // fail
+  794 |   expect<123>().type.toBe<bigint>(); // fail
+  795 |   expect<123>().type.toBe<boolean>(); // fail
+  796 |   expect<123>().type.toBe<symbol>(); // fail
       |                           ~~~~~~
-  741 |   expect<123>().type.toBe<object>(); // fail
-  742 |   expect<123>().type.toBe<void>(); // fail
-  743 |   expect<123>().type.toBe<undefined>(); // fail
+  797 |   expect<123>().type.toBe<object>(); // fail
+  798 |   expect<123>().type.toBe<void>(); // fail
+  799 |   expect<123>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:740:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:796:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'object'.
 
-  739 |   expect<123>().type.toBe<boolean>(); // fail
-  740 |   expect<123>().type.toBe<symbol>(); // fail
-  741 |   expect<123>().type.toBe<object>(); // fail
+  795 |   expect<123>().type.toBe<boolean>(); // fail
+  796 |   expect<123>().type.toBe<symbol>(); // fail
+  797 |   expect<123>().type.toBe<object>(); // fail
       |                           ~~~~~~
-  742 |   expect<123>().type.toBe<void>(); // fail
-  743 |   expect<123>().type.toBe<undefined>(); // fail
-  744 |   expect<123>().type.toBe<null>(); // fail
+  798 |   expect<123>().type.toBe<void>(); // fail
+  799 |   expect<123>().type.toBe<undefined>(); // fail
+  800 |   expect<123>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:741:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:797:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'void'.
 
-  740 |   expect<123>().type.toBe<symbol>(); // fail
-  741 |   expect<123>().type.toBe<object>(); // fail
-  742 |   expect<123>().type.toBe<void>(); // fail
+  796 |   expect<123>().type.toBe<symbol>(); // fail
+  797 |   expect<123>().type.toBe<object>(); // fail
+  798 |   expect<123>().type.toBe<void>(); // fail
       |                           ~~~~
-  743 |   expect<123>().type.toBe<undefined>(); // fail
-  744 |   expect<123>().type.toBe<null>(); // fail
-  745 |   expect<123>().type.toBe<never>(); // fail
+  799 |   expect<123>().type.toBe<undefined>(); // fail
+  800 |   expect<123>().type.toBe<null>(); // fail
+  801 |   expect<123>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:742:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:798:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'undefined'.
 
-  741 |   expect<123>().type.toBe<object>(); // fail
-  742 |   expect<123>().type.toBe<void>(); // fail
-  743 |   expect<123>().type.toBe<undefined>(); // fail
+  797 |   expect<123>().type.toBe<object>(); // fail
+  798 |   expect<123>().type.toBe<void>(); // fail
+  799 |   expect<123>().type.toBe<undefined>(); // fail
       |                           ~~~~~~~~~
-  744 |   expect<123>().type.toBe<null>(); // fail
-  745 |   expect<123>().type.toBe<never>(); // fail
-  746 |   expect<123>().type.toBe<'abc'>(); // fail
+  800 |   expect<123>().type.toBe<null>(); // fail
+  801 |   expect<123>().type.toBe<never>(); // fail
+  802 |   expect<123>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:743:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:799:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'null'.
 
-  742 |   expect<123>().type.toBe<void>(); // fail
-  743 |   expect<123>().type.toBe<undefined>(); // fail
-  744 |   expect<123>().type.toBe<null>(); // fail
+  798 |   expect<123>().type.toBe<void>(); // fail
+  799 |   expect<123>().type.toBe<undefined>(); // fail
+  800 |   expect<123>().type.toBe<null>(); // fail
       |                           ~~~~
-  745 |   expect<123>().type.toBe<never>(); // fail
-  746 |   expect<123>().type.toBe<'abc'>(); // fail
-  747 |   expect<123>().type.toBe<'def'>(); // fail
+  801 |   expect<123>().type.toBe<never>(); // fail
+  802 |   expect<123>().type.toBe<'abc'>(); // fail
+  803 |   expect<123>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:744:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:800:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'never'.
 
-  743 |   expect<123>().type.toBe<undefined>(); // fail
-  744 |   expect<123>().type.toBe<null>(); // fail
-  745 |   expect<123>().type.toBe<never>(); // fail
+  799 |   expect<123>().type.toBe<undefined>(); // fail
+  800 |   expect<123>().type.toBe<null>(); // fail
+  801 |   expect<123>().type.toBe<never>(); // fail
       |                           ~~~~~
-  746 |   expect<123>().type.toBe<'abc'>(); // fail
-  747 |   expect<123>().type.toBe<'def'>(); // fail
-  748 |   expect<123>().type.toBe<456>(); // fail
+  802 |   expect<123>().type.toBe<'abc'>(); // fail
+  803 |   expect<123>().type.toBe<'def'>(); // fail
+  804 |   expect<123>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:745:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:801:27 ❭ is 123?
 
 Error: Type '123' is not the same as type '"abc"'.
 
-  744 |   expect<123>().type.toBe<null>(); // fail
-  745 |   expect<123>().type.toBe<never>(); // fail
-  746 |   expect<123>().type.toBe<'abc'>(); // fail
+  800 |   expect<123>().type.toBe<null>(); // fail
+  801 |   expect<123>().type.toBe<never>(); // fail
+  802 |   expect<123>().type.toBe<'abc'>(); // fail
       |                           ~~~~~
-  747 |   expect<123>().type.toBe<'def'>(); // fail
-  748 |   expect<123>().type.toBe<456>(); // fail
-  749 |   expect<123>().type.toBe<887n>(); // fail
+  803 |   expect<123>().type.toBe<'def'>(); // fail
+  804 |   expect<123>().type.toBe<456>(); // fail
+  805 |   expect<123>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:746:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:802:27 ❭ is 123?
 
 Error: Type '123' is not the same as type '"def"'.
 
-  745 |   expect<123>().type.toBe<never>(); // fail
-  746 |   expect<123>().type.toBe<'abc'>(); // fail
-  747 |   expect<123>().type.toBe<'def'>(); // fail
+  801 |   expect<123>().type.toBe<never>(); // fail
+  802 |   expect<123>().type.toBe<'abc'>(); // fail
+  803 |   expect<123>().type.toBe<'def'>(); // fail
       |                           ~~~~~
-  748 |   expect<123>().type.toBe<456>(); // fail
-  749 |   expect<123>().type.toBe<887n>(); // fail
-  750 |   expect<123>().type.toBe<998n>(); // fail
+  804 |   expect<123>().type.toBe<456>(); // fail
+  805 |   expect<123>().type.toBe<887n>(); // fail
+  806 |   expect<123>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:747:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:803:27 ❭ is 123?
 
 Error: Type '123' is not the same as type '456'.
 
-  746 |   expect<123>().type.toBe<'abc'>(); // fail
-  747 |   expect<123>().type.toBe<'def'>(); // fail
-  748 |   expect<123>().type.toBe<456>(); // fail
+  802 |   expect<123>().type.toBe<'abc'>(); // fail
+  803 |   expect<123>().type.toBe<'def'>(); // fail
+  804 |   expect<123>().type.toBe<456>(); // fail
       |                           ~~~
-  749 |   expect<123>().type.toBe<887n>(); // fail
-  750 |   expect<123>().type.toBe<998n>(); // fail
-  751 |   expect<123>().type.toBe<true>(); // fail
+  805 |   expect<123>().type.toBe<887n>(); // fail
+  806 |   expect<123>().type.toBe<998n>(); // fail
+  807 |   expect<123>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:748:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:804:27 ❭ is 123?
 
 Error: Type '123' is not the same as type '887n'.
 
-  747 |   expect<123>().type.toBe<'def'>(); // fail
-  748 |   expect<123>().type.toBe<456>(); // fail
-  749 |   expect<123>().type.toBe<887n>(); // fail
+  803 |   expect<123>().type.toBe<'def'>(); // fail
+  804 |   expect<123>().type.toBe<456>(); // fail
+  805 |   expect<123>().type.toBe<887n>(); // fail
       |                           ~~~~
-  750 |   expect<123>().type.toBe<998n>(); // fail
-  751 |   expect<123>().type.toBe<true>(); // fail
-  752 |   expect<123>().type.toBe<false>(); // fail
+  806 |   expect<123>().type.toBe<998n>(); // fail
+  807 |   expect<123>().type.toBe<true>(); // fail
+  808 |   expect<123>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:749:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:805:27 ❭ is 123?
 
 Error: Type '123' is not the same as type '998n'.
 
-  748 |   expect<123>().type.toBe<456>(); // fail
-  749 |   expect<123>().type.toBe<887n>(); // fail
-  750 |   expect<123>().type.toBe<998n>(); // fail
+  804 |   expect<123>().type.toBe<456>(); // fail
+  805 |   expect<123>().type.toBe<887n>(); // fail
+  806 |   expect<123>().type.toBe<998n>(); // fail
       |                           ~~~~
-  751 |   expect<123>().type.toBe<true>(); // fail
-  752 |   expect<123>().type.toBe<false>(); // fail
-  753 |   expect<123>().type.toBe<Array<string>>(); // fail
+  807 |   expect<123>().type.toBe<true>(); // fail
+  808 |   expect<123>().type.toBe<false>(); // fail
+  809 |   expect<123>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:750:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:806:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'true'.
 
-  749 |   expect<123>().type.toBe<887n>(); // fail
-  750 |   expect<123>().type.toBe<998n>(); // fail
-  751 |   expect<123>().type.toBe<true>(); // fail
+  805 |   expect<123>().type.toBe<887n>(); // fail
+  806 |   expect<123>().type.toBe<998n>(); // fail
+  807 |   expect<123>().type.toBe<true>(); // fail
       |                           ~~~~
-  752 |   expect<123>().type.toBe<false>(); // fail
-  753 |   expect<123>().type.toBe<Array<string>>(); // fail
-  754 |   expect<123>().type.toBe<number[]>(); // fail
+  808 |   expect<123>().type.toBe<false>(); // fail
+  809 |   expect<123>().type.toBe<Array<string>>(); // fail
+  810 |   expect<123>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:751:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:807:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'false'.
 
-  750 |   expect<123>().type.toBe<998n>(); // fail
-  751 |   expect<123>().type.toBe<true>(); // fail
-  752 |   expect<123>().type.toBe<false>(); // fail
+  806 |   expect<123>().type.toBe<998n>(); // fail
+  807 |   expect<123>().type.toBe<true>(); // fail
+  808 |   expect<123>().type.toBe<false>(); // fail
       |                           ~~~~~
-  753 |   expect<123>().type.toBe<Array<string>>(); // fail
-  754 |   expect<123>().type.toBe<number[]>(); // fail
-  755 | });
+  809 |   expect<123>().type.toBe<Array<string>>(); // fail
+  810 |   expect<123>().type.toBe<number[]>(); // fail
+  811 |   expect<123>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:752:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:808:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'string[]'.
 
-  751 |   expect<123>().type.toBe<true>(); // fail
-  752 |   expect<123>().type.toBe<false>(); // fail
-  753 |   expect<123>().type.toBe<Array<string>>(); // fail
+  807 |   expect<123>().type.toBe<true>(); // fail
+  808 |   expect<123>().type.toBe<false>(); // fail
+  809 |   expect<123>().type.toBe<Array<string>>(); // fail
       |                           ~~~~~~~~~~~~~
-  754 |   expect<123>().type.toBe<number[]>(); // fail
-  755 | });
-  756 | 
+  810 |   expect<123>().type.toBe<number[]>(); // fail
+  811 |   expect<123>().type.toBe<string | number>(); // fail
+  812 |   expect<123>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:753:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:809:27 ❭ is 123?
 
 Error: Type '123' is not the same as type 'number[]'.
 
-  752 |   expect<123>().type.toBe<false>(); // fail
-  753 |   expect<123>().type.toBe<Array<string>>(); // fail
-  754 |   expect<123>().type.toBe<number[]>(); // fail
+  808 |   expect<123>().type.toBe<false>(); // fail
+  809 |   expect<123>().type.toBe<Array<string>>(); // fail
+  810 |   expect<123>().type.toBe<number[]>(); // fail
       |                           ~~~~~~~~
-  755 | });
-  756 | 
-  757 | test("is NOT 123?", () => {
+  811 |   expect<123>().type.toBe<string | number>(); // fail
+  812 |   expect<123>().type.toBe<string | Array<string>>(); // fail
+  813 | });
 
-        at ./__typetests__/structure.tst.ts:754:27 ❭ is 123?
+        at ./__typetests__/structure.tst.ts:810:27 ❭ is 123?
+
+Error: Type '123' is not the same as type 'string | number'.
+
+  809 |   expect<123>().type.toBe<Array<string>>(); // fail
+  810 |   expect<123>().type.toBe<number[]>(); // fail
+  811 |   expect<123>().type.toBe<string | number>(); // fail
+      |                           ~~~~~~~~~~~~~~~
+  812 |   expect<123>().type.toBe<string | Array<string>>(); // fail
+  813 | });
+  814 | 
+
+        at ./__typetests__/structure.tst.ts:811:27 ❭ is 123?
+
+Error: Type '123' is not the same as type 'string | string[]'.
+
+  810 |   expect<123>().type.toBe<number[]>(); // fail
+  811 |   expect<123>().type.toBe<string | number>(); // fail
+  812 |   expect<123>().type.toBe<string | Array<string>>(); // fail
+      |                           ~~~~~~~~~~~~~~~~~~~~~~
+  813 | });
+  814 | 
+  815 | test("is NOT 123?", () => {
+
+        at ./__typetests__/structure.tst.ts:812:27 ❭ is 123?
 
 Error: Type '123' is the same as type '123'.
 
-  778 |   expect<123>().type.not.toBe<number[]>();
-  779 | 
-  780 |   expect<123>().type.not.toBe<123>(); // fail
+  838 |   expect<123>().type.not.toBe<string | Array<string>>();
+  839 | 
+  840 |   expect<123>().type.not.toBe<123>(); // fail
       |                               ~~~
-  781 | });
-  782 | 
-  783 | test("is 456?", () => {
+  841 | });
+  842 | 
+  843 | test("is 456?", () => {
 
-        at ./__typetests__/structure.tst.ts:780:31 ❭ is NOT 123?
+        at ./__typetests__/structure.tst.ts:840:31 ❭ is NOT 123?
 
 Error: Type '456' is not the same as type 'any'.
 
-  784 |   expect<456>().type.toBe<456>();
-  785 | 
-  786 |   expect<456>().type.toBe<any>(); // fail
+  844 |   expect<456>().type.toBe<456>();
+  845 | 
+  846 |   expect<456>().type.toBe<any>(); // fail
       |                           ~~~
-  787 |   expect<456>().type.toBe<unknown>(); // fail
-  788 |   expect<456>().type.toBe<string>(); // fail
-  789 |   expect<456>().type.toBe<number>(); // fail
+  847 |   expect<456>().type.toBe<unknown>(); // fail
+  848 |   expect<456>().type.toBe<string>(); // fail
+  849 |   expect<456>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:786:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:846:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'unknown'.
 
-  785 | 
-  786 |   expect<456>().type.toBe<any>(); // fail
-  787 |   expect<456>().type.toBe<unknown>(); // fail
+  845 | 
+  846 |   expect<456>().type.toBe<any>(); // fail
+  847 |   expect<456>().type.toBe<unknown>(); // fail
       |                           ~~~~~~~
-  788 |   expect<456>().type.toBe<string>(); // fail
-  789 |   expect<456>().type.toBe<number>(); // fail
-  790 |   expect<456>().type.toBe<bigint>(); // fail
+  848 |   expect<456>().type.toBe<string>(); // fail
+  849 |   expect<456>().type.toBe<number>(); // fail
+  850 |   expect<456>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:787:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:847:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'string'.
 
-  786 |   expect<456>().type.toBe<any>(); // fail
-  787 |   expect<456>().type.toBe<unknown>(); // fail
-  788 |   expect<456>().type.toBe<string>(); // fail
+  846 |   expect<456>().type.toBe<any>(); // fail
+  847 |   expect<456>().type.toBe<unknown>(); // fail
+  848 |   expect<456>().type.toBe<string>(); // fail
       |                           ~~~~~~
-  789 |   expect<456>().type.toBe<number>(); // fail
-  790 |   expect<456>().type.toBe<bigint>(); // fail
-  791 |   expect<456>().type.toBe<boolean>(); // fail
+  849 |   expect<456>().type.toBe<number>(); // fail
+  850 |   expect<456>().type.toBe<bigint>(); // fail
+  851 |   expect<456>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:788:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:848:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'number'.
 
-  787 |   expect<456>().type.toBe<unknown>(); // fail
-  788 |   expect<456>().type.toBe<string>(); // fail
-  789 |   expect<456>().type.toBe<number>(); // fail
+  847 |   expect<456>().type.toBe<unknown>(); // fail
+  848 |   expect<456>().type.toBe<string>(); // fail
+  849 |   expect<456>().type.toBe<number>(); // fail
       |                           ~~~~~~
-  790 |   expect<456>().type.toBe<bigint>(); // fail
-  791 |   expect<456>().type.toBe<boolean>(); // fail
-  792 |   expect<456>().type.toBe<symbol>(); // fail
+  850 |   expect<456>().type.toBe<bigint>(); // fail
+  851 |   expect<456>().type.toBe<boolean>(); // fail
+  852 |   expect<456>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:789:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:849:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'bigint'.
 
-  788 |   expect<456>().type.toBe<string>(); // fail
-  789 |   expect<456>().type.toBe<number>(); // fail
-  790 |   expect<456>().type.toBe<bigint>(); // fail
+  848 |   expect<456>().type.toBe<string>(); // fail
+  849 |   expect<456>().type.toBe<number>(); // fail
+  850 |   expect<456>().type.toBe<bigint>(); // fail
       |                           ~~~~~~
-  791 |   expect<456>().type.toBe<boolean>(); // fail
-  792 |   expect<456>().type.toBe<symbol>(); // fail
-  793 |   expect<456>().type.toBe<object>(); // fail
+  851 |   expect<456>().type.toBe<boolean>(); // fail
+  852 |   expect<456>().type.toBe<symbol>(); // fail
+  853 |   expect<456>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:790:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:850:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'boolean'.
 
-  789 |   expect<456>().type.toBe<number>(); // fail
-  790 |   expect<456>().type.toBe<bigint>(); // fail
-  791 |   expect<456>().type.toBe<boolean>(); // fail
+  849 |   expect<456>().type.toBe<number>(); // fail
+  850 |   expect<456>().type.toBe<bigint>(); // fail
+  851 |   expect<456>().type.toBe<boolean>(); // fail
       |                           ~~~~~~~
-  792 |   expect<456>().type.toBe<symbol>(); // fail
-  793 |   expect<456>().type.toBe<object>(); // fail
-  794 |   expect<456>().type.toBe<void>(); // fail
+  852 |   expect<456>().type.toBe<symbol>(); // fail
+  853 |   expect<456>().type.toBe<object>(); // fail
+  854 |   expect<456>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:791:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:851:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'symbol'.
 
-  790 |   expect<456>().type.toBe<bigint>(); // fail
-  791 |   expect<456>().type.toBe<boolean>(); // fail
-  792 |   expect<456>().type.toBe<symbol>(); // fail
+  850 |   expect<456>().type.toBe<bigint>(); // fail
+  851 |   expect<456>().type.toBe<boolean>(); // fail
+  852 |   expect<456>().type.toBe<symbol>(); // fail
       |                           ~~~~~~
-  793 |   expect<456>().type.toBe<object>(); // fail
-  794 |   expect<456>().type.toBe<void>(); // fail
-  795 |   expect<456>().type.toBe<undefined>(); // fail
+  853 |   expect<456>().type.toBe<object>(); // fail
+  854 |   expect<456>().type.toBe<void>(); // fail
+  855 |   expect<456>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:792:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:852:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'object'.
 
-  791 |   expect<456>().type.toBe<boolean>(); // fail
-  792 |   expect<456>().type.toBe<symbol>(); // fail
-  793 |   expect<456>().type.toBe<object>(); // fail
+  851 |   expect<456>().type.toBe<boolean>(); // fail
+  852 |   expect<456>().type.toBe<symbol>(); // fail
+  853 |   expect<456>().type.toBe<object>(); // fail
       |                           ~~~~~~
-  794 |   expect<456>().type.toBe<void>(); // fail
-  795 |   expect<456>().type.toBe<undefined>(); // fail
-  796 |   expect<456>().type.toBe<null>(); // fail
+  854 |   expect<456>().type.toBe<void>(); // fail
+  855 |   expect<456>().type.toBe<undefined>(); // fail
+  856 |   expect<456>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:793:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:853:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'void'.
 
-  792 |   expect<456>().type.toBe<symbol>(); // fail
-  793 |   expect<456>().type.toBe<object>(); // fail
-  794 |   expect<456>().type.toBe<void>(); // fail
+  852 |   expect<456>().type.toBe<symbol>(); // fail
+  853 |   expect<456>().type.toBe<object>(); // fail
+  854 |   expect<456>().type.toBe<void>(); // fail
       |                           ~~~~
-  795 |   expect<456>().type.toBe<undefined>(); // fail
-  796 |   expect<456>().type.toBe<null>(); // fail
-  797 |   expect<456>().type.toBe<never>(); // fail
+  855 |   expect<456>().type.toBe<undefined>(); // fail
+  856 |   expect<456>().type.toBe<null>(); // fail
+  857 |   expect<456>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:794:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:854:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'undefined'.
 
-  793 |   expect<456>().type.toBe<object>(); // fail
-  794 |   expect<456>().type.toBe<void>(); // fail
-  795 |   expect<456>().type.toBe<undefined>(); // fail
+  853 |   expect<456>().type.toBe<object>(); // fail
+  854 |   expect<456>().type.toBe<void>(); // fail
+  855 |   expect<456>().type.toBe<undefined>(); // fail
       |                           ~~~~~~~~~
-  796 |   expect<456>().type.toBe<null>(); // fail
-  797 |   expect<456>().type.toBe<never>(); // fail
-  798 |   expect<456>().type.toBe<'abc'>(); // fail
+  856 |   expect<456>().type.toBe<null>(); // fail
+  857 |   expect<456>().type.toBe<never>(); // fail
+  858 |   expect<456>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:795:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:855:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'null'.
 
-  794 |   expect<456>().type.toBe<void>(); // fail
-  795 |   expect<456>().type.toBe<undefined>(); // fail
-  796 |   expect<456>().type.toBe<null>(); // fail
+  854 |   expect<456>().type.toBe<void>(); // fail
+  855 |   expect<456>().type.toBe<undefined>(); // fail
+  856 |   expect<456>().type.toBe<null>(); // fail
       |                           ~~~~
-  797 |   expect<456>().type.toBe<never>(); // fail
-  798 |   expect<456>().type.toBe<'abc'>(); // fail
-  799 |   expect<456>().type.toBe<'def'>(); // fail
+  857 |   expect<456>().type.toBe<never>(); // fail
+  858 |   expect<456>().type.toBe<'abc'>(); // fail
+  859 |   expect<456>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:796:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:856:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'never'.
 
-  795 |   expect<456>().type.toBe<undefined>(); // fail
-  796 |   expect<456>().type.toBe<null>(); // fail
-  797 |   expect<456>().type.toBe<never>(); // fail
+  855 |   expect<456>().type.toBe<undefined>(); // fail
+  856 |   expect<456>().type.toBe<null>(); // fail
+  857 |   expect<456>().type.toBe<never>(); // fail
       |                           ~~~~~
-  798 |   expect<456>().type.toBe<'abc'>(); // fail
-  799 |   expect<456>().type.toBe<'def'>(); // fail
-  800 |   expect<456>().type.toBe<123>(); // fail
+  858 |   expect<456>().type.toBe<'abc'>(); // fail
+  859 |   expect<456>().type.toBe<'def'>(); // fail
+  860 |   expect<456>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:797:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:857:27 ❭ is 456?
 
 Error: Type '456' is not the same as type '"abc"'.
 
-  796 |   expect<456>().type.toBe<null>(); // fail
-  797 |   expect<456>().type.toBe<never>(); // fail
-  798 |   expect<456>().type.toBe<'abc'>(); // fail
+  856 |   expect<456>().type.toBe<null>(); // fail
+  857 |   expect<456>().type.toBe<never>(); // fail
+  858 |   expect<456>().type.toBe<'abc'>(); // fail
       |                           ~~~~~
-  799 |   expect<456>().type.toBe<'def'>(); // fail
-  800 |   expect<456>().type.toBe<123>(); // fail
-  801 |   expect<456>().type.toBe<887n>(); // fail
+  859 |   expect<456>().type.toBe<'def'>(); // fail
+  860 |   expect<456>().type.toBe<123>(); // fail
+  861 |   expect<456>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:798:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:858:27 ❭ is 456?
 
 Error: Type '456' is not the same as type '"def"'.
 
-  797 |   expect<456>().type.toBe<never>(); // fail
-  798 |   expect<456>().type.toBe<'abc'>(); // fail
-  799 |   expect<456>().type.toBe<'def'>(); // fail
+  857 |   expect<456>().type.toBe<never>(); // fail
+  858 |   expect<456>().type.toBe<'abc'>(); // fail
+  859 |   expect<456>().type.toBe<'def'>(); // fail
       |                           ~~~~~
-  800 |   expect<456>().type.toBe<123>(); // fail
-  801 |   expect<456>().type.toBe<887n>(); // fail
-  802 |   expect<456>().type.toBe<998n>(); // fail
+  860 |   expect<456>().type.toBe<123>(); // fail
+  861 |   expect<456>().type.toBe<887n>(); // fail
+  862 |   expect<456>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:799:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:859:27 ❭ is 456?
 
 Error: Type '456' is not the same as type '123'.
 
-  798 |   expect<456>().type.toBe<'abc'>(); // fail
-  799 |   expect<456>().type.toBe<'def'>(); // fail
-  800 |   expect<456>().type.toBe<123>(); // fail
+  858 |   expect<456>().type.toBe<'abc'>(); // fail
+  859 |   expect<456>().type.toBe<'def'>(); // fail
+  860 |   expect<456>().type.toBe<123>(); // fail
       |                           ~~~
-  801 |   expect<456>().type.toBe<887n>(); // fail
-  802 |   expect<456>().type.toBe<998n>(); // fail
-  803 |   expect<456>().type.toBe<true>(); // fail
+  861 |   expect<456>().type.toBe<887n>(); // fail
+  862 |   expect<456>().type.toBe<998n>(); // fail
+  863 |   expect<456>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:800:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:860:27 ❭ is 456?
 
 Error: Type '456' is not the same as type '887n'.
 
-  799 |   expect<456>().type.toBe<'def'>(); // fail
-  800 |   expect<456>().type.toBe<123>(); // fail
-  801 |   expect<456>().type.toBe<887n>(); // fail
+  859 |   expect<456>().type.toBe<'def'>(); // fail
+  860 |   expect<456>().type.toBe<123>(); // fail
+  861 |   expect<456>().type.toBe<887n>(); // fail
       |                           ~~~~
-  802 |   expect<456>().type.toBe<998n>(); // fail
-  803 |   expect<456>().type.toBe<true>(); // fail
-  804 |   expect<456>().type.toBe<false>(); // fail
+  862 |   expect<456>().type.toBe<998n>(); // fail
+  863 |   expect<456>().type.toBe<true>(); // fail
+  864 |   expect<456>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:801:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:861:27 ❭ is 456?
 
 Error: Type '456' is not the same as type '998n'.
 
-  800 |   expect<456>().type.toBe<123>(); // fail
-  801 |   expect<456>().type.toBe<887n>(); // fail
-  802 |   expect<456>().type.toBe<998n>(); // fail
+  860 |   expect<456>().type.toBe<123>(); // fail
+  861 |   expect<456>().type.toBe<887n>(); // fail
+  862 |   expect<456>().type.toBe<998n>(); // fail
       |                           ~~~~
-  803 |   expect<456>().type.toBe<true>(); // fail
-  804 |   expect<456>().type.toBe<false>(); // fail
-  805 |   expect<456>().type.toBe<Array<string>>(); // fail
+  863 |   expect<456>().type.toBe<true>(); // fail
+  864 |   expect<456>().type.toBe<false>(); // fail
+  865 |   expect<456>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:802:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:862:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'true'.
 
-  801 |   expect<456>().type.toBe<887n>(); // fail
-  802 |   expect<456>().type.toBe<998n>(); // fail
-  803 |   expect<456>().type.toBe<true>(); // fail
+  861 |   expect<456>().type.toBe<887n>(); // fail
+  862 |   expect<456>().type.toBe<998n>(); // fail
+  863 |   expect<456>().type.toBe<true>(); // fail
       |                           ~~~~
-  804 |   expect<456>().type.toBe<false>(); // fail
-  805 |   expect<456>().type.toBe<Array<string>>(); // fail
-  806 |   expect<456>().type.toBe<number[]>(); // fail
+  864 |   expect<456>().type.toBe<false>(); // fail
+  865 |   expect<456>().type.toBe<Array<string>>(); // fail
+  866 |   expect<456>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:803:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:863:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'false'.
 
-  802 |   expect<456>().type.toBe<998n>(); // fail
-  803 |   expect<456>().type.toBe<true>(); // fail
-  804 |   expect<456>().type.toBe<false>(); // fail
+  862 |   expect<456>().type.toBe<998n>(); // fail
+  863 |   expect<456>().type.toBe<true>(); // fail
+  864 |   expect<456>().type.toBe<false>(); // fail
       |                           ~~~~~
-  805 |   expect<456>().type.toBe<Array<string>>(); // fail
-  806 |   expect<456>().type.toBe<number[]>(); // fail
-  807 | });
+  865 |   expect<456>().type.toBe<Array<string>>(); // fail
+  866 |   expect<456>().type.toBe<number[]>(); // fail
+  867 |   expect<456>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:804:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:864:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'string[]'.
 
-  803 |   expect<456>().type.toBe<true>(); // fail
-  804 |   expect<456>().type.toBe<false>(); // fail
-  805 |   expect<456>().type.toBe<Array<string>>(); // fail
+  863 |   expect<456>().type.toBe<true>(); // fail
+  864 |   expect<456>().type.toBe<false>(); // fail
+  865 |   expect<456>().type.toBe<Array<string>>(); // fail
       |                           ~~~~~~~~~~~~~
-  806 |   expect<456>().type.toBe<number[]>(); // fail
-  807 | });
-  808 | 
+  866 |   expect<456>().type.toBe<number[]>(); // fail
+  867 |   expect<456>().type.toBe<string | number>(); // fail
+  868 |   expect<456>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:805:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:865:27 ❭ is 456?
 
 Error: Type '456' is not the same as type 'number[]'.
 
-  804 |   expect<456>().type.toBe<false>(); // fail
-  805 |   expect<456>().type.toBe<Array<string>>(); // fail
-  806 |   expect<456>().type.toBe<number[]>(); // fail
+  864 |   expect<456>().type.toBe<false>(); // fail
+  865 |   expect<456>().type.toBe<Array<string>>(); // fail
+  866 |   expect<456>().type.toBe<number[]>(); // fail
       |                           ~~~~~~~~
-  807 | });
-  808 | 
-  809 | test("is NOT 456?", () => {
+  867 |   expect<456>().type.toBe<string | number>(); // fail
+  868 |   expect<456>().type.toBe<string | Array<string>>(); // fail
+  869 | });
 
-        at ./__typetests__/structure.tst.ts:806:27 ❭ is 456?
+        at ./__typetests__/structure.tst.ts:866:27 ❭ is 456?
+
+Error: Type '456' is not the same as type 'string | number'.
+
+  865 |   expect<456>().type.toBe<Array<string>>(); // fail
+  866 |   expect<456>().type.toBe<number[]>(); // fail
+  867 |   expect<456>().type.toBe<string | number>(); // fail
+      |                           ~~~~~~~~~~~~~~~
+  868 |   expect<456>().type.toBe<string | Array<string>>(); // fail
+  869 | });
+  870 | 
+
+        at ./__typetests__/structure.tst.ts:867:27 ❭ is 456?
+
+Error: Type '456' is not the same as type 'string | string[]'.
+
+  866 |   expect<456>().type.toBe<number[]>(); // fail
+  867 |   expect<456>().type.toBe<string | number>(); // fail
+  868 |   expect<456>().type.toBe<string | Array<string>>(); // fail
+      |                           ~~~~~~~~~~~~~~~~~~~~~~
+  869 | });
+  870 | 
+  871 | test("is NOT 456?", () => {
+
+        at ./__typetests__/structure.tst.ts:868:27 ❭ is 456?
 
 Error: Type '456' is the same as type '456'.
 
-  830 |   expect<456>().type.not.toBe<number[]>();
-  831 | 
-  832 |   expect<456>().type.not.toBe<456>(); // fail
+  894 |   expect<456>().type.not.toBe<string | Array<string>>();
+  895 | 
+  896 |   expect<456>().type.not.toBe<456>(); // fail
       |                               ~~~
-  833 | });
-  834 | 
-  835 | test("is 887n?", () => {
+  897 | });
+  898 | 
+  899 | test("is 887n?", () => {
 
-        at ./__typetests__/structure.tst.ts:832:31 ❭ is NOT 456?
+        at ./__typetests__/structure.tst.ts:896:31 ❭ is NOT 456?
 
 Error: Type '887n' is not the same as type 'any'.
 
-  836 |   expect<887n>().type.toBe<887n>();
-  837 | 
-  838 |   expect<887n>().type.toBe<any>(); // fail
+  900 |   expect<887n>().type.toBe<887n>();
+  901 | 
+  902 |   expect<887n>().type.toBe<any>(); // fail
       |                            ~~~
-  839 |   expect<887n>().type.toBe<unknown>(); // fail
-  840 |   expect<887n>().type.toBe<string>(); // fail
-  841 |   expect<887n>().type.toBe<number>(); // fail
+  903 |   expect<887n>().type.toBe<unknown>(); // fail
+  904 |   expect<887n>().type.toBe<string>(); // fail
+  905 |   expect<887n>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:838:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:902:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'unknown'.
 
-  837 | 
-  838 |   expect<887n>().type.toBe<any>(); // fail
-  839 |   expect<887n>().type.toBe<unknown>(); // fail
+  901 | 
+  902 |   expect<887n>().type.toBe<any>(); // fail
+  903 |   expect<887n>().type.toBe<unknown>(); // fail
       |                            ~~~~~~~
-  840 |   expect<887n>().type.toBe<string>(); // fail
-  841 |   expect<887n>().type.toBe<number>(); // fail
-  842 |   expect<887n>().type.toBe<bigint>(); // fail
+  904 |   expect<887n>().type.toBe<string>(); // fail
+  905 |   expect<887n>().type.toBe<number>(); // fail
+  906 |   expect<887n>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:839:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:903:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'string'.
 
-  838 |   expect<887n>().type.toBe<any>(); // fail
-  839 |   expect<887n>().type.toBe<unknown>(); // fail
-  840 |   expect<887n>().type.toBe<string>(); // fail
+  902 |   expect<887n>().type.toBe<any>(); // fail
+  903 |   expect<887n>().type.toBe<unknown>(); // fail
+  904 |   expect<887n>().type.toBe<string>(); // fail
       |                            ~~~~~~
-  841 |   expect<887n>().type.toBe<number>(); // fail
-  842 |   expect<887n>().type.toBe<bigint>(); // fail
-  843 |   expect<887n>().type.toBe<boolean>(); // fail
+  905 |   expect<887n>().type.toBe<number>(); // fail
+  906 |   expect<887n>().type.toBe<bigint>(); // fail
+  907 |   expect<887n>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:840:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:904:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'number'.
 
-  839 |   expect<887n>().type.toBe<unknown>(); // fail
-  840 |   expect<887n>().type.toBe<string>(); // fail
-  841 |   expect<887n>().type.toBe<number>(); // fail
+  903 |   expect<887n>().type.toBe<unknown>(); // fail
+  904 |   expect<887n>().type.toBe<string>(); // fail
+  905 |   expect<887n>().type.toBe<number>(); // fail
       |                            ~~~~~~
-  842 |   expect<887n>().type.toBe<bigint>(); // fail
-  843 |   expect<887n>().type.toBe<boolean>(); // fail
-  844 |   expect<887n>().type.toBe<symbol>(); // fail
+  906 |   expect<887n>().type.toBe<bigint>(); // fail
+  907 |   expect<887n>().type.toBe<boolean>(); // fail
+  908 |   expect<887n>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:841:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:905:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'bigint'.
 
-  840 |   expect<887n>().type.toBe<string>(); // fail
-  841 |   expect<887n>().type.toBe<number>(); // fail
-  842 |   expect<887n>().type.toBe<bigint>(); // fail
+  904 |   expect<887n>().type.toBe<string>(); // fail
+  905 |   expect<887n>().type.toBe<number>(); // fail
+  906 |   expect<887n>().type.toBe<bigint>(); // fail
       |                            ~~~~~~
-  843 |   expect<887n>().type.toBe<boolean>(); // fail
-  844 |   expect<887n>().type.toBe<symbol>(); // fail
-  845 |   expect<887n>().type.toBe<object>(); // fail
+  907 |   expect<887n>().type.toBe<boolean>(); // fail
+  908 |   expect<887n>().type.toBe<symbol>(); // fail
+  909 |   expect<887n>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:842:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:906:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'boolean'.
 
-  841 |   expect<887n>().type.toBe<number>(); // fail
-  842 |   expect<887n>().type.toBe<bigint>(); // fail
-  843 |   expect<887n>().type.toBe<boolean>(); // fail
+  905 |   expect<887n>().type.toBe<number>(); // fail
+  906 |   expect<887n>().type.toBe<bigint>(); // fail
+  907 |   expect<887n>().type.toBe<boolean>(); // fail
       |                            ~~~~~~~
-  844 |   expect<887n>().type.toBe<symbol>(); // fail
-  845 |   expect<887n>().type.toBe<object>(); // fail
-  846 |   expect<887n>().type.toBe<void>(); // fail
+  908 |   expect<887n>().type.toBe<symbol>(); // fail
+  909 |   expect<887n>().type.toBe<object>(); // fail
+  910 |   expect<887n>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:843:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:907:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'symbol'.
 
-  842 |   expect<887n>().type.toBe<bigint>(); // fail
-  843 |   expect<887n>().type.toBe<boolean>(); // fail
-  844 |   expect<887n>().type.toBe<symbol>(); // fail
+  906 |   expect<887n>().type.toBe<bigint>(); // fail
+  907 |   expect<887n>().type.toBe<boolean>(); // fail
+  908 |   expect<887n>().type.toBe<symbol>(); // fail
       |                            ~~~~~~
-  845 |   expect<887n>().type.toBe<object>(); // fail
-  846 |   expect<887n>().type.toBe<void>(); // fail
-  847 |   expect<887n>().type.toBe<undefined>(); // fail
+  909 |   expect<887n>().type.toBe<object>(); // fail
+  910 |   expect<887n>().type.toBe<void>(); // fail
+  911 |   expect<887n>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:844:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:908:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'object'.
 
-  843 |   expect<887n>().type.toBe<boolean>(); // fail
-  844 |   expect<887n>().type.toBe<symbol>(); // fail
-  845 |   expect<887n>().type.toBe<object>(); // fail
+  907 |   expect<887n>().type.toBe<boolean>(); // fail
+  908 |   expect<887n>().type.toBe<symbol>(); // fail
+  909 |   expect<887n>().type.toBe<object>(); // fail
       |                            ~~~~~~
-  846 |   expect<887n>().type.toBe<void>(); // fail
-  847 |   expect<887n>().type.toBe<undefined>(); // fail
-  848 |   expect<887n>().type.toBe<null>(); // fail
+  910 |   expect<887n>().type.toBe<void>(); // fail
+  911 |   expect<887n>().type.toBe<undefined>(); // fail
+  912 |   expect<887n>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:845:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:909:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'void'.
 
-  844 |   expect<887n>().type.toBe<symbol>(); // fail
-  845 |   expect<887n>().type.toBe<object>(); // fail
-  846 |   expect<887n>().type.toBe<void>(); // fail
+  908 |   expect<887n>().type.toBe<symbol>(); // fail
+  909 |   expect<887n>().type.toBe<object>(); // fail
+  910 |   expect<887n>().type.toBe<void>(); // fail
       |                            ~~~~
-  847 |   expect<887n>().type.toBe<undefined>(); // fail
-  848 |   expect<887n>().type.toBe<null>(); // fail
-  849 |   expect<887n>().type.toBe<never>(); // fail
+  911 |   expect<887n>().type.toBe<undefined>(); // fail
+  912 |   expect<887n>().type.toBe<null>(); // fail
+  913 |   expect<887n>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:846:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:910:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'undefined'.
 
-  845 |   expect<887n>().type.toBe<object>(); // fail
-  846 |   expect<887n>().type.toBe<void>(); // fail
-  847 |   expect<887n>().type.toBe<undefined>(); // fail
+  909 |   expect<887n>().type.toBe<object>(); // fail
+  910 |   expect<887n>().type.toBe<void>(); // fail
+  911 |   expect<887n>().type.toBe<undefined>(); // fail
       |                            ~~~~~~~~~
-  848 |   expect<887n>().type.toBe<null>(); // fail
-  849 |   expect<887n>().type.toBe<never>(); // fail
-  850 |   expect<887n>().type.toBe<'abc'>(); // fail
+  912 |   expect<887n>().type.toBe<null>(); // fail
+  913 |   expect<887n>().type.toBe<never>(); // fail
+  914 |   expect<887n>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:847:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:911:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'null'.
 
-  846 |   expect<887n>().type.toBe<void>(); // fail
-  847 |   expect<887n>().type.toBe<undefined>(); // fail
-  848 |   expect<887n>().type.toBe<null>(); // fail
+  910 |   expect<887n>().type.toBe<void>(); // fail
+  911 |   expect<887n>().type.toBe<undefined>(); // fail
+  912 |   expect<887n>().type.toBe<null>(); // fail
       |                            ~~~~
-  849 |   expect<887n>().type.toBe<never>(); // fail
-  850 |   expect<887n>().type.toBe<'abc'>(); // fail
-  851 |   expect<887n>().type.toBe<'def'>(); // fail
+  913 |   expect<887n>().type.toBe<never>(); // fail
+  914 |   expect<887n>().type.toBe<'abc'>(); // fail
+  915 |   expect<887n>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:848:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:912:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'never'.
 
-  847 |   expect<887n>().type.toBe<undefined>(); // fail
-  848 |   expect<887n>().type.toBe<null>(); // fail
-  849 |   expect<887n>().type.toBe<never>(); // fail
+  911 |   expect<887n>().type.toBe<undefined>(); // fail
+  912 |   expect<887n>().type.toBe<null>(); // fail
+  913 |   expect<887n>().type.toBe<never>(); // fail
       |                            ~~~~~
-  850 |   expect<887n>().type.toBe<'abc'>(); // fail
-  851 |   expect<887n>().type.toBe<'def'>(); // fail
-  852 |   expect<887n>().type.toBe<123>(); // fail
+  914 |   expect<887n>().type.toBe<'abc'>(); // fail
+  915 |   expect<887n>().type.toBe<'def'>(); // fail
+  916 |   expect<887n>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:849:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:913:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type '"abc"'.
 
-  848 |   expect<887n>().type.toBe<null>(); // fail
-  849 |   expect<887n>().type.toBe<never>(); // fail
-  850 |   expect<887n>().type.toBe<'abc'>(); // fail
+  912 |   expect<887n>().type.toBe<null>(); // fail
+  913 |   expect<887n>().type.toBe<never>(); // fail
+  914 |   expect<887n>().type.toBe<'abc'>(); // fail
       |                            ~~~~~
-  851 |   expect<887n>().type.toBe<'def'>(); // fail
-  852 |   expect<887n>().type.toBe<123>(); // fail
-  853 |   expect<887n>().type.toBe<456>(); // fail
+  915 |   expect<887n>().type.toBe<'def'>(); // fail
+  916 |   expect<887n>().type.toBe<123>(); // fail
+  917 |   expect<887n>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:850:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:914:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type '"def"'.
 
-  849 |   expect<887n>().type.toBe<never>(); // fail
-  850 |   expect<887n>().type.toBe<'abc'>(); // fail
-  851 |   expect<887n>().type.toBe<'def'>(); // fail
+  913 |   expect<887n>().type.toBe<never>(); // fail
+  914 |   expect<887n>().type.toBe<'abc'>(); // fail
+  915 |   expect<887n>().type.toBe<'def'>(); // fail
       |                            ~~~~~
-  852 |   expect<887n>().type.toBe<123>(); // fail
-  853 |   expect<887n>().type.toBe<456>(); // fail
-  854 |   expect<887n>().type.toBe<998n>(); // fail
+  916 |   expect<887n>().type.toBe<123>(); // fail
+  917 |   expect<887n>().type.toBe<456>(); // fail
+  918 |   expect<887n>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:851:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:915:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type '123'.
 
-  850 |   expect<887n>().type.toBe<'abc'>(); // fail
-  851 |   expect<887n>().type.toBe<'def'>(); // fail
-  852 |   expect<887n>().type.toBe<123>(); // fail
+  914 |   expect<887n>().type.toBe<'abc'>(); // fail
+  915 |   expect<887n>().type.toBe<'def'>(); // fail
+  916 |   expect<887n>().type.toBe<123>(); // fail
       |                            ~~~
-  853 |   expect<887n>().type.toBe<456>(); // fail
-  854 |   expect<887n>().type.toBe<998n>(); // fail
-  855 |   expect<887n>().type.toBe<true>(); // fail
+  917 |   expect<887n>().type.toBe<456>(); // fail
+  918 |   expect<887n>().type.toBe<998n>(); // fail
+  919 |   expect<887n>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:852:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:916:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type '456'.
 
-  851 |   expect<887n>().type.toBe<'def'>(); // fail
-  852 |   expect<887n>().type.toBe<123>(); // fail
-  853 |   expect<887n>().type.toBe<456>(); // fail
+  915 |   expect<887n>().type.toBe<'def'>(); // fail
+  916 |   expect<887n>().type.toBe<123>(); // fail
+  917 |   expect<887n>().type.toBe<456>(); // fail
       |                            ~~~
-  854 |   expect<887n>().type.toBe<998n>(); // fail
-  855 |   expect<887n>().type.toBe<true>(); // fail
-  856 |   expect<887n>().type.toBe<false>(); // fail
+  918 |   expect<887n>().type.toBe<998n>(); // fail
+  919 |   expect<887n>().type.toBe<true>(); // fail
+  920 |   expect<887n>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:853:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:917:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type '998n'.
 
-  852 |   expect<887n>().type.toBe<123>(); // fail
-  853 |   expect<887n>().type.toBe<456>(); // fail
-  854 |   expect<887n>().type.toBe<998n>(); // fail
+  916 |   expect<887n>().type.toBe<123>(); // fail
+  917 |   expect<887n>().type.toBe<456>(); // fail
+  918 |   expect<887n>().type.toBe<998n>(); // fail
       |                            ~~~~
-  855 |   expect<887n>().type.toBe<true>(); // fail
-  856 |   expect<887n>().type.toBe<false>(); // fail
-  857 |   expect<887n>().type.toBe<Array<string>>(); // fail
+  919 |   expect<887n>().type.toBe<true>(); // fail
+  920 |   expect<887n>().type.toBe<false>(); // fail
+  921 |   expect<887n>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:854:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:918:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'true'.
 
-  853 |   expect<887n>().type.toBe<456>(); // fail
-  854 |   expect<887n>().type.toBe<998n>(); // fail
-  855 |   expect<887n>().type.toBe<true>(); // fail
+  917 |   expect<887n>().type.toBe<456>(); // fail
+  918 |   expect<887n>().type.toBe<998n>(); // fail
+  919 |   expect<887n>().type.toBe<true>(); // fail
       |                            ~~~~
-  856 |   expect<887n>().type.toBe<false>(); // fail
-  857 |   expect<887n>().type.toBe<Array<string>>(); // fail
-  858 |   expect<887n>().type.toBe<number[]>(); // fail
+  920 |   expect<887n>().type.toBe<false>(); // fail
+  921 |   expect<887n>().type.toBe<Array<string>>(); // fail
+  922 |   expect<887n>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:855:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:919:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'false'.
 
-  854 |   expect<887n>().type.toBe<998n>(); // fail
-  855 |   expect<887n>().type.toBe<true>(); // fail
-  856 |   expect<887n>().type.toBe<false>(); // fail
+  918 |   expect<887n>().type.toBe<998n>(); // fail
+  919 |   expect<887n>().type.toBe<true>(); // fail
+  920 |   expect<887n>().type.toBe<false>(); // fail
       |                            ~~~~~
-  857 |   expect<887n>().type.toBe<Array<string>>(); // fail
-  858 |   expect<887n>().type.toBe<number[]>(); // fail
-  859 | });
+  921 |   expect<887n>().type.toBe<Array<string>>(); // fail
+  922 |   expect<887n>().type.toBe<number[]>(); // fail
+  923 |   expect<887n>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:856:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:920:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'string[]'.
 
-  855 |   expect<887n>().type.toBe<true>(); // fail
-  856 |   expect<887n>().type.toBe<false>(); // fail
-  857 |   expect<887n>().type.toBe<Array<string>>(); // fail
+  919 |   expect<887n>().type.toBe<true>(); // fail
+  920 |   expect<887n>().type.toBe<false>(); // fail
+  921 |   expect<887n>().type.toBe<Array<string>>(); // fail
       |                            ~~~~~~~~~~~~~
-  858 |   expect<887n>().type.toBe<number[]>(); // fail
-  859 | });
-  860 | 
+  922 |   expect<887n>().type.toBe<number[]>(); // fail
+  923 |   expect<887n>().type.toBe<string | number>(); // fail
+  924 |   expect<887n>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:857:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:921:28 ❭ is 887n?
 
 Error: Type '887n' is not the same as type 'number[]'.
 
-  856 |   expect<887n>().type.toBe<false>(); // fail
-  857 |   expect<887n>().type.toBe<Array<string>>(); // fail
-  858 |   expect<887n>().type.toBe<number[]>(); // fail
+  920 |   expect<887n>().type.toBe<false>(); // fail
+  921 |   expect<887n>().type.toBe<Array<string>>(); // fail
+  922 |   expect<887n>().type.toBe<number[]>(); // fail
       |                            ~~~~~~~~
-  859 | });
-  860 | 
-  861 | test("is NOT 887n?", () => {
+  923 |   expect<887n>().type.toBe<string | number>(); // fail
+  924 |   expect<887n>().type.toBe<string | Array<string>>(); // fail
+  925 | });
 
-        at ./__typetests__/structure.tst.ts:858:28 ❭ is 887n?
+        at ./__typetests__/structure.tst.ts:922:28 ❭ is 887n?
+
+Error: Type '887n' is not the same as type 'string | number'.
+
+  921 |   expect<887n>().type.toBe<Array<string>>(); // fail
+  922 |   expect<887n>().type.toBe<number[]>(); // fail
+  923 |   expect<887n>().type.toBe<string | number>(); // fail
+      |                            ~~~~~~~~~~~~~~~
+  924 |   expect<887n>().type.toBe<string | Array<string>>(); // fail
+  925 | });
+  926 | 
+
+        at ./__typetests__/structure.tst.ts:923:28 ❭ is 887n?
+
+Error: Type '887n' is not the same as type 'string | string[]'.
+
+  922 |   expect<887n>().type.toBe<number[]>(); // fail
+  923 |   expect<887n>().type.toBe<string | number>(); // fail
+  924 |   expect<887n>().type.toBe<string | Array<string>>(); // fail
+      |                            ~~~~~~~~~~~~~~~~~~~~~~
+  925 | });
+  926 | 
+  927 | test("is NOT 887n?", () => {
+
+        at ./__typetests__/structure.tst.ts:924:28 ❭ is 887n?
 
 Error: Type '887n' is the same as type '887n'.
 
-  882 |   expect<887n>().type.not.toBe<number[]>();
-  883 | 
-  884 |   expect<887n>().type.not.toBe<887n>(); // fail
+  950 |   expect<887n>().type.not.toBe<string | Array<string>>();
+  951 | 
+  952 |   expect<887n>().type.not.toBe<887n>(); // fail
       |                                ~~~~
-  885 | });
-  886 | 
-  887 | test("is 998n?", () => {
+  953 | });
+  954 | 
+  955 | test("is 998n?", () => {
 
-        at ./__typetests__/structure.tst.ts:884:32 ❭ is NOT 887n?
+        at ./__typetests__/structure.tst.ts:952:32 ❭ is NOT 887n?
 
 Error: Type '998n' is not the same as type 'any'.
 
-  888 |   expect<998n>().type.toBe<998n>();
-  889 | 
-  890 |   expect<998n>().type.toBe<any>(); // fail
+  956 |   expect<998n>().type.toBe<998n>();
+  957 | 
+  958 |   expect<998n>().type.toBe<any>(); // fail
       |                            ~~~
-  891 |   expect<998n>().type.toBe<unknown>(); // fail
-  892 |   expect<998n>().type.toBe<string>(); // fail
-  893 |   expect<998n>().type.toBe<number>(); // fail
+  959 |   expect<998n>().type.toBe<unknown>(); // fail
+  960 |   expect<998n>().type.toBe<string>(); // fail
+  961 |   expect<998n>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:890:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:958:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'unknown'.
 
-  889 | 
-  890 |   expect<998n>().type.toBe<any>(); // fail
-  891 |   expect<998n>().type.toBe<unknown>(); // fail
+  957 | 
+  958 |   expect<998n>().type.toBe<any>(); // fail
+  959 |   expect<998n>().type.toBe<unknown>(); // fail
       |                            ~~~~~~~
-  892 |   expect<998n>().type.toBe<string>(); // fail
-  893 |   expect<998n>().type.toBe<number>(); // fail
-  894 |   expect<998n>().type.toBe<bigint>(); // fail
+  960 |   expect<998n>().type.toBe<string>(); // fail
+  961 |   expect<998n>().type.toBe<number>(); // fail
+  962 |   expect<998n>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:891:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:959:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'string'.
 
-  890 |   expect<998n>().type.toBe<any>(); // fail
-  891 |   expect<998n>().type.toBe<unknown>(); // fail
-  892 |   expect<998n>().type.toBe<string>(); // fail
+  958 |   expect<998n>().type.toBe<any>(); // fail
+  959 |   expect<998n>().type.toBe<unknown>(); // fail
+  960 |   expect<998n>().type.toBe<string>(); // fail
       |                            ~~~~~~
-  893 |   expect<998n>().type.toBe<number>(); // fail
-  894 |   expect<998n>().type.toBe<bigint>(); // fail
-  895 |   expect<998n>().type.toBe<boolean>(); // fail
+  961 |   expect<998n>().type.toBe<number>(); // fail
+  962 |   expect<998n>().type.toBe<bigint>(); // fail
+  963 |   expect<998n>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:892:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:960:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'number'.
 
-  891 |   expect<998n>().type.toBe<unknown>(); // fail
-  892 |   expect<998n>().type.toBe<string>(); // fail
-  893 |   expect<998n>().type.toBe<number>(); // fail
+  959 |   expect<998n>().type.toBe<unknown>(); // fail
+  960 |   expect<998n>().type.toBe<string>(); // fail
+  961 |   expect<998n>().type.toBe<number>(); // fail
       |                            ~~~~~~
-  894 |   expect<998n>().type.toBe<bigint>(); // fail
-  895 |   expect<998n>().type.toBe<boolean>(); // fail
-  896 |   expect<998n>().type.toBe<symbol>(); // fail
+  962 |   expect<998n>().type.toBe<bigint>(); // fail
+  963 |   expect<998n>().type.toBe<boolean>(); // fail
+  964 |   expect<998n>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:893:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:961:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'bigint'.
 
-  892 |   expect<998n>().type.toBe<string>(); // fail
-  893 |   expect<998n>().type.toBe<number>(); // fail
-  894 |   expect<998n>().type.toBe<bigint>(); // fail
+  960 |   expect<998n>().type.toBe<string>(); // fail
+  961 |   expect<998n>().type.toBe<number>(); // fail
+  962 |   expect<998n>().type.toBe<bigint>(); // fail
       |                            ~~~~~~
-  895 |   expect<998n>().type.toBe<boolean>(); // fail
-  896 |   expect<998n>().type.toBe<symbol>(); // fail
-  897 |   expect<998n>().type.toBe<object>(); // fail
+  963 |   expect<998n>().type.toBe<boolean>(); // fail
+  964 |   expect<998n>().type.toBe<symbol>(); // fail
+  965 |   expect<998n>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:894:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:962:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'boolean'.
 
-  893 |   expect<998n>().type.toBe<number>(); // fail
-  894 |   expect<998n>().type.toBe<bigint>(); // fail
-  895 |   expect<998n>().type.toBe<boolean>(); // fail
+  961 |   expect<998n>().type.toBe<number>(); // fail
+  962 |   expect<998n>().type.toBe<bigint>(); // fail
+  963 |   expect<998n>().type.toBe<boolean>(); // fail
       |                            ~~~~~~~
-  896 |   expect<998n>().type.toBe<symbol>(); // fail
-  897 |   expect<998n>().type.toBe<object>(); // fail
-  898 |   expect<998n>().type.toBe<void>(); // fail
+  964 |   expect<998n>().type.toBe<symbol>(); // fail
+  965 |   expect<998n>().type.toBe<object>(); // fail
+  966 |   expect<998n>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:895:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:963:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'symbol'.
 
-  894 |   expect<998n>().type.toBe<bigint>(); // fail
-  895 |   expect<998n>().type.toBe<boolean>(); // fail
-  896 |   expect<998n>().type.toBe<symbol>(); // fail
+  962 |   expect<998n>().type.toBe<bigint>(); // fail
+  963 |   expect<998n>().type.toBe<boolean>(); // fail
+  964 |   expect<998n>().type.toBe<symbol>(); // fail
       |                            ~~~~~~
-  897 |   expect<998n>().type.toBe<object>(); // fail
-  898 |   expect<998n>().type.toBe<void>(); // fail
-  899 |   expect<998n>().type.toBe<undefined>(); // fail
+  965 |   expect<998n>().type.toBe<object>(); // fail
+  966 |   expect<998n>().type.toBe<void>(); // fail
+  967 |   expect<998n>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:896:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:964:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'object'.
 
-  895 |   expect<998n>().type.toBe<boolean>(); // fail
-  896 |   expect<998n>().type.toBe<symbol>(); // fail
-  897 |   expect<998n>().type.toBe<object>(); // fail
+  963 |   expect<998n>().type.toBe<boolean>(); // fail
+  964 |   expect<998n>().type.toBe<symbol>(); // fail
+  965 |   expect<998n>().type.toBe<object>(); // fail
       |                            ~~~~~~
-  898 |   expect<998n>().type.toBe<void>(); // fail
-  899 |   expect<998n>().type.toBe<undefined>(); // fail
-  900 |   expect<998n>().type.toBe<null>(); // fail
+  966 |   expect<998n>().type.toBe<void>(); // fail
+  967 |   expect<998n>().type.toBe<undefined>(); // fail
+  968 |   expect<998n>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:897:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:965:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'void'.
 
-  896 |   expect<998n>().type.toBe<symbol>(); // fail
-  897 |   expect<998n>().type.toBe<object>(); // fail
-  898 |   expect<998n>().type.toBe<void>(); // fail
+  964 |   expect<998n>().type.toBe<symbol>(); // fail
+  965 |   expect<998n>().type.toBe<object>(); // fail
+  966 |   expect<998n>().type.toBe<void>(); // fail
       |                            ~~~~
-  899 |   expect<998n>().type.toBe<undefined>(); // fail
-  900 |   expect<998n>().type.toBe<null>(); // fail
-  901 |   expect<998n>().type.toBe<never>(); // fail
+  967 |   expect<998n>().type.toBe<undefined>(); // fail
+  968 |   expect<998n>().type.toBe<null>(); // fail
+  969 |   expect<998n>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:898:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:966:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'undefined'.
 
-  897 |   expect<998n>().type.toBe<object>(); // fail
-  898 |   expect<998n>().type.toBe<void>(); // fail
-  899 |   expect<998n>().type.toBe<undefined>(); // fail
+  965 |   expect<998n>().type.toBe<object>(); // fail
+  966 |   expect<998n>().type.toBe<void>(); // fail
+  967 |   expect<998n>().type.toBe<undefined>(); // fail
       |                            ~~~~~~~~~
-  900 |   expect<998n>().type.toBe<null>(); // fail
-  901 |   expect<998n>().type.toBe<never>(); // fail
-  902 |   expect<998n>().type.toBe<'abc'>(); // fail
+  968 |   expect<998n>().type.toBe<null>(); // fail
+  969 |   expect<998n>().type.toBe<never>(); // fail
+  970 |   expect<998n>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:899:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:967:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'null'.
 
-  898 |   expect<998n>().type.toBe<void>(); // fail
-  899 |   expect<998n>().type.toBe<undefined>(); // fail
-  900 |   expect<998n>().type.toBe<null>(); // fail
+  966 |   expect<998n>().type.toBe<void>(); // fail
+  967 |   expect<998n>().type.toBe<undefined>(); // fail
+  968 |   expect<998n>().type.toBe<null>(); // fail
       |                            ~~~~
-  901 |   expect<998n>().type.toBe<never>(); // fail
-  902 |   expect<998n>().type.toBe<'abc'>(); // fail
-  903 |   expect<998n>().type.toBe<'def'>(); // fail
+  969 |   expect<998n>().type.toBe<never>(); // fail
+  970 |   expect<998n>().type.toBe<'abc'>(); // fail
+  971 |   expect<998n>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:900:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:968:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'never'.
 
-  899 |   expect<998n>().type.toBe<undefined>(); // fail
-  900 |   expect<998n>().type.toBe<null>(); // fail
-  901 |   expect<998n>().type.toBe<never>(); // fail
+  967 |   expect<998n>().type.toBe<undefined>(); // fail
+  968 |   expect<998n>().type.toBe<null>(); // fail
+  969 |   expect<998n>().type.toBe<never>(); // fail
       |                            ~~~~~
-  902 |   expect<998n>().type.toBe<'abc'>(); // fail
-  903 |   expect<998n>().type.toBe<'def'>(); // fail
-  904 |   expect<998n>().type.toBe<123>(); // fail
+  970 |   expect<998n>().type.toBe<'abc'>(); // fail
+  971 |   expect<998n>().type.toBe<'def'>(); // fail
+  972 |   expect<998n>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:901:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:969:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type '"abc"'.
 
-  900 |   expect<998n>().type.toBe<null>(); // fail
-  901 |   expect<998n>().type.toBe<never>(); // fail
-  902 |   expect<998n>().type.toBe<'abc'>(); // fail
+  968 |   expect<998n>().type.toBe<null>(); // fail
+  969 |   expect<998n>().type.toBe<never>(); // fail
+  970 |   expect<998n>().type.toBe<'abc'>(); // fail
       |                            ~~~~~
-  903 |   expect<998n>().type.toBe<'def'>(); // fail
-  904 |   expect<998n>().type.toBe<123>(); // fail
-  905 |   expect<998n>().type.toBe<456>(); // fail
+  971 |   expect<998n>().type.toBe<'def'>(); // fail
+  972 |   expect<998n>().type.toBe<123>(); // fail
+  973 |   expect<998n>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:902:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:970:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type '"def"'.
 
-  901 |   expect<998n>().type.toBe<never>(); // fail
-  902 |   expect<998n>().type.toBe<'abc'>(); // fail
-  903 |   expect<998n>().type.toBe<'def'>(); // fail
+  969 |   expect<998n>().type.toBe<never>(); // fail
+  970 |   expect<998n>().type.toBe<'abc'>(); // fail
+  971 |   expect<998n>().type.toBe<'def'>(); // fail
       |                            ~~~~~
-  904 |   expect<998n>().type.toBe<123>(); // fail
-  905 |   expect<998n>().type.toBe<456>(); // fail
-  906 |   expect<998n>().type.toBe<887n>(); // fail
+  972 |   expect<998n>().type.toBe<123>(); // fail
+  973 |   expect<998n>().type.toBe<456>(); // fail
+  974 |   expect<998n>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:903:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:971:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type '123'.
 
-  902 |   expect<998n>().type.toBe<'abc'>(); // fail
-  903 |   expect<998n>().type.toBe<'def'>(); // fail
-  904 |   expect<998n>().type.toBe<123>(); // fail
+  970 |   expect<998n>().type.toBe<'abc'>(); // fail
+  971 |   expect<998n>().type.toBe<'def'>(); // fail
+  972 |   expect<998n>().type.toBe<123>(); // fail
       |                            ~~~
-  905 |   expect<998n>().type.toBe<456>(); // fail
-  906 |   expect<998n>().type.toBe<887n>(); // fail
-  907 |   expect<998n>().type.toBe<true>(); // fail
+  973 |   expect<998n>().type.toBe<456>(); // fail
+  974 |   expect<998n>().type.toBe<887n>(); // fail
+  975 |   expect<998n>().type.toBe<true>(); // fail
 
-        at ./__typetests__/structure.tst.ts:904:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:972:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type '456'.
 
-  903 |   expect<998n>().type.toBe<'def'>(); // fail
-  904 |   expect<998n>().type.toBe<123>(); // fail
-  905 |   expect<998n>().type.toBe<456>(); // fail
+  971 |   expect<998n>().type.toBe<'def'>(); // fail
+  972 |   expect<998n>().type.toBe<123>(); // fail
+  973 |   expect<998n>().type.toBe<456>(); // fail
       |                            ~~~
-  906 |   expect<998n>().type.toBe<887n>(); // fail
-  907 |   expect<998n>().type.toBe<true>(); // fail
-  908 |   expect<998n>().type.toBe<false>(); // fail
+  974 |   expect<998n>().type.toBe<887n>(); // fail
+  975 |   expect<998n>().type.toBe<true>(); // fail
+  976 |   expect<998n>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:905:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:973:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type '887n'.
 
-  904 |   expect<998n>().type.toBe<123>(); // fail
-  905 |   expect<998n>().type.toBe<456>(); // fail
-  906 |   expect<998n>().type.toBe<887n>(); // fail
+  972 |   expect<998n>().type.toBe<123>(); // fail
+  973 |   expect<998n>().type.toBe<456>(); // fail
+  974 |   expect<998n>().type.toBe<887n>(); // fail
       |                            ~~~~
-  907 |   expect<998n>().type.toBe<true>(); // fail
-  908 |   expect<998n>().type.toBe<false>(); // fail
-  909 |   expect<998n>().type.toBe<Array<string>>(); // fail
+  975 |   expect<998n>().type.toBe<true>(); // fail
+  976 |   expect<998n>().type.toBe<false>(); // fail
+  977 |   expect<998n>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:906:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:974:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'true'.
 
-  905 |   expect<998n>().type.toBe<456>(); // fail
-  906 |   expect<998n>().type.toBe<887n>(); // fail
-  907 |   expect<998n>().type.toBe<true>(); // fail
+  973 |   expect<998n>().type.toBe<456>(); // fail
+  974 |   expect<998n>().type.toBe<887n>(); // fail
+  975 |   expect<998n>().type.toBe<true>(); // fail
       |                            ~~~~
-  908 |   expect<998n>().type.toBe<false>(); // fail
-  909 |   expect<998n>().type.toBe<Array<string>>(); // fail
-  910 |   expect<998n>().type.toBe<number[]>(); // fail
+  976 |   expect<998n>().type.toBe<false>(); // fail
+  977 |   expect<998n>().type.toBe<Array<string>>(); // fail
+  978 |   expect<998n>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:907:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:975:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'false'.
 
-  906 |   expect<998n>().type.toBe<887n>(); // fail
-  907 |   expect<998n>().type.toBe<true>(); // fail
-  908 |   expect<998n>().type.toBe<false>(); // fail
+  974 |   expect<998n>().type.toBe<887n>(); // fail
+  975 |   expect<998n>().type.toBe<true>(); // fail
+  976 |   expect<998n>().type.toBe<false>(); // fail
       |                            ~~~~~
-  909 |   expect<998n>().type.toBe<Array<string>>(); // fail
-  910 |   expect<998n>().type.toBe<number[]>(); // fail
-  911 | });
+  977 |   expect<998n>().type.toBe<Array<string>>(); // fail
+  978 |   expect<998n>().type.toBe<number[]>(); // fail
+  979 |   expect<998n>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:908:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:976:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'string[]'.
 
-  907 |   expect<998n>().type.toBe<true>(); // fail
-  908 |   expect<998n>().type.toBe<false>(); // fail
-  909 |   expect<998n>().type.toBe<Array<string>>(); // fail
+  975 |   expect<998n>().type.toBe<true>(); // fail
+  976 |   expect<998n>().type.toBe<false>(); // fail
+  977 |   expect<998n>().type.toBe<Array<string>>(); // fail
       |                            ~~~~~~~~~~~~~
-  910 |   expect<998n>().type.toBe<number[]>(); // fail
-  911 | });
-  912 | 
+  978 |   expect<998n>().type.toBe<number[]>(); // fail
+  979 |   expect<998n>().type.toBe<string | number>(); // fail
+  980 |   expect<998n>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:909:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:977:28 ❭ is 998n?
 
 Error: Type '998n' is not the same as type 'number[]'.
 
-  908 |   expect<998n>().type.toBe<false>(); // fail
-  909 |   expect<998n>().type.toBe<Array<string>>(); // fail
-  910 |   expect<998n>().type.toBe<number[]>(); // fail
+  976 |   expect<998n>().type.toBe<false>(); // fail
+  977 |   expect<998n>().type.toBe<Array<string>>(); // fail
+  978 |   expect<998n>().type.toBe<number[]>(); // fail
       |                            ~~~~~~~~
-  911 | });
-  912 | 
-  913 | test("is NOT 998n?", () => {
+  979 |   expect<998n>().type.toBe<string | number>(); // fail
+  980 |   expect<998n>().type.toBe<string | Array<string>>(); // fail
+  981 | });
 
-        at ./__typetests__/structure.tst.ts:910:28 ❭ is 998n?
+        at ./__typetests__/structure.tst.ts:978:28 ❭ is 998n?
+
+Error: Type '998n' is not the same as type 'string | number'.
+
+  977 |   expect<998n>().type.toBe<Array<string>>(); // fail
+  978 |   expect<998n>().type.toBe<number[]>(); // fail
+  979 |   expect<998n>().type.toBe<string | number>(); // fail
+      |                            ~~~~~~~~~~~~~~~
+  980 |   expect<998n>().type.toBe<string | Array<string>>(); // fail
+  981 | });
+  982 | 
+
+        at ./__typetests__/structure.tst.ts:979:28 ❭ is 998n?
+
+Error: Type '998n' is not the same as type 'string | string[]'.
+
+  978 |   expect<998n>().type.toBe<number[]>(); // fail
+  979 |   expect<998n>().type.toBe<string | number>(); // fail
+  980 |   expect<998n>().type.toBe<string | Array<string>>(); // fail
+      |                            ~~~~~~~~~~~~~~~~~~~~~~
+  981 | });
+  982 | 
+  983 | test("is NOT 998n?", () => {
+
+        at ./__typetests__/structure.tst.ts:980:28 ❭ is 998n?
 
 Error: Type '998n' is the same as type '998n'.
 
-  934 |   expect<998n>().type.not.toBe<number[]>();
-  935 | 
-  936 |   expect<998n>().type.not.toBe<998n>(); // fail
-      |                                ~~~~
-  937 | });
-  938 | 
-  939 | test("is true?", () => {
+  1006 |   expect<998n>().type.not.toBe<string | Array<string>>();
+  1007 | 
+  1008 |   expect<998n>().type.not.toBe<998n>(); // fail
+       |                                ~~~~
+  1009 | });
+  1010 | 
+  1011 | test("is true?", () => {
 
-        at ./__typetests__/structure.tst.ts:936:32 ❭ is NOT 998n?
+         at ./__typetests__/structure.tst.ts:1008:32 ❭ is NOT 998n?
 
 Error: Type 'true' is not the same as type 'any'.
 
-  940 |   expect<true>().type.toBe<true>();
-  941 | 
-  942 |   expect<true>().type.toBe<any>(); // fail
-      |                            ~~~
-  943 |   expect<true>().type.toBe<unknown>(); // fail
-  944 |   expect<true>().type.toBe<string>(); // fail
-  945 |   expect<true>().type.toBe<number>(); // fail
+  1012 |   expect<true>().type.toBe<true>();
+  1013 | 
+  1014 |   expect<true>().type.toBe<any>(); // fail
+       |                            ~~~
+  1015 |   expect<true>().type.toBe<unknown>(); // fail
+  1016 |   expect<true>().type.toBe<string>(); // fail
+  1017 |   expect<true>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:942:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1014:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'unknown'.
 
-  941 | 
-  942 |   expect<true>().type.toBe<any>(); // fail
-  943 |   expect<true>().type.toBe<unknown>(); // fail
-      |                            ~~~~~~~
-  944 |   expect<true>().type.toBe<string>(); // fail
-  945 |   expect<true>().type.toBe<number>(); // fail
-  946 |   expect<true>().type.toBe<bigint>(); // fail
+  1013 | 
+  1014 |   expect<true>().type.toBe<any>(); // fail
+  1015 |   expect<true>().type.toBe<unknown>(); // fail
+       |                            ~~~~~~~
+  1016 |   expect<true>().type.toBe<string>(); // fail
+  1017 |   expect<true>().type.toBe<number>(); // fail
+  1018 |   expect<true>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:943:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1015:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'string'.
 
-  942 |   expect<true>().type.toBe<any>(); // fail
-  943 |   expect<true>().type.toBe<unknown>(); // fail
-  944 |   expect<true>().type.toBe<string>(); // fail
-      |                            ~~~~~~
-  945 |   expect<true>().type.toBe<number>(); // fail
-  946 |   expect<true>().type.toBe<bigint>(); // fail
-  947 |   expect<true>().type.toBe<boolean>(); // fail
+  1014 |   expect<true>().type.toBe<any>(); // fail
+  1015 |   expect<true>().type.toBe<unknown>(); // fail
+  1016 |   expect<true>().type.toBe<string>(); // fail
+       |                            ~~~~~~
+  1017 |   expect<true>().type.toBe<number>(); // fail
+  1018 |   expect<true>().type.toBe<bigint>(); // fail
+  1019 |   expect<true>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:944:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1016:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'number'.
 
-  943 |   expect<true>().type.toBe<unknown>(); // fail
-  944 |   expect<true>().type.toBe<string>(); // fail
-  945 |   expect<true>().type.toBe<number>(); // fail
-      |                            ~~~~~~
-  946 |   expect<true>().type.toBe<bigint>(); // fail
-  947 |   expect<true>().type.toBe<boolean>(); // fail
-  948 |   expect<true>().type.toBe<symbol>(); // fail
+  1015 |   expect<true>().type.toBe<unknown>(); // fail
+  1016 |   expect<true>().type.toBe<string>(); // fail
+  1017 |   expect<true>().type.toBe<number>(); // fail
+       |                            ~~~~~~
+  1018 |   expect<true>().type.toBe<bigint>(); // fail
+  1019 |   expect<true>().type.toBe<boolean>(); // fail
+  1020 |   expect<true>().type.toBe<symbol>(); // fail
 
-        at ./__typetests__/structure.tst.ts:945:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1017:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'bigint'.
 
-  944 |   expect<true>().type.toBe<string>(); // fail
-  945 |   expect<true>().type.toBe<number>(); // fail
-  946 |   expect<true>().type.toBe<bigint>(); // fail
-      |                            ~~~~~~
-  947 |   expect<true>().type.toBe<boolean>(); // fail
-  948 |   expect<true>().type.toBe<symbol>(); // fail
-  949 |   expect<true>().type.toBe<object>(); // fail
+  1016 |   expect<true>().type.toBe<string>(); // fail
+  1017 |   expect<true>().type.toBe<number>(); // fail
+  1018 |   expect<true>().type.toBe<bigint>(); // fail
+       |                            ~~~~~~
+  1019 |   expect<true>().type.toBe<boolean>(); // fail
+  1020 |   expect<true>().type.toBe<symbol>(); // fail
+  1021 |   expect<true>().type.toBe<object>(); // fail
 
-        at ./__typetests__/structure.tst.ts:946:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1018:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'boolean'.
 
-  945 |   expect<true>().type.toBe<number>(); // fail
-  946 |   expect<true>().type.toBe<bigint>(); // fail
-  947 |   expect<true>().type.toBe<boolean>(); // fail
-      |                            ~~~~~~~
-  948 |   expect<true>().type.toBe<symbol>(); // fail
-  949 |   expect<true>().type.toBe<object>(); // fail
-  950 |   expect<true>().type.toBe<void>(); // fail
+  1017 |   expect<true>().type.toBe<number>(); // fail
+  1018 |   expect<true>().type.toBe<bigint>(); // fail
+  1019 |   expect<true>().type.toBe<boolean>(); // fail
+       |                            ~~~~~~~
+  1020 |   expect<true>().type.toBe<symbol>(); // fail
+  1021 |   expect<true>().type.toBe<object>(); // fail
+  1022 |   expect<true>().type.toBe<void>(); // fail
 
-        at ./__typetests__/structure.tst.ts:947:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1019:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'symbol'.
 
-  946 |   expect<true>().type.toBe<bigint>(); // fail
-  947 |   expect<true>().type.toBe<boolean>(); // fail
-  948 |   expect<true>().type.toBe<symbol>(); // fail
-      |                            ~~~~~~
-  949 |   expect<true>().type.toBe<object>(); // fail
-  950 |   expect<true>().type.toBe<void>(); // fail
-  951 |   expect<true>().type.toBe<undefined>(); // fail
+  1018 |   expect<true>().type.toBe<bigint>(); // fail
+  1019 |   expect<true>().type.toBe<boolean>(); // fail
+  1020 |   expect<true>().type.toBe<symbol>(); // fail
+       |                            ~~~~~~
+  1021 |   expect<true>().type.toBe<object>(); // fail
+  1022 |   expect<true>().type.toBe<void>(); // fail
+  1023 |   expect<true>().type.toBe<undefined>(); // fail
 
-        at ./__typetests__/structure.tst.ts:948:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1020:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'object'.
 
-  947 |   expect<true>().type.toBe<boolean>(); // fail
-  948 |   expect<true>().type.toBe<symbol>(); // fail
-  949 |   expect<true>().type.toBe<object>(); // fail
-      |                            ~~~~~~
-  950 |   expect<true>().type.toBe<void>(); // fail
-  951 |   expect<true>().type.toBe<undefined>(); // fail
-  952 |   expect<true>().type.toBe<null>(); // fail
+  1019 |   expect<true>().type.toBe<boolean>(); // fail
+  1020 |   expect<true>().type.toBe<symbol>(); // fail
+  1021 |   expect<true>().type.toBe<object>(); // fail
+       |                            ~~~~~~
+  1022 |   expect<true>().type.toBe<void>(); // fail
+  1023 |   expect<true>().type.toBe<undefined>(); // fail
+  1024 |   expect<true>().type.toBe<null>(); // fail
 
-        at ./__typetests__/structure.tst.ts:949:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1021:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'void'.
 
-  948 |   expect<true>().type.toBe<symbol>(); // fail
-  949 |   expect<true>().type.toBe<object>(); // fail
-  950 |   expect<true>().type.toBe<void>(); // fail
-      |                            ~~~~
-  951 |   expect<true>().type.toBe<undefined>(); // fail
-  952 |   expect<true>().type.toBe<null>(); // fail
-  953 |   expect<true>().type.toBe<never>(); // fail
+  1020 |   expect<true>().type.toBe<symbol>(); // fail
+  1021 |   expect<true>().type.toBe<object>(); // fail
+  1022 |   expect<true>().type.toBe<void>(); // fail
+       |                            ~~~~
+  1023 |   expect<true>().type.toBe<undefined>(); // fail
+  1024 |   expect<true>().type.toBe<null>(); // fail
+  1025 |   expect<true>().type.toBe<never>(); // fail
 
-        at ./__typetests__/structure.tst.ts:950:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1022:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'undefined'.
 
-  949 |   expect<true>().type.toBe<object>(); // fail
-  950 |   expect<true>().type.toBe<void>(); // fail
-  951 |   expect<true>().type.toBe<undefined>(); // fail
-      |                            ~~~~~~~~~
-  952 |   expect<true>().type.toBe<null>(); // fail
-  953 |   expect<true>().type.toBe<never>(); // fail
-  954 |   expect<true>().type.toBe<'abc'>(); // fail
+  1021 |   expect<true>().type.toBe<object>(); // fail
+  1022 |   expect<true>().type.toBe<void>(); // fail
+  1023 |   expect<true>().type.toBe<undefined>(); // fail
+       |                            ~~~~~~~~~
+  1024 |   expect<true>().type.toBe<null>(); // fail
+  1025 |   expect<true>().type.toBe<never>(); // fail
+  1026 |   expect<true>().type.toBe<'abc'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:951:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1023:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'null'.
 
-  950 |   expect<true>().type.toBe<void>(); // fail
-  951 |   expect<true>().type.toBe<undefined>(); // fail
-  952 |   expect<true>().type.toBe<null>(); // fail
-      |                            ~~~~
-  953 |   expect<true>().type.toBe<never>(); // fail
-  954 |   expect<true>().type.toBe<'abc'>(); // fail
-  955 |   expect<true>().type.toBe<'def'>(); // fail
+  1022 |   expect<true>().type.toBe<void>(); // fail
+  1023 |   expect<true>().type.toBe<undefined>(); // fail
+  1024 |   expect<true>().type.toBe<null>(); // fail
+       |                            ~~~~
+  1025 |   expect<true>().type.toBe<never>(); // fail
+  1026 |   expect<true>().type.toBe<'abc'>(); // fail
+  1027 |   expect<true>().type.toBe<'def'>(); // fail
 
-        at ./__typetests__/structure.tst.ts:952:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1024:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'never'.
 
-  951 |   expect<true>().type.toBe<undefined>(); // fail
-  952 |   expect<true>().type.toBe<null>(); // fail
-  953 |   expect<true>().type.toBe<never>(); // fail
-      |                            ~~~~~
-  954 |   expect<true>().type.toBe<'abc'>(); // fail
-  955 |   expect<true>().type.toBe<'def'>(); // fail
-  956 |   expect<true>().type.toBe<123>(); // fail
+  1023 |   expect<true>().type.toBe<undefined>(); // fail
+  1024 |   expect<true>().type.toBe<null>(); // fail
+  1025 |   expect<true>().type.toBe<never>(); // fail
+       |                            ~~~~~
+  1026 |   expect<true>().type.toBe<'abc'>(); // fail
+  1027 |   expect<true>().type.toBe<'def'>(); // fail
+  1028 |   expect<true>().type.toBe<123>(); // fail
 
-        at ./__typetests__/structure.tst.ts:953:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1025:28 ❭ is true?
 
 Error: Type 'true' is not the same as type '"abc"'.
 
-  952 |   expect<true>().type.toBe<null>(); // fail
-  953 |   expect<true>().type.toBe<never>(); // fail
-  954 |   expect<true>().type.toBe<'abc'>(); // fail
-      |                            ~~~~~
-  955 |   expect<true>().type.toBe<'def'>(); // fail
-  956 |   expect<true>().type.toBe<123>(); // fail
-  957 |   expect<true>().type.toBe<456>(); // fail
+  1024 |   expect<true>().type.toBe<null>(); // fail
+  1025 |   expect<true>().type.toBe<never>(); // fail
+  1026 |   expect<true>().type.toBe<'abc'>(); // fail
+       |                            ~~~~~
+  1027 |   expect<true>().type.toBe<'def'>(); // fail
+  1028 |   expect<true>().type.toBe<123>(); // fail
+  1029 |   expect<true>().type.toBe<456>(); // fail
 
-        at ./__typetests__/structure.tst.ts:954:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1026:28 ❭ is true?
 
 Error: Type 'true' is not the same as type '"def"'.
 
-  953 |   expect<true>().type.toBe<never>(); // fail
-  954 |   expect<true>().type.toBe<'abc'>(); // fail
-  955 |   expect<true>().type.toBe<'def'>(); // fail
-      |                            ~~~~~
-  956 |   expect<true>().type.toBe<123>(); // fail
-  957 |   expect<true>().type.toBe<456>(); // fail
-  958 |   expect<true>().type.toBe<887n>(); // fail
+  1025 |   expect<true>().type.toBe<never>(); // fail
+  1026 |   expect<true>().type.toBe<'abc'>(); // fail
+  1027 |   expect<true>().type.toBe<'def'>(); // fail
+       |                            ~~~~~
+  1028 |   expect<true>().type.toBe<123>(); // fail
+  1029 |   expect<true>().type.toBe<456>(); // fail
+  1030 |   expect<true>().type.toBe<887n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:955:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1027:28 ❭ is true?
 
 Error: Type 'true' is not the same as type '123'.
 
-  954 |   expect<true>().type.toBe<'abc'>(); // fail
-  955 |   expect<true>().type.toBe<'def'>(); // fail
-  956 |   expect<true>().type.toBe<123>(); // fail
-      |                            ~~~
-  957 |   expect<true>().type.toBe<456>(); // fail
-  958 |   expect<true>().type.toBe<887n>(); // fail
-  959 |   expect<true>().type.toBe<998n>(); // fail
+  1026 |   expect<true>().type.toBe<'abc'>(); // fail
+  1027 |   expect<true>().type.toBe<'def'>(); // fail
+  1028 |   expect<true>().type.toBe<123>(); // fail
+       |                            ~~~
+  1029 |   expect<true>().type.toBe<456>(); // fail
+  1030 |   expect<true>().type.toBe<887n>(); // fail
+  1031 |   expect<true>().type.toBe<998n>(); // fail
 
-        at ./__typetests__/structure.tst.ts:956:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1028:28 ❭ is true?
 
 Error: Type 'true' is not the same as type '456'.
 
-  955 |   expect<true>().type.toBe<'def'>(); // fail
-  956 |   expect<true>().type.toBe<123>(); // fail
-  957 |   expect<true>().type.toBe<456>(); // fail
-      |                            ~~~
-  958 |   expect<true>().type.toBe<887n>(); // fail
-  959 |   expect<true>().type.toBe<998n>(); // fail
-  960 |   expect<true>().type.toBe<false>(); // fail
+  1027 |   expect<true>().type.toBe<'def'>(); // fail
+  1028 |   expect<true>().type.toBe<123>(); // fail
+  1029 |   expect<true>().type.toBe<456>(); // fail
+       |                            ~~~
+  1030 |   expect<true>().type.toBe<887n>(); // fail
+  1031 |   expect<true>().type.toBe<998n>(); // fail
+  1032 |   expect<true>().type.toBe<false>(); // fail
 
-        at ./__typetests__/structure.tst.ts:957:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1029:28 ❭ is true?
 
 Error: Type 'true' is not the same as type '887n'.
 
-  956 |   expect<true>().type.toBe<123>(); // fail
-  957 |   expect<true>().type.toBe<456>(); // fail
-  958 |   expect<true>().type.toBe<887n>(); // fail
-      |                            ~~~~
-  959 |   expect<true>().type.toBe<998n>(); // fail
-  960 |   expect<true>().type.toBe<false>(); // fail
-  961 |   expect<true>().type.toBe<Array<string>>(); // fail
+  1028 |   expect<true>().type.toBe<123>(); // fail
+  1029 |   expect<true>().type.toBe<456>(); // fail
+  1030 |   expect<true>().type.toBe<887n>(); // fail
+       |                            ~~~~
+  1031 |   expect<true>().type.toBe<998n>(); // fail
+  1032 |   expect<true>().type.toBe<false>(); // fail
+  1033 |   expect<true>().type.toBe<Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:958:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1030:28 ❭ is true?
 
 Error: Type 'true' is not the same as type '998n'.
 
-  957 |   expect<true>().type.toBe<456>(); // fail
-  958 |   expect<true>().type.toBe<887n>(); // fail
-  959 |   expect<true>().type.toBe<998n>(); // fail
-      |                            ~~~~
-  960 |   expect<true>().type.toBe<false>(); // fail
-  961 |   expect<true>().type.toBe<Array<string>>(); // fail
-  962 |   expect<true>().type.toBe<number[]>(); // fail
+  1029 |   expect<true>().type.toBe<456>(); // fail
+  1030 |   expect<true>().type.toBe<887n>(); // fail
+  1031 |   expect<true>().type.toBe<998n>(); // fail
+       |                            ~~~~
+  1032 |   expect<true>().type.toBe<false>(); // fail
+  1033 |   expect<true>().type.toBe<Array<string>>(); // fail
+  1034 |   expect<true>().type.toBe<number[]>(); // fail
 
-        at ./__typetests__/structure.tst.ts:959:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1031:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'false'.
 
-  958 |   expect<true>().type.toBe<887n>(); // fail
-  959 |   expect<true>().type.toBe<998n>(); // fail
-  960 |   expect<true>().type.toBe<false>(); // fail
-      |                            ~~~~~
-  961 |   expect<true>().type.toBe<Array<string>>(); // fail
-  962 |   expect<true>().type.toBe<number[]>(); // fail
-  963 | });
+  1030 |   expect<true>().type.toBe<887n>(); // fail
+  1031 |   expect<true>().type.toBe<998n>(); // fail
+  1032 |   expect<true>().type.toBe<false>(); // fail
+       |                            ~~~~~
+  1033 |   expect<true>().type.toBe<Array<string>>(); // fail
+  1034 |   expect<true>().type.toBe<number[]>(); // fail
+  1035 |   expect<true>().type.toBe<string | number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:960:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1032:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'string[]'.
 
-  959 |   expect<true>().type.toBe<998n>(); // fail
-  960 |   expect<true>().type.toBe<false>(); // fail
-  961 |   expect<true>().type.toBe<Array<string>>(); // fail
-      |                            ~~~~~~~~~~~~~
-  962 |   expect<true>().type.toBe<number[]>(); // fail
-  963 | });
-  964 | 
+  1031 |   expect<true>().type.toBe<998n>(); // fail
+  1032 |   expect<true>().type.toBe<false>(); // fail
+  1033 |   expect<true>().type.toBe<Array<string>>(); // fail
+       |                            ~~~~~~~~~~~~~
+  1034 |   expect<true>().type.toBe<number[]>(); // fail
+  1035 |   expect<true>().type.toBe<string | number>(); // fail
+  1036 |   expect<true>().type.toBe<string | Array<string>>(); // fail
 
-        at ./__typetests__/structure.tst.ts:961:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1033:28 ❭ is true?
 
 Error: Type 'true' is not the same as type 'number[]'.
 
-  960 |   expect<true>().type.toBe<false>(); // fail
-  961 |   expect<true>().type.toBe<Array<string>>(); // fail
-  962 |   expect<true>().type.toBe<number[]>(); // fail
-      |                            ~~~~~~~~
-  963 | });
-  964 | 
-  965 | test("is NOT true?", () => {
+  1032 |   expect<true>().type.toBe<false>(); // fail
+  1033 |   expect<true>().type.toBe<Array<string>>(); // fail
+  1034 |   expect<true>().type.toBe<number[]>(); // fail
+       |                            ~~~~~~~~
+  1035 |   expect<true>().type.toBe<string | number>(); // fail
+  1036 |   expect<true>().type.toBe<string | Array<string>>(); // fail
+  1037 | });
 
-        at ./__typetests__/structure.tst.ts:962:28 ❭ is true?
+         at ./__typetests__/structure.tst.ts:1034:28 ❭ is true?
+
+Error: Type 'true' is not the same as type 'string | number'.
+
+  1033 |   expect<true>().type.toBe<Array<string>>(); // fail
+  1034 |   expect<true>().type.toBe<number[]>(); // fail
+  1035 |   expect<true>().type.toBe<string | number>(); // fail
+       |                            ~~~~~~~~~~~~~~~
+  1036 |   expect<true>().type.toBe<string | Array<string>>(); // fail
+  1037 | });
+  1038 | 
+
+         at ./__typetests__/structure.tst.ts:1035:28 ❭ is true?
+
+Error: Type 'true' is not the same as type 'string | string[]'.
+
+  1034 |   expect<true>().type.toBe<number[]>(); // fail
+  1035 |   expect<true>().type.toBe<string | number>(); // fail
+  1036 |   expect<true>().type.toBe<string | Array<string>>(); // fail
+       |                            ~~~~~~~~~~~~~~~~~~~~~~
+  1037 | });
+  1038 | 
+  1039 | test("is NOT true?", () => {
+
+         at ./__typetests__/structure.tst.ts:1036:28 ❭ is true?
 
 Error: Type 'true' is the same as type 'true'.
 
-  986 |   expect<true>().type.not.toBe<number[]>();
-  987 | 
-  988 |   expect<true>().type.not.toBe<true>(); // fail
-      |                                ~~~~
-  989 | });
-  990 | 
-  991 | test("is false?", () => {
+  1062 |   expect<true>().type.not.toBe<string | Array<string>>();
+  1063 | 
+  1064 |   expect<true>().type.not.toBe<true>(); // fail
+       |                                ~~~~
+  1065 | });
+  1066 | 
+  1067 | test("is false?", () => {
 
-        at ./__typetests__/structure.tst.ts:988:32 ❭ is NOT true?
+         at ./__typetests__/structure.tst.ts:1064:32 ❭ is NOT true?
 
 Error: Type 'false' is not the same as type 'any'.
 
-  992 |   expect<false>().type.toBe<false>();
-  993 | 
-  994 |   expect<false>().type.toBe<any>(); // fail
-      |                             ~~~
-  995 |   expect<false>().type.toBe<unknown>(); // fail
-  996 |   expect<false>().type.toBe<string>(); // fail
-  997 |   expect<false>().type.toBe<number>(); // fail
+  1068 |   expect<false>().type.toBe<false>();
+  1069 | 
+  1070 |   expect<false>().type.toBe<any>(); // fail
+       |                             ~~~
+  1071 |   expect<false>().type.toBe<unknown>(); // fail
+  1072 |   expect<false>().type.toBe<string>(); // fail
+  1073 |   expect<false>().type.toBe<number>(); // fail
 
-        at ./__typetests__/structure.tst.ts:994:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1070:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'unknown'.
 
-  993 | 
-  994 |   expect<false>().type.toBe<any>(); // fail
-  995 |   expect<false>().type.toBe<unknown>(); // fail
-      |                             ~~~~~~~
-  996 |   expect<false>().type.toBe<string>(); // fail
-  997 |   expect<false>().type.toBe<number>(); // fail
-  998 |   expect<false>().type.toBe<bigint>(); // fail
+  1069 | 
+  1070 |   expect<false>().type.toBe<any>(); // fail
+  1071 |   expect<false>().type.toBe<unknown>(); // fail
+       |                             ~~~~~~~
+  1072 |   expect<false>().type.toBe<string>(); // fail
+  1073 |   expect<false>().type.toBe<number>(); // fail
+  1074 |   expect<false>().type.toBe<bigint>(); // fail
 
-        at ./__typetests__/structure.tst.ts:995:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1071:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'string'.
 
-  994 |   expect<false>().type.toBe<any>(); // fail
-  995 |   expect<false>().type.toBe<unknown>(); // fail
-  996 |   expect<false>().type.toBe<string>(); // fail
-      |                             ~~~~~~
-  997 |   expect<false>().type.toBe<number>(); // fail
-  998 |   expect<false>().type.toBe<bigint>(); // fail
-  999 |   expect<false>().type.toBe<boolean>(); // fail
+  1070 |   expect<false>().type.toBe<any>(); // fail
+  1071 |   expect<false>().type.toBe<unknown>(); // fail
+  1072 |   expect<false>().type.toBe<string>(); // fail
+       |                             ~~~~~~
+  1073 |   expect<false>().type.toBe<number>(); // fail
+  1074 |   expect<false>().type.toBe<bigint>(); // fail
+  1075 |   expect<false>().type.toBe<boolean>(); // fail
 
-        at ./__typetests__/structure.tst.ts:996:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1072:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'number'.
 
-   995 |   expect<false>().type.toBe<unknown>(); // fail
-   996 |   expect<false>().type.toBe<string>(); // fail
-   997 |   expect<false>().type.toBe<number>(); // fail
+  1071 |   expect<false>().type.toBe<unknown>(); // fail
+  1072 |   expect<false>().type.toBe<string>(); // fail
+  1073 |   expect<false>().type.toBe<number>(); // fail
        |                             ~~~~~~
-   998 |   expect<false>().type.toBe<bigint>(); // fail
-   999 |   expect<false>().type.toBe<boolean>(); // fail
-  1000 |   expect<false>().type.toBe<symbol>(); // fail
+  1074 |   expect<false>().type.toBe<bigint>(); // fail
+  1075 |   expect<false>().type.toBe<boolean>(); // fail
+  1076 |   expect<false>().type.toBe<symbol>(); // fail
 
-         at ./__typetests__/structure.tst.ts:997:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1073:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'bigint'.
 
-   996 |   expect<false>().type.toBe<string>(); // fail
-   997 |   expect<false>().type.toBe<number>(); // fail
-   998 |   expect<false>().type.toBe<bigint>(); // fail
+  1072 |   expect<false>().type.toBe<string>(); // fail
+  1073 |   expect<false>().type.toBe<number>(); // fail
+  1074 |   expect<false>().type.toBe<bigint>(); // fail
        |                             ~~~~~~
-   999 |   expect<false>().type.toBe<boolean>(); // fail
-  1000 |   expect<false>().type.toBe<symbol>(); // fail
-  1001 |   expect<false>().type.toBe<object>(); // fail
+  1075 |   expect<false>().type.toBe<boolean>(); // fail
+  1076 |   expect<false>().type.toBe<symbol>(); // fail
+  1077 |   expect<false>().type.toBe<object>(); // fail
 
-         at ./__typetests__/structure.tst.ts:998:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1074:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'boolean'.
 
-   997 |   expect<false>().type.toBe<number>(); // fail
-   998 |   expect<false>().type.toBe<bigint>(); // fail
-   999 |   expect<false>().type.toBe<boolean>(); // fail
+  1073 |   expect<false>().type.toBe<number>(); // fail
+  1074 |   expect<false>().type.toBe<bigint>(); // fail
+  1075 |   expect<false>().type.toBe<boolean>(); // fail
        |                             ~~~~~~~
-  1000 |   expect<false>().type.toBe<symbol>(); // fail
-  1001 |   expect<false>().type.toBe<object>(); // fail
-  1002 |   expect<false>().type.toBe<void>(); // fail
+  1076 |   expect<false>().type.toBe<symbol>(); // fail
+  1077 |   expect<false>().type.toBe<object>(); // fail
+  1078 |   expect<false>().type.toBe<void>(); // fail
 
-         at ./__typetests__/structure.tst.ts:999:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1075:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'symbol'.
 
-   998 |   expect<false>().type.toBe<bigint>(); // fail
-   999 |   expect<false>().type.toBe<boolean>(); // fail
-  1000 |   expect<false>().type.toBe<symbol>(); // fail
+  1074 |   expect<false>().type.toBe<bigint>(); // fail
+  1075 |   expect<false>().type.toBe<boolean>(); // fail
+  1076 |   expect<false>().type.toBe<symbol>(); // fail
        |                             ~~~~~~
-  1001 |   expect<false>().type.toBe<object>(); // fail
-  1002 |   expect<false>().type.toBe<void>(); // fail
-  1003 |   expect<false>().type.toBe<undefined>(); // fail
+  1077 |   expect<false>().type.toBe<object>(); // fail
+  1078 |   expect<false>().type.toBe<void>(); // fail
+  1079 |   expect<false>().type.toBe<undefined>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1000:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1076:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'object'.
 
-   999 |   expect<false>().type.toBe<boolean>(); // fail
-  1000 |   expect<false>().type.toBe<symbol>(); // fail
-  1001 |   expect<false>().type.toBe<object>(); // fail
+  1075 |   expect<false>().type.toBe<boolean>(); // fail
+  1076 |   expect<false>().type.toBe<symbol>(); // fail
+  1077 |   expect<false>().type.toBe<object>(); // fail
        |                             ~~~~~~
-  1002 |   expect<false>().type.toBe<void>(); // fail
-  1003 |   expect<false>().type.toBe<undefined>(); // fail
-  1004 |   expect<false>().type.toBe<null>(); // fail
+  1078 |   expect<false>().type.toBe<void>(); // fail
+  1079 |   expect<false>().type.toBe<undefined>(); // fail
+  1080 |   expect<false>().type.toBe<null>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1001:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1077:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'void'.
 
-  1000 |   expect<false>().type.toBe<symbol>(); // fail
-  1001 |   expect<false>().type.toBe<object>(); // fail
-  1002 |   expect<false>().type.toBe<void>(); // fail
+  1076 |   expect<false>().type.toBe<symbol>(); // fail
+  1077 |   expect<false>().type.toBe<object>(); // fail
+  1078 |   expect<false>().type.toBe<void>(); // fail
        |                             ~~~~
-  1003 |   expect<false>().type.toBe<undefined>(); // fail
-  1004 |   expect<false>().type.toBe<null>(); // fail
-  1005 |   expect<false>().type.toBe<never>(); // fail
+  1079 |   expect<false>().type.toBe<undefined>(); // fail
+  1080 |   expect<false>().type.toBe<null>(); // fail
+  1081 |   expect<false>().type.toBe<never>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1002:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1078:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'undefined'.
 
-  1001 |   expect<false>().type.toBe<object>(); // fail
-  1002 |   expect<false>().type.toBe<void>(); // fail
-  1003 |   expect<false>().type.toBe<undefined>(); // fail
+  1077 |   expect<false>().type.toBe<object>(); // fail
+  1078 |   expect<false>().type.toBe<void>(); // fail
+  1079 |   expect<false>().type.toBe<undefined>(); // fail
        |                             ~~~~~~~~~
-  1004 |   expect<false>().type.toBe<null>(); // fail
-  1005 |   expect<false>().type.toBe<never>(); // fail
-  1006 |   expect<false>().type.toBe<'abc'>(); // fail
+  1080 |   expect<false>().type.toBe<null>(); // fail
+  1081 |   expect<false>().type.toBe<never>(); // fail
+  1082 |   expect<false>().type.toBe<'abc'>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1003:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1079:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'null'.
 
-  1002 |   expect<false>().type.toBe<void>(); // fail
-  1003 |   expect<false>().type.toBe<undefined>(); // fail
-  1004 |   expect<false>().type.toBe<null>(); // fail
+  1078 |   expect<false>().type.toBe<void>(); // fail
+  1079 |   expect<false>().type.toBe<undefined>(); // fail
+  1080 |   expect<false>().type.toBe<null>(); // fail
        |                             ~~~~
-  1005 |   expect<false>().type.toBe<never>(); // fail
-  1006 |   expect<false>().type.toBe<'abc'>(); // fail
-  1007 |   expect<false>().type.toBe<'def'>(); // fail
+  1081 |   expect<false>().type.toBe<never>(); // fail
+  1082 |   expect<false>().type.toBe<'abc'>(); // fail
+  1083 |   expect<false>().type.toBe<'def'>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1004:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1080:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'never'.
 
-  1003 |   expect<false>().type.toBe<undefined>(); // fail
-  1004 |   expect<false>().type.toBe<null>(); // fail
-  1005 |   expect<false>().type.toBe<never>(); // fail
+  1079 |   expect<false>().type.toBe<undefined>(); // fail
+  1080 |   expect<false>().type.toBe<null>(); // fail
+  1081 |   expect<false>().type.toBe<never>(); // fail
        |                             ~~~~~
-  1006 |   expect<false>().type.toBe<'abc'>(); // fail
-  1007 |   expect<false>().type.toBe<'def'>(); // fail
-  1008 |   expect<false>().type.toBe<123>(); // fail
+  1082 |   expect<false>().type.toBe<'abc'>(); // fail
+  1083 |   expect<false>().type.toBe<'def'>(); // fail
+  1084 |   expect<false>().type.toBe<123>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1005:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1081:29 ❭ is false?
 
 Error: Type 'false' is not the same as type '"abc"'.
 
-  1004 |   expect<false>().type.toBe<null>(); // fail
-  1005 |   expect<false>().type.toBe<never>(); // fail
-  1006 |   expect<false>().type.toBe<'abc'>(); // fail
+  1080 |   expect<false>().type.toBe<null>(); // fail
+  1081 |   expect<false>().type.toBe<never>(); // fail
+  1082 |   expect<false>().type.toBe<'abc'>(); // fail
        |                             ~~~~~
-  1007 |   expect<false>().type.toBe<'def'>(); // fail
-  1008 |   expect<false>().type.toBe<123>(); // fail
-  1009 |   expect<false>().type.toBe<456>(); // fail
+  1083 |   expect<false>().type.toBe<'def'>(); // fail
+  1084 |   expect<false>().type.toBe<123>(); // fail
+  1085 |   expect<false>().type.toBe<456>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1006:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1082:29 ❭ is false?
 
 Error: Type 'false' is not the same as type '"def"'.
 
-  1005 |   expect<false>().type.toBe<never>(); // fail
-  1006 |   expect<false>().type.toBe<'abc'>(); // fail
-  1007 |   expect<false>().type.toBe<'def'>(); // fail
+  1081 |   expect<false>().type.toBe<never>(); // fail
+  1082 |   expect<false>().type.toBe<'abc'>(); // fail
+  1083 |   expect<false>().type.toBe<'def'>(); // fail
        |                             ~~~~~
-  1008 |   expect<false>().type.toBe<123>(); // fail
-  1009 |   expect<false>().type.toBe<456>(); // fail
-  1010 |   expect<false>().type.toBe<887n>(); // fail
+  1084 |   expect<false>().type.toBe<123>(); // fail
+  1085 |   expect<false>().type.toBe<456>(); // fail
+  1086 |   expect<false>().type.toBe<887n>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1007:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1083:29 ❭ is false?
 
 Error: Type 'false' is not the same as type '123'.
 
-  1006 |   expect<false>().type.toBe<'abc'>(); // fail
-  1007 |   expect<false>().type.toBe<'def'>(); // fail
-  1008 |   expect<false>().type.toBe<123>(); // fail
+  1082 |   expect<false>().type.toBe<'abc'>(); // fail
+  1083 |   expect<false>().type.toBe<'def'>(); // fail
+  1084 |   expect<false>().type.toBe<123>(); // fail
        |                             ~~~
-  1009 |   expect<false>().type.toBe<456>(); // fail
-  1010 |   expect<false>().type.toBe<887n>(); // fail
-  1011 |   expect<false>().type.toBe<998n>(); // fail
+  1085 |   expect<false>().type.toBe<456>(); // fail
+  1086 |   expect<false>().type.toBe<887n>(); // fail
+  1087 |   expect<false>().type.toBe<998n>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1008:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1084:29 ❭ is false?
 
 Error: Type 'false' is not the same as type '456'.
 
-  1007 |   expect<false>().type.toBe<'def'>(); // fail
-  1008 |   expect<false>().type.toBe<123>(); // fail
-  1009 |   expect<false>().type.toBe<456>(); // fail
+  1083 |   expect<false>().type.toBe<'def'>(); // fail
+  1084 |   expect<false>().type.toBe<123>(); // fail
+  1085 |   expect<false>().type.toBe<456>(); // fail
        |                             ~~~
-  1010 |   expect<false>().type.toBe<887n>(); // fail
-  1011 |   expect<false>().type.toBe<998n>(); // fail
-  1012 |   expect<false>().type.toBe<true>(); // fail
+  1086 |   expect<false>().type.toBe<887n>(); // fail
+  1087 |   expect<false>().type.toBe<998n>(); // fail
+  1088 |   expect<false>().type.toBe<true>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1009:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1085:29 ❭ is false?
 
 Error: Type 'false' is not the same as type '887n'.
 
-  1008 |   expect<false>().type.toBe<123>(); // fail
-  1009 |   expect<false>().type.toBe<456>(); // fail
-  1010 |   expect<false>().type.toBe<887n>(); // fail
+  1084 |   expect<false>().type.toBe<123>(); // fail
+  1085 |   expect<false>().type.toBe<456>(); // fail
+  1086 |   expect<false>().type.toBe<887n>(); // fail
        |                             ~~~~
-  1011 |   expect<false>().type.toBe<998n>(); // fail
-  1012 |   expect<false>().type.toBe<true>(); // fail
-  1013 |   expect<false>().type.toBe<Array<string>>(); // fail
+  1087 |   expect<false>().type.toBe<998n>(); // fail
+  1088 |   expect<false>().type.toBe<true>(); // fail
+  1089 |   expect<false>().type.toBe<Array<string>>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1010:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1086:29 ❭ is false?
 
 Error: Type 'false' is not the same as type '998n'.
 
-  1009 |   expect<false>().type.toBe<456>(); // fail
-  1010 |   expect<false>().type.toBe<887n>(); // fail
-  1011 |   expect<false>().type.toBe<998n>(); // fail
+  1085 |   expect<false>().type.toBe<456>(); // fail
+  1086 |   expect<false>().type.toBe<887n>(); // fail
+  1087 |   expect<false>().type.toBe<998n>(); // fail
        |                             ~~~~
-  1012 |   expect<false>().type.toBe<true>(); // fail
-  1013 |   expect<false>().type.toBe<Array<string>>(); // fail
-  1014 |   expect<false>().type.toBe<number[]>(); // fail
+  1088 |   expect<false>().type.toBe<true>(); // fail
+  1089 |   expect<false>().type.toBe<Array<string>>(); // fail
+  1090 |   expect<false>().type.toBe<number[]>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1011:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1087:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'true'.
 
-  1010 |   expect<false>().type.toBe<887n>(); // fail
-  1011 |   expect<false>().type.toBe<998n>(); // fail
-  1012 |   expect<false>().type.toBe<true>(); // fail
+  1086 |   expect<false>().type.toBe<887n>(); // fail
+  1087 |   expect<false>().type.toBe<998n>(); // fail
+  1088 |   expect<false>().type.toBe<true>(); // fail
        |                             ~~~~
-  1013 |   expect<false>().type.toBe<Array<string>>(); // fail
-  1014 |   expect<false>().type.toBe<number[]>(); // fail
-  1015 | });
+  1089 |   expect<false>().type.toBe<Array<string>>(); // fail
+  1090 |   expect<false>().type.toBe<number[]>(); // fail
+  1091 |   expect<false>().type.toBe<string | number>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1012:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1088:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'string[]'.
 
-  1011 |   expect<false>().type.toBe<998n>(); // fail
-  1012 |   expect<false>().type.toBe<true>(); // fail
-  1013 |   expect<false>().type.toBe<Array<string>>(); // fail
+  1087 |   expect<false>().type.toBe<998n>(); // fail
+  1088 |   expect<false>().type.toBe<true>(); // fail
+  1089 |   expect<false>().type.toBe<Array<string>>(); // fail
        |                             ~~~~~~~~~~~~~
-  1014 |   expect<false>().type.toBe<number[]>(); // fail
-  1015 | });
-  1016 | 
+  1090 |   expect<false>().type.toBe<number[]>(); // fail
+  1091 |   expect<false>().type.toBe<string | number>(); // fail
+  1092 |   expect<false>().type.toBe<string | Array<string>>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1013:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1089:29 ❭ is false?
 
 Error: Type 'false' is not the same as type 'number[]'.
 
-  1012 |   expect<false>().type.toBe<true>(); // fail
-  1013 |   expect<false>().type.toBe<Array<string>>(); // fail
-  1014 |   expect<false>().type.toBe<number[]>(); // fail
+  1088 |   expect<false>().type.toBe<true>(); // fail
+  1089 |   expect<false>().type.toBe<Array<string>>(); // fail
+  1090 |   expect<false>().type.toBe<number[]>(); // fail
        |                             ~~~~~~~~
-  1015 | });
-  1016 | 
-  1017 | test("is NOT false?", () => {
+  1091 |   expect<false>().type.toBe<string | number>(); // fail
+  1092 |   expect<false>().type.toBe<string | Array<string>>(); // fail
+  1093 | });
 
-         at ./__typetests__/structure.tst.ts:1014:29 ❭ is false?
+         at ./__typetests__/structure.tst.ts:1090:29 ❭ is false?
+
+Error: Type 'false' is not the same as type 'string | number'.
+
+  1089 |   expect<false>().type.toBe<Array<string>>(); // fail
+  1090 |   expect<false>().type.toBe<number[]>(); // fail
+  1091 |   expect<false>().type.toBe<string | number>(); // fail
+       |                             ~~~~~~~~~~~~~~~
+  1092 |   expect<false>().type.toBe<string | Array<string>>(); // fail
+  1093 | });
+  1094 | 
+
+         at ./__typetests__/structure.tst.ts:1091:29 ❭ is false?
+
+Error: Type 'false' is not the same as type 'string | string[]'.
+
+  1090 |   expect<false>().type.toBe<number[]>(); // fail
+  1091 |   expect<false>().type.toBe<string | number>(); // fail
+  1092 |   expect<false>().type.toBe<string | Array<string>>(); // fail
+       |                             ~~~~~~~~~~~~~~~~~~~~~~
+  1093 | });
+  1094 | 
+  1095 | test("is NOT false?", () => {
+
+         at ./__typetests__/structure.tst.ts:1092:29 ❭ is false?
 
 Error: Type 'false' is the same as type 'false'.
 
-  1038 |   expect<false>().type.not.toBe<number[]>();
-  1039 | 
-  1040 |   expect<false>().type.not.toBe<false>(); // fail
+  1118 |   expect<false>().type.not.toBe<string | Array<string>>();
+  1119 | 
+  1120 |   expect<false>().type.not.toBe<false>(); // fail
        |                                 ~~~~~
-  1041 | });
-  1042 | 
-  1043 | test("is Array<string>?", () => {
+  1121 | });
+  1122 | 
+  1123 | test("is Array<string>?", () => {
 
-         at ./__typetests__/structure.tst.ts:1040:33 ❭ is NOT false?
+         at ./__typetests__/structure.tst.ts:1120:33 ❭ is NOT false?
 
 Error: Type 'string[]' is not the same as type 'any'.
 
-  1044 |   expect<Array<string>>().type.toBe<Array<string>>();
-  1045 | 
-  1046 |   expect<Array<string>>().type.toBe<any>(); // fail
+  1124 |   expect<Array<string>>().type.toBe<Array<string>>();
+  1125 | 
+  1126 |   expect<Array<string>>().type.toBe<any>(); // fail
        |                                     ~~~
-  1047 |   expect<Array<string>>().type.toBe<unknown>(); // fail
-  1048 |   expect<Array<string>>().type.toBe<string>(); // fail
-  1049 |   expect<Array<string>>().type.toBe<number>(); // fail
+  1127 |   expect<Array<string>>().type.toBe<unknown>(); // fail
+  1128 |   expect<Array<string>>().type.toBe<string>(); // fail
+  1129 |   expect<Array<string>>().type.toBe<number>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1046:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1126:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'unknown'.
 
-  1045 | 
-  1046 |   expect<Array<string>>().type.toBe<any>(); // fail
-  1047 |   expect<Array<string>>().type.toBe<unknown>(); // fail
+  1125 | 
+  1126 |   expect<Array<string>>().type.toBe<any>(); // fail
+  1127 |   expect<Array<string>>().type.toBe<unknown>(); // fail
        |                                     ~~~~~~~
-  1048 |   expect<Array<string>>().type.toBe<string>(); // fail
-  1049 |   expect<Array<string>>().type.toBe<number>(); // fail
-  1050 |   expect<Array<string>>().type.toBe<bigint>(); // fail
+  1128 |   expect<Array<string>>().type.toBe<string>(); // fail
+  1129 |   expect<Array<string>>().type.toBe<number>(); // fail
+  1130 |   expect<Array<string>>().type.toBe<bigint>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1047:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1127:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'string'.
 
-  1046 |   expect<Array<string>>().type.toBe<any>(); // fail
-  1047 |   expect<Array<string>>().type.toBe<unknown>(); // fail
-  1048 |   expect<Array<string>>().type.toBe<string>(); // fail
+  1126 |   expect<Array<string>>().type.toBe<any>(); // fail
+  1127 |   expect<Array<string>>().type.toBe<unknown>(); // fail
+  1128 |   expect<Array<string>>().type.toBe<string>(); // fail
        |                                     ~~~~~~
-  1049 |   expect<Array<string>>().type.toBe<number>(); // fail
-  1050 |   expect<Array<string>>().type.toBe<bigint>(); // fail
-  1051 |   expect<Array<string>>().type.toBe<boolean>(); // fail
+  1129 |   expect<Array<string>>().type.toBe<number>(); // fail
+  1130 |   expect<Array<string>>().type.toBe<bigint>(); // fail
+  1131 |   expect<Array<string>>().type.toBe<boolean>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1048:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1128:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'number'.
 
-  1047 |   expect<Array<string>>().type.toBe<unknown>(); // fail
-  1048 |   expect<Array<string>>().type.toBe<string>(); // fail
-  1049 |   expect<Array<string>>().type.toBe<number>(); // fail
+  1127 |   expect<Array<string>>().type.toBe<unknown>(); // fail
+  1128 |   expect<Array<string>>().type.toBe<string>(); // fail
+  1129 |   expect<Array<string>>().type.toBe<number>(); // fail
        |                                     ~~~~~~
-  1050 |   expect<Array<string>>().type.toBe<bigint>(); // fail
-  1051 |   expect<Array<string>>().type.toBe<boolean>(); // fail
-  1052 |   expect<Array<string>>().type.toBe<symbol>(); // fail
+  1130 |   expect<Array<string>>().type.toBe<bigint>(); // fail
+  1131 |   expect<Array<string>>().type.toBe<boolean>(); // fail
+  1132 |   expect<Array<string>>().type.toBe<symbol>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1049:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1129:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'bigint'.
 
-  1048 |   expect<Array<string>>().type.toBe<string>(); // fail
-  1049 |   expect<Array<string>>().type.toBe<number>(); // fail
-  1050 |   expect<Array<string>>().type.toBe<bigint>(); // fail
+  1128 |   expect<Array<string>>().type.toBe<string>(); // fail
+  1129 |   expect<Array<string>>().type.toBe<number>(); // fail
+  1130 |   expect<Array<string>>().type.toBe<bigint>(); // fail
        |                                     ~~~~~~
-  1051 |   expect<Array<string>>().type.toBe<boolean>(); // fail
-  1052 |   expect<Array<string>>().type.toBe<symbol>(); // fail
-  1053 |   expect<Array<string>>().type.toBe<object>(); // fail
+  1131 |   expect<Array<string>>().type.toBe<boolean>(); // fail
+  1132 |   expect<Array<string>>().type.toBe<symbol>(); // fail
+  1133 |   expect<Array<string>>().type.toBe<object>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1050:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1130:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'boolean'.
 
-  1049 |   expect<Array<string>>().type.toBe<number>(); // fail
-  1050 |   expect<Array<string>>().type.toBe<bigint>(); // fail
-  1051 |   expect<Array<string>>().type.toBe<boolean>(); // fail
+  1129 |   expect<Array<string>>().type.toBe<number>(); // fail
+  1130 |   expect<Array<string>>().type.toBe<bigint>(); // fail
+  1131 |   expect<Array<string>>().type.toBe<boolean>(); // fail
        |                                     ~~~~~~~
-  1052 |   expect<Array<string>>().type.toBe<symbol>(); // fail
-  1053 |   expect<Array<string>>().type.toBe<object>(); // fail
-  1054 |   expect<Array<string>>().type.toBe<void>(); // fail
+  1132 |   expect<Array<string>>().type.toBe<symbol>(); // fail
+  1133 |   expect<Array<string>>().type.toBe<object>(); // fail
+  1134 |   expect<Array<string>>().type.toBe<void>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1051:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1131:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'symbol'.
 
-  1050 |   expect<Array<string>>().type.toBe<bigint>(); // fail
-  1051 |   expect<Array<string>>().type.toBe<boolean>(); // fail
-  1052 |   expect<Array<string>>().type.toBe<symbol>(); // fail
+  1130 |   expect<Array<string>>().type.toBe<bigint>(); // fail
+  1131 |   expect<Array<string>>().type.toBe<boolean>(); // fail
+  1132 |   expect<Array<string>>().type.toBe<symbol>(); // fail
        |                                     ~~~~~~
-  1053 |   expect<Array<string>>().type.toBe<object>(); // fail
-  1054 |   expect<Array<string>>().type.toBe<void>(); // fail
-  1055 |   expect<Array<string>>().type.toBe<undefined>(); // fail
+  1133 |   expect<Array<string>>().type.toBe<object>(); // fail
+  1134 |   expect<Array<string>>().type.toBe<void>(); // fail
+  1135 |   expect<Array<string>>().type.toBe<undefined>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1052:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1132:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'object'.
 
-  1051 |   expect<Array<string>>().type.toBe<boolean>(); // fail
-  1052 |   expect<Array<string>>().type.toBe<symbol>(); // fail
-  1053 |   expect<Array<string>>().type.toBe<object>(); // fail
+  1131 |   expect<Array<string>>().type.toBe<boolean>(); // fail
+  1132 |   expect<Array<string>>().type.toBe<symbol>(); // fail
+  1133 |   expect<Array<string>>().type.toBe<object>(); // fail
        |                                     ~~~~~~
-  1054 |   expect<Array<string>>().type.toBe<void>(); // fail
-  1055 |   expect<Array<string>>().type.toBe<undefined>(); // fail
-  1056 |   expect<Array<string>>().type.toBe<null>(); // fail
+  1134 |   expect<Array<string>>().type.toBe<void>(); // fail
+  1135 |   expect<Array<string>>().type.toBe<undefined>(); // fail
+  1136 |   expect<Array<string>>().type.toBe<null>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1053:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1133:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'void'.
 
-  1052 |   expect<Array<string>>().type.toBe<symbol>(); // fail
-  1053 |   expect<Array<string>>().type.toBe<object>(); // fail
-  1054 |   expect<Array<string>>().type.toBe<void>(); // fail
+  1132 |   expect<Array<string>>().type.toBe<symbol>(); // fail
+  1133 |   expect<Array<string>>().type.toBe<object>(); // fail
+  1134 |   expect<Array<string>>().type.toBe<void>(); // fail
        |                                     ~~~~
-  1055 |   expect<Array<string>>().type.toBe<undefined>(); // fail
-  1056 |   expect<Array<string>>().type.toBe<null>(); // fail
-  1057 |   expect<Array<string>>().type.toBe<never>(); // fail
+  1135 |   expect<Array<string>>().type.toBe<undefined>(); // fail
+  1136 |   expect<Array<string>>().type.toBe<null>(); // fail
+  1137 |   expect<Array<string>>().type.toBe<never>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1054:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1134:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'undefined'.
 
-  1053 |   expect<Array<string>>().type.toBe<object>(); // fail
-  1054 |   expect<Array<string>>().type.toBe<void>(); // fail
-  1055 |   expect<Array<string>>().type.toBe<undefined>(); // fail
+  1133 |   expect<Array<string>>().type.toBe<object>(); // fail
+  1134 |   expect<Array<string>>().type.toBe<void>(); // fail
+  1135 |   expect<Array<string>>().type.toBe<undefined>(); // fail
        |                                     ~~~~~~~~~
-  1056 |   expect<Array<string>>().type.toBe<null>(); // fail
-  1057 |   expect<Array<string>>().type.toBe<never>(); // fail
-  1058 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
+  1136 |   expect<Array<string>>().type.toBe<null>(); // fail
+  1137 |   expect<Array<string>>().type.toBe<never>(); // fail
+  1138 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1055:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1135:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'null'.
 
-  1054 |   expect<Array<string>>().type.toBe<void>(); // fail
-  1055 |   expect<Array<string>>().type.toBe<undefined>(); // fail
-  1056 |   expect<Array<string>>().type.toBe<null>(); // fail
+  1134 |   expect<Array<string>>().type.toBe<void>(); // fail
+  1135 |   expect<Array<string>>().type.toBe<undefined>(); // fail
+  1136 |   expect<Array<string>>().type.toBe<null>(); // fail
        |                                     ~~~~
-  1057 |   expect<Array<string>>().type.toBe<never>(); // fail
-  1058 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
-  1059 |   expect<Array<string>>().type.toBe<'def'>(); // fail
+  1137 |   expect<Array<string>>().type.toBe<never>(); // fail
+  1138 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
+  1139 |   expect<Array<string>>().type.toBe<'def'>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1056:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1136:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'never'.
 
-  1055 |   expect<Array<string>>().type.toBe<undefined>(); // fail
-  1056 |   expect<Array<string>>().type.toBe<null>(); // fail
-  1057 |   expect<Array<string>>().type.toBe<never>(); // fail
+  1135 |   expect<Array<string>>().type.toBe<undefined>(); // fail
+  1136 |   expect<Array<string>>().type.toBe<null>(); // fail
+  1137 |   expect<Array<string>>().type.toBe<never>(); // fail
        |                                     ~~~~~
-  1058 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
-  1059 |   expect<Array<string>>().type.toBe<'def'>(); // fail
-  1060 |   expect<Array<string>>().type.toBe<123>(); // fail
+  1138 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
+  1139 |   expect<Array<string>>().type.toBe<'def'>(); // fail
+  1140 |   expect<Array<string>>().type.toBe<123>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1057:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1137:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type '"abc"'.
 
-  1056 |   expect<Array<string>>().type.toBe<null>(); // fail
-  1057 |   expect<Array<string>>().type.toBe<never>(); // fail
-  1058 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
+  1136 |   expect<Array<string>>().type.toBe<null>(); // fail
+  1137 |   expect<Array<string>>().type.toBe<never>(); // fail
+  1138 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
        |                                     ~~~~~
-  1059 |   expect<Array<string>>().type.toBe<'def'>(); // fail
-  1060 |   expect<Array<string>>().type.toBe<123>(); // fail
-  1061 |   expect<Array<string>>().type.toBe<456>(); // fail
+  1139 |   expect<Array<string>>().type.toBe<'def'>(); // fail
+  1140 |   expect<Array<string>>().type.toBe<123>(); // fail
+  1141 |   expect<Array<string>>().type.toBe<456>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1058:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1138:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type '"def"'.
 
-  1057 |   expect<Array<string>>().type.toBe<never>(); // fail
-  1058 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
-  1059 |   expect<Array<string>>().type.toBe<'def'>(); // fail
+  1137 |   expect<Array<string>>().type.toBe<never>(); // fail
+  1138 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
+  1139 |   expect<Array<string>>().type.toBe<'def'>(); // fail
        |                                     ~~~~~
-  1060 |   expect<Array<string>>().type.toBe<123>(); // fail
-  1061 |   expect<Array<string>>().type.toBe<456>(); // fail
-  1062 |   expect<Array<string>>().type.toBe<887n>(); // fail
+  1140 |   expect<Array<string>>().type.toBe<123>(); // fail
+  1141 |   expect<Array<string>>().type.toBe<456>(); // fail
+  1142 |   expect<Array<string>>().type.toBe<887n>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1059:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1139:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type '123'.
 
-  1058 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
-  1059 |   expect<Array<string>>().type.toBe<'def'>(); // fail
-  1060 |   expect<Array<string>>().type.toBe<123>(); // fail
+  1138 |   expect<Array<string>>().type.toBe<'abc'>(); // fail
+  1139 |   expect<Array<string>>().type.toBe<'def'>(); // fail
+  1140 |   expect<Array<string>>().type.toBe<123>(); // fail
        |                                     ~~~
-  1061 |   expect<Array<string>>().type.toBe<456>(); // fail
-  1062 |   expect<Array<string>>().type.toBe<887n>(); // fail
-  1063 |   expect<Array<string>>().type.toBe<998n>(); // fail
+  1141 |   expect<Array<string>>().type.toBe<456>(); // fail
+  1142 |   expect<Array<string>>().type.toBe<887n>(); // fail
+  1143 |   expect<Array<string>>().type.toBe<998n>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1060:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1140:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type '456'.
 
-  1059 |   expect<Array<string>>().type.toBe<'def'>(); // fail
-  1060 |   expect<Array<string>>().type.toBe<123>(); // fail
-  1061 |   expect<Array<string>>().type.toBe<456>(); // fail
+  1139 |   expect<Array<string>>().type.toBe<'def'>(); // fail
+  1140 |   expect<Array<string>>().type.toBe<123>(); // fail
+  1141 |   expect<Array<string>>().type.toBe<456>(); // fail
        |                                     ~~~
-  1062 |   expect<Array<string>>().type.toBe<887n>(); // fail
-  1063 |   expect<Array<string>>().type.toBe<998n>(); // fail
-  1064 |   expect<Array<string>>().type.toBe<true>(); // fail
+  1142 |   expect<Array<string>>().type.toBe<887n>(); // fail
+  1143 |   expect<Array<string>>().type.toBe<998n>(); // fail
+  1144 |   expect<Array<string>>().type.toBe<true>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1061:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1141:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type '887n'.
 
-  1060 |   expect<Array<string>>().type.toBe<123>(); // fail
-  1061 |   expect<Array<string>>().type.toBe<456>(); // fail
-  1062 |   expect<Array<string>>().type.toBe<887n>(); // fail
+  1140 |   expect<Array<string>>().type.toBe<123>(); // fail
+  1141 |   expect<Array<string>>().type.toBe<456>(); // fail
+  1142 |   expect<Array<string>>().type.toBe<887n>(); // fail
        |                                     ~~~~
-  1063 |   expect<Array<string>>().type.toBe<998n>(); // fail
-  1064 |   expect<Array<string>>().type.toBe<true>(); // fail
-  1065 |   expect<Array<string>>().type.toBe<false>(); // fail
+  1143 |   expect<Array<string>>().type.toBe<998n>(); // fail
+  1144 |   expect<Array<string>>().type.toBe<true>(); // fail
+  1145 |   expect<Array<string>>().type.toBe<false>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1062:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1142:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type '998n'.
 
-  1061 |   expect<Array<string>>().type.toBe<456>(); // fail
-  1062 |   expect<Array<string>>().type.toBe<887n>(); // fail
-  1063 |   expect<Array<string>>().type.toBe<998n>(); // fail
+  1141 |   expect<Array<string>>().type.toBe<456>(); // fail
+  1142 |   expect<Array<string>>().type.toBe<887n>(); // fail
+  1143 |   expect<Array<string>>().type.toBe<998n>(); // fail
        |                                     ~~~~
-  1064 |   expect<Array<string>>().type.toBe<true>(); // fail
-  1065 |   expect<Array<string>>().type.toBe<false>(); // fail
-  1066 |   expect<Array<string>>().type.toBe<number[]>(); // fail
+  1144 |   expect<Array<string>>().type.toBe<true>(); // fail
+  1145 |   expect<Array<string>>().type.toBe<false>(); // fail
+  1146 |   expect<Array<string>>().type.toBe<number[]>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1063:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1143:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'true'.
 
-  1062 |   expect<Array<string>>().type.toBe<887n>(); // fail
-  1063 |   expect<Array<string>>().type.toBe<998n>(); // fail
-  1064 |   expect<Array<string>>().type.toBe<true>(); // fail
+  1142 |   expect<Array<string>>().type.toBe<887n>(); // fail
+  1143 |   expect<Array<string>>().type.toBe<998n>(); // fail
+  1144 |   expect<Array<string>>().type.toBe<true>(); // fail
        |                                     ~~~~
-  1065 |   expect<Array<string>>().type.toBe<false>(); // fail
-  1066 |   expect<Array<string>>().type.toBe<number[]>(); // fail
-  1067 | });
+  1145 |   expect<Array<string>>().type.toBe<false>(); // fail
+  1146 |   expect<Array<string>>().type.toBe<number[]>(); // fail
+  1147 |   expect<Array<string>>().type.toBe<string | number>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1064:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1144:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'false'.
 
-  1063 |   expect<Array<string>>().type.toBe<998n>(); // fail
-  1064 |   expect<Array<string>>().type.toBe<true>(); // fail
-  1065 |   expect<Array<string>>().type.toBe<false>(); // fail
+  1143 |   expect<Array<string>>().type.toBe<998n>(); // fail
+  1144 |   expect<Array<string>>().type.toBe<true>(); // fail
+  1145 |   expect<Array<string>>().type.toBe<false>(); // fail
        |                                     ~~~~~
-  1066 |   expect<Array<string>>().type.toBe<number[]>(); // fail
-  1067 | });
-  1068 | 
+  1146 |   expect<Array<string>>().type.toBe<number[]>(); // fail
+  1147 |   expect<Array<string>>().type.toBe<string | number>(); // fail
+  1148 |   expect<Array<string>>().type.toBe<string | Array<string>>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1065:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1145:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is not the same as type 'number[]'.
 
-  1064 |   expect<Array<string>>().type.toBe<true>(); // fail
-  1065 |   expect<Array<string>>().type.toBe<false>(); // fail
-  1066 |   expect<Array<string>>().type.toBe<number[]>(); // fail
+  1144 |   expect<Array<string>>().type.toBe<true>(); // fail
+  1145 |   expect<Array<string>>().type.toBe<false>(); // fail
+  1146 |   expect<Array<string>>().type.toBe<number[]>(); // fail
        |                                     ~~~~~~~~
-  1067 | });
-  1068 | 
-  1069 | test("is NOT Array<string>?", () => {
+  1147 |   expect<Array<string>>().type.toBe<string | number>(); // fail
+  1148 |   expect<Array<string>>().type.toBe<string | Array<string>>(); // fail
+  1149 | });
 
-         at ./__typetests__/structure.tst.ts:1066:37 ❭ is Array<string>?
+         at ./__typetests__/structure.tst.ts:1146:37 ❭ is Array<string>?
+
+Error: Type 'string[]' is not the same as type 'string | number'.
+
+  1145 |   expect<Array<string>>().type.toBe<false>(); // fail
+  1146 |   expect<Array<string>>().type.toBe<number[]>(); // fail
+  1147 |   expect<Array<string>>().type.toBe<string | number>(); // fail
+       |                                     ~~~~~~~~~~~~~~~
+  1148 |   expect<Array<string>>().type.toBe<string | Array<string>>(); // fail
+  1149 | });
+  1150 | 
+
+         at ./__typetests__/structure.tst.ts:1147:37 ❭ is Array<string>?
+
+Error: Type 'string[]' is not the same as type 'string | string[]'.
+
+  1146 |   expect<Array<string>>().type.toBe<number[]>(); // fail
+  1147 |   expect<Array<string>>().type.toBe<string | number>(); // fail
+  1148 |   expect<Array<string>>().type.toBe<string | Array<string>>(); // fail
+       |                                     ~~~~~~~~~~~~~~~~~~~~~~
+  1149 | });
+  1150 | 
+  1151 | test("is NOT Array<string>?", () => {
+
+         at ./__typetests__/structure.tst.ts:1148:37 ❭ is Array<string>?
 
 Error: Type 'string[]' is the same as type 'string[]'.
 
-  1090 |   expect<Array<string>>().type.not.toBe<number[]>();
-  1091 | 
-  1092 |   expect<Array<string>>().type.not.toBe<Array<string>>(); // fail
+  1174 |   expect<Array<string>>().type.not.toBe<string | Array<string>>();
+  1175 | 
+  1176 |   expect<Array<string>>().type.not.toBe<Array<string>>(); // fail
        |                                         ~~~~~~~~~~~~~
-  1093 | });
-  1094 | 
-  1095 | test("is number[]?", () => {
+  1177 | });
+  1178 | 
+  1179 | test("is number[]?", () => {
 
-         at ./__typetests__/structure.tst.ts:1092:41 ❭ is NOT Array<string>?
+         at ./__typetests__/structure.tst.ts:1176:41 ❭ is NOT Array<string>?
 
 Error: Type 'number[]' is not the same as type 'any'.
 
-  1096 |   expect<number[]>().type.toBe<number[]>();
-  1097 | 
-  1098 |   expect<number[]>().type.toBe<any>(); // fail
+  1180 |   expect<number[]>().type.toBe<number[]>();
+  1181 | 
+  1182 |   expect<number[]>().type.toBe<any>(); // fail
        |                                ~~~
-  1099 |   expect<number[]>().type.toBe<unknown>(); // fail
-  1100 |   expect<number[]>().type.toBe<string>(); // fail
-  1101 |   expect<number[]>().type.toBe<number>(); // fail
+  1183 |   expect<number[]>().type.toBe<unknown>(); // fail
+  1184 |   expect<number[]>().type.toBe<string>(); // fail
+  1185 |   expect<number[]>().type.toBe<number>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1098:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1182:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'unknown'.
 
-  1097 | 
-  1098 |   expect<number[]>().type.toBe<any>(); // fail
-  1099 |   expect<number[]>().type.toBe<unknown>(); // fail
+  1181 | 
+  1182 |   expect<number[]>().type.toBe<any>(); // fail
+  1183 |   expect<number[]>().type.toBe<unknown>(); // fail
        |                                ~~~~~~~
-  1100 |   expect<number[]>().type.toBe<string>(); // fail
-  1101 |   expect<number[]>().type.toBe<number>(); // fail
-  1102 |   expect<number[]>().type.toBe<bigint>(); // fail
+  1184 |   expect<number[]>().type.toBe<string>(); // fail
+  1185 |   expect<number[]>().type.toBe<number>(); // fail
+  1186 |   expect<number[]>().type.toBe<bigint>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1099:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1183:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'string'.
 
-  1098 |   expect<number[]>().type.toBe<any>(); // fail
-  1099 |   expect<number[]>().type.toBe<unknown>(); // fail
-  1100 |   expect<number[]>().type.toBe<string>(); // fail
+  1182 |   expect<number[]>().type.toBe<any>(); // fail
+  1183 |   expect<number[]>().type.toBe<unknown>(); // fail
+  1184 |   expect<number[]>().type.toBe<string>(); // fail
        |                                ~~~~~~
-  1101 |   expect<number[]>().type.toBe<number>(); // fail
-  1102 |   expect<number[]>().type.toBe<bigint>(); // fail
-  1103 |   expect<number[]>().type.toBe<boolean>(); // fail
+  1185 |   expect<number[]>().type.toBe<number>(); // fail
+  1186 |   expect<number[]>().type.toBe<bigint>(); // fail
+  1187 |   expect<number[]>().type.toBe<boolean>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1100:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1184:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'number'.
 
-  1099 |   expect<number[]>().type.toBe<unknown>(); // fail
-  1100 |   expect<number[]>().type.toBe<string>(); // fail
-  1101 |   expect<number[]>().type.toBe<number>(); // fail
+  1183 |   expect<number[]>().type.toBe<unknown>(); // fail
+  1184 |   expect<number[]>().type.toBe<string>(); // fail
+  1185 |   expect<number[]>().type.toBe<number>(); // fail
        |                                ~~~~~~
-  1102 |   expect<number[]>().type.toBe<bigint>(); // fail
-  1103 |   expect<number[]>().type.toBe<boolean>(); // fail
-  1104 |   expect<number[]>().type.toBe<symbol>(); // fail
+  1186 |   expect<number[]>().type.toBe<bigint>(); // fail
+  1187 |   expect<number[]>().type.toBe<boolean>(); // fail
+  1188 |   expect<number[]>().type.toBe<symbol>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1101:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1185:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'bigint'.
 
-  1100 |   expect<number[]>().type.toBe<string>(); // fail
-  1101 |   expect<number[]>().type.toBe<number>(); // fail
-  1102 |   expect<number[]>().type.toBe<bigint>(); // fail
+  1184 |   expect<number[]>().type.toBe<string>(); // fail
+  1185 |   expect<number[]>().type.toBe<number>(); // fail
+  1186 |   expect<number[]>().type.toBe<bigint>(); // fail
        |                                ~~~~~~
-  1103 |   expect<number[]>().type.toBe<boolean>(); // fail
-  1104 |   expect<number[]>().type.toBe<symbol>(); // fail
-  1105 |   expect<number[]>().type.toBe<object>(); // fail
+  1187 |   expect<number[]>().type.toBe<boolean>(); // fail
+  1188 |   expect<number[]>().type.toBe<symbol>(); // fail
+  1189 |   expect<number[]>().type.toBe<object>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1102:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1186:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'boolean'.
 
-  1101 |   expect<number[]>().type.toBe<number>(); // fail
-  1102 |   expect<number[]>().type.toBe<bigint>(); // fail
-  1103 |   expect<number[]>().type.toBe<boolean>(); // fail
+  1185 |   expect<number[]>().type.toBe<number>(); // fail
+  1186 |   expect<number[]>().type.toBe<bigint>(); // fail
+  1187 |   expect<number[]>().type.toBe<boolean>(); // fail
        |                                ~~~~~~~
-  1104 |   expect<number[]>().type.toBe<symbol>(); // fail
-  1105 |   expect<number[]>().type.toBe<object>(); // fail
-  1106 |   expect<number[]>().type.toBe<void>(); // fail
+  1188 |   expect<number[]>().type.toBe<symbol>(); // fail
+  1189 |   expect<number[]>().type.toBe<object>(); // fail
+  1190 |   expect<number[]>().type.toBe<void>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1103:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1187:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'symbol'.
 
-  1102 |   expect<number[]>().type.toBe<bigint>(); // fail
-  1103 |   expect<number[]>().type.toBe<boolean>(); // fail
-  1104 |   expect<number[]>().type.toBe<symbol>(); // fail
+  1186 |   expect<number[]>().type.toBe<bigint>(); // fail
+  1187 |   expect<number[]>().type.toBe<boolean>(); // fail
+  1188 |   expect<number[]>().type.toBe<symbol>(); // fail
        |                                ~~~~~~
-  1105 |   expect<number[]>().type.toBe<object>(); // fail
-  1106 |   expect<number[]>().type.toBe<void>(); // fail
-  1107 |   expect<number[]>().type.toBe<undefined>(); // fail
+  1189 |   expect<number[]>().type.toBe<object>(); // fail
+  1190 |   expect<number[]>().type.toBe<void>(); // fail
+  1191 |   expect<number[]>().type.toBe<undefined>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1104:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1188:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'object'.
 
-  1103 |   expect<number[]>().type.toBe<boolean>(); // fail
-  1104 |   expect<number[]>().type.toBe<symbol>(); // fail
-  1105 |   expect<number[]>().type.toBe<object>(); // fail
+  1187 |   expect<number[]>().type.toBe<boolean>(); // fail
+  1188 |   expect<number[]>().type.toBe<symbol>(); // fail
+  1189 |   expect<number[]>().type.toBe<object>(); // fail
        |                                ~~~~~~
-  1106 |   expect<number[]>().type.toBe<void>(); // fail
-  1107 |   expect<number[]>().type.toBe<undefined>(); // fail
-  1108 |   expect<number[]>().type.toBe<null>(); // fail
+  1190 |   expect<number[]>().type.toBe<void>(); // fail
+  1191 |   expect<number[]>().type.toBe<undefined>(); // fail
+  1192 |   expect<number[]>().type.toBe<null>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1105:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1189:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'void'.
 
-  1104 |   expect<number[]>().type.toBe<symbol>(); // fail
-  1105 |   expect<number[]>().type.toBe<object>(); // fail
-  1106 |   expect<number[]>().type.toBe<void>(); // fail
+  1188 |   expect<number[]>().type.toBe<symbol>(); // fail
+  1189 |   expect<number[]>().type.toBe<object>(); // fail
+  1190 |   expect<number[]>().type.toBe<void>(); // fail
        |                                ~~~~
-  1107 |   expect<number[]>().type.toBe<undefined>(); // fail
-  1108 |   expect<number[]>().type.toBe<null>(); // fail
-  1109 |   expect<number[]>().type.toBe<never>(); // fail
+  1191 |   expect<number[]>().type.toBe<undefined>(); // fail
+  1192 |   expect<number[]>().type.toBe<null>(); // fail
+  1193 |   expect<number[]>().type.toBe<never>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1106:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1190:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'undefined'.
 
-  1105 |   expect<number[]>().type.toBe<object>(); // fail
-  1106 |   expect<number[]>().type.toBe<void>(); // fail
-  1107 |   expect<number[]>().type.toBe<undefined>(); // fail
+  1189 |   expect<number[]>().type.toBe<object>(); // fail
+  1190 |   expect<number[]>().type.toBe<void>(); // fail
+  1191 |   expect<number[]>().type.toBe<undefined>(); // fail
        |                                ~~~~~~~~~
-  1108 |   expect<number[]>().type.toBe<null>(); // fail
-  1109 |   expect<number[]>().type.toBe<never>(); // fail
-  1110 |   expect<number[]>().type.toBe<'abc'>(); // fail
+  1192 |   expect<number[]>().type.toBe<null>(); // fail
+  1193 |   expect<number[]>().type.toBe<never>(); // fail
+  1194 |   expect<number[]>().type.toBe<'abc'>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1107:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1191:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'null'.
 
-  1106 |   expect<number[]>().type.toBe<void>(); // fail
-  1107 |   expect<number[]>().type.toBe<undefined>(); // fail
-  1108 |   expect<number[]>().type.toBe<null>(); // fail
+  1190 |   expect<number[]>().type.toBe<void>(); // fail
+  1191 |   expect<number[]>().type.toBe<undefined>(); // fail
+  1192 |   expect<number[]>().type.toBe<null>(); // fail
        |                                ~~~~
-  1109 |   expect<number[]>().type.toBe<never>(); // fail
-  1110 |   expect<number[]>().type.toBe<'abc'>(); // fail
-  1111 |   expect<number[]>().type.toBe<'def'>(); // fail
+  1193 |   expect<number[]>().type.toBe<never>(); // fail
+  1194 |   expect<number[]>().type.toBe<'abc'>(); // fail
+  1195 |   expect<number[]>().type.toBe<'def'>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1108:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1192:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'never'.
 
-  1107 |   expect<number[]>().type.toBe<undefined>(); // fail
-  1108 |   expect<number[]>().type.toBe<null>(); // fail
-  1109 |   expect<number[]>().type.toBe<never>(); // fail
+  1191 |   expect<number[]>().type.toBe<undefined>(); // fail
+  1192 |   expect<number[]>().type.toBe<null>(); // fail
+  1193 |   expect<number[]>().type.toBe<never>(); // fail
        |                                ~~~~~
-  1110 |   expect<number[]>().type.toBe<'abc'>(); // fail
-  1111 |   expect<number[]>().type.toBe<'def'>(); // fail
-  1112 |   expect<number[]>().type.toBe<123>(); // fail
+  1194 |   expect<number[]>().type.toBe<'abc'>(); // fail
+  1195 |   expect<number[]>().type.toBe<'def'>(); // fail
+  1196 |   expect<number[]>().type.toBe<123>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1109:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1193:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type '"abc"'.
 
-  1108 |   expect<number[]>().type.toBe<null>(); // fail
-  1109 |   expect<number[]>().type.toBe<never>(); // fail
-  1110 |   expect<number[]>().type.toBe<'abc'>(); // fail
+  1192 |   expect<number[]>().type.toBe<null>(); // fail
+  1193 |   expect<number[]>().type.toBe<never>(); // fail
+  1194 |   expect<number[]>().type.toBe<'abc'>(); // fail
        |                                ~~~~~
-  1111 |   expect<number[]>().type.toBe<'def'>(); // fail
-  1112 |   expect<number[]>().type.toBe<123>(); // fail
-  1113 |   expect<number[]>().type.toBe<456>(); // fail
+  1195 |   expect<number[]>().type.toBe<'def'>(); // fail
+  1196 |   expect<number[]>().type.toBe<123>(); // fail
+  1197 |   expect<number[]>().type.toBe<456>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1110:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1194:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type '"def"'.
 
-  1109 |   expect<number[]>().type.toBe<never>(); // fail
-  1110 |   expect<number[]>().type.toBe<'abc'>(); // fail
-  1111 |   expect<number[]>().type.toBe<'def'>(); // fail
+  1193 |   expect<number[]>().type.toBe<never>(); // fail
+  1194 |   expect<number[]>().type.toBe<'abc'>(); // fail
+  1195 |   expect<number[]>().type.toBe<'def'>(); // fail
        |                                ~~~~~
-  1112 |   expect<number[]>().type.toBe<123>(); // fail
-  1113 |   expect<number[]>().type.toBe<456>(); // fail
-  1114 |   expect<number[]>().type.toBe<887n>(); // fail
+  1196 |   expect<number[]>().type.toBe<123>(); // fail
+  1197 |   expect<number[]>().type.toBe<456>(); // fail
+  1198 |   expect<number[]>().type.toBe<887n>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1111:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1195:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type '123'.
 
-  1110 |   expect<number[]>().type.toBe<'abc'>(); // fail
-  1111 |   expect<number[]>().type.toBe<'def'>(); // fail
-  1112 |   expect<number[]>().type.toBe<123>(); // fail
+  1194 |   expect<number[]>().type.toBe<'abc'>(); // fail
+  1195 |   expect<number[]>().type.toBe<'def'>(); // fail
+  1196 |   expect<number[]>().type.toBe<123>(); // fail
        |                                ~~~
-  1113 |   expect<number[]>().type.toBe<456>(); // fail
-  1114 |   expect<number[]>().type.toBe<887n>(); // fail
-  1115 |   expect<number[]>().type.toBe<998n>(); // fail
+  1197 |   expect<number[]>().type.toBe<456>(); // fail
+  1198 |   expect<number[]>().type.toBe<887n>(); // fail
+  1199 |   expect<number[]>().type.toBe<998n>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1112:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1196:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type '456'.
 
-  1111 |   expect<number[]>().type.toBe<'def'>(); // fail
-  1112 |   expect<number[]>().type.toBe<123>(); // fail
-  1113 |   expect<number[]>().type.toBe<456>(); // fail
+  1195 |   expect<number[]>().type.toBe<'def'>(); // fail
+  1196 |   expect<number[]>().type.toBe<123>(); // fail
+  1197 |   expect<number[]>().type.toBe<456>(); // fail
        |                                ~~~
-  1114 |   expect<number[]>().type.toBe<887n>(); // fail
-  1115 |   expect<number[]>().type.toBe<998n>(); // fail
-  1116 |   expect<number[]>().type.toBe<true>(); // fail
+  1198 |   expect<number[]>().type.toBe<887n>(); // fail
+  1199 |   expect<number[]>().type.toBe<998n>(); // fail
+  1200 |   expect<number[]>().type.toBe<true>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1113:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1197:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type '887n'.
 
-  1112 |   expect<number[]>().type.toBe<123>(); // fail
-  1113 |   expect<number[]>().type.toBe<456>(); // fail
-  1114 |   expect<number[]>().type.toBe<887n>(); // fail
+  1196 |   expect<number[]>().type.toBe<123>(); // fail
+  1197 |   expect<number[]>().type.toBe<456>(); // fail
+  1198 |   expect<number[]>().type.toBe<887n>(); // fail
        |                                ~~~~
-  1115 |   expect<number[]>().type.toBe<998n>(); // fail
-  1116 |   expect<number[]>().type.toBe<true>(); // fail
-  1117 |   expect<number[]>().type.toBe<false>(); // fail
+  1199 |   expect<number[]>().type.toBe<998n>(); // fail
+  1200 |   expect<number[]>().type.toBe<true>(); // fail
+  1201 |   expect<number[]>().type.toBe<false>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1114:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1198:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type '998n'.
 
-  1113 |   expect<number[]>().type.toBe<456>(); // fail
-  1114 |   expect<number[]>().type.toBe<887n>(); // fail
-  1115 |   expect<number[]>().type.toBe<998n>(); // fail
+  1197 |   expect<number[]>().type.toBe<456>(); // fail
+  1198 |   expect<number[]>().type.toBe<887n>(); // fail
+  1199 |   expect<number[]>().type.toBe<998n>(); // fail
        |                                ~~~~
-  1116 |   expect<number[]>().type.toBe<true>(); // fail
-  1117 |   expect<number[]>().type.toBe<false>(); // fail
-  1118 |   expect<number[]>().type.toBe<Array<string>>(); // fail
+  1200 |   expect<number[]>().type.toBe<true>(); // fail
+  1201 |   expect<number[]>().type.toBe<false>(); // fail
+  1202 |   expect<number[]>().type.toBe<Array<string>>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1115:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1199:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'true'.
 
-  1114 |   expect<number[]>().type.toBe<887n>(); // fail
-  1115 |   expect<number[]>().type.toBe<998n>(); // fail
-  1116 |   expect<number[]>().type.toBe<true>(); // fail
+  1198 |   expect<number[]>().type.toBe<887n>(); // fail
+  1199 |   expect<number[]>().type.toBe<998n>(); // fail
+  1200 |   expect<number[]>().type.toBe<true>(); // fail
        |                                ~~~~
-  1117 |   expect<number[]>().type.toBe<false>(); // fail
-  1118 |   expect<number[]>().type.toBe<Array<string>>(); // fail
-  1119 | });
+  1201 |   expect<number[]>().type.toBe<false>(); // fail
+  1202 |   expect<number[]>().type.toBe<Array<string>>(); // fail
+  1203 |   expect<number[]>().type.toBe<string | number>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1116:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1200:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'false'.
 
-  1115 |   expect<number[]>().type.toBe<998n>(); // fail
-  1116 |   expect<number[]>().type.toBe<true>(); // fail
-  1117 |   expect<number[]>().type.toBe<false>(); // fail
+  1199 |   expect<number[]>().type.toBe<998n>(); // fail
+  1200 |   expect<number[]>().type.toBe<true>(); // fail
+  1201 |   expect<number[]>().type.toBe<false>(); // fail
        |                                ~~~~~
-  1118 |   expect<number[]>().type.toBe<Array<string>>(); // fail
-  1119 | });
-  1120 | 
+  1202 |   expect<number[]>().type.toBe<Array<string>>(); // fail
+  1203 |   expect<number[]>().type.toBe<string | number>(); // fail
+  1204 |   expect<number[]>().type.toBe<string | Array<string>>(); // fail
 
-         at ./__typetests__/structure.tst.ts:1117:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1201:32 ❭ is number[]?
 
 Error: Type 'number[]' is not the same as type 'string[]'.
 
-  1116 |   expect<number[]>().type.toBe<true>(); // fail
-  1117 |   expect<number[]>().type.toBe<false>(); // fail
-  1118 |   expect<number[]>().type.toBe<Array<string>>(); // fail
+  1200 |   expect<number[]>().type.toBe<true>(); // fail
+  1201 |   expect<number[]>().type.toBe<false>(); // fail
+  1202 |   expect<number[]>().type.toBe<Array<string>>(); // fail
        |                                ~~~~~~~~~~~~~
-  1119 | });
-  1120 | 
-  1121 | test("is NOT number[]?", () => {
+  1203 |   expect<number[]>().type.toBe<string | number>(); // fail
+  1204 |   expect<number[]>().type.toBe<string | Array<string>>(); // fail
+  1205 | });
 
-         at ./__typetests__/structure.tst.ts:1118:32 ❭ is number[]?
+         at ./__typetests__/structure.tst.ts:1202:32 ❭ is number[]?
+
+Error: Type 'number[]' is not the same as type 'string | number'.
+
+  1201 |   expect<number[]>().type.toBe<false>(); // fail
+  1202 |   expect<number[]>().type.toBe<Array<string>>(); // fail
+  1203 |   expect<number[]>().type.toBe<string | number>(); // fail
+       |                                ~~~~~~~~~~~~~~~
+  1204 |   expect<number[]>().type.toBe<string | Array<string>>(); // fail
+  1205 | });
+  1206 | 
+
+         at ./__typetests__/structure.tst.ts:1203:32 ❭ is number[]?
+
+Error: Type 'number[]' is not the same as type 'string | string[]'.
+
+  1202 |   expect<number[]>().type.toBe<Array<string>>(); // fail
+  1203 |   expect<number[]>().type.toBe<string | number>(); // fail
+  1204 |   expect<number[]>().type.toBe<string | Array<string>>(); // fail
+       |                                ~~~~~~~~~~~~~~~~~~~~~~
+  1205 | });
+  1206 | 
+  1207 | test("is NOT number[]?", () => {
+
+         at ./__typetests__/structure.tst.ts:1204:32 ❭ is number[]?
 
 Error: Type 'number[]' is the same as type 'number[]'.
 
-  1142 |   expect<number[]>().type.not.toBe<Array<string>>();
-  1143 | 
-  1144 |   expect<number[]>().type.not.toBe<number[]>(); // fail
+  1230 |   expect<number[]>().type.not.toBe<string | Array<string>>();
+  1231 | 
+  1232 |   expect<number[]>().type.not.toBe<number[]>(); // fail
        |                                    ~~~~~~~~
-  1145 | });
-  1146 | 
+  1233 | });
+  1234 | 
+  1235 | test("is string | number?", () => {
 
-         at ./__typetests__/structure.tst.ts:1144:36 ❭ is NOT number[]?
+         at ./__typetests__/structure.tst.ts:1232:36 ❭ is NOT number[]?
+
+Error: Type 'string | number' is not the same as type 'any'.
+
+  1236 |   expect<string | number>().type.toBe<string | number>();
+  1237 | 
+  1238 |   expect<string | number>().type.toBe<any>(); // fail
+       |                                       ~~~
+  1239 |   expect<string | number>().type.toBe<unknown>(); // fail
+  1240 |   expect<string | number>().type.toBe<string>(); // fail
+  1241 |   expect<string | number>().type.toBe<number>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1238:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'unknown'.
+
+  1237 | 
+  1238 |   expect<string | number>().type.toBe<any>(); // fail
+  1239 |   expect<string | number>().type.toBe<unknown>(); // fail
+       |                                       ~~~~~~~
+  1240 |   expect<string | number>().type.toBe<string>(); // fail
+  1241 |   expect<string | number>().type.toBe<number>(); // fail
+  1242 |   expect<string | number>().type.toBe<bigint>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1239:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'string'.
+
+  1238 |   expect<string | number>().type.toBe<any>(); // fail
+  1239 |   expect<string | number>().type.toBe<unknown>(); // fail
+  1240 |   expect<string | number>().type.toBe<string>(); // fail
+       |                                       ~~~~~~
+  1241 |   expect<string | number>().type.toBe<number>(); // fail
+  1242 |   expect<string | number>().type.toBe<bigint>(); // fail
+  1243 |   expect<string | number>().type.toBe<boolean>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1240:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'number'.
+
+  1239 |   expect<string | number>().type.toBe<unknown>(); // fail
+  1240 |   expect<string | number>().type.toBe<string>(); // fail
+  1241 |   expect<string | number>().type.toBe<number>(); // fail
+       |                                       ~~~~~~
+  1242 |   expect<string | number>().type.toBe<bigint>(); // fail
+  1243 |   expect<string | number>().type.toBe<boolean>(); // fail
+  1244 |   expect<string | number>().type.toBe<symbol>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1241:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'bigint'.
+
+  1240 |   expect<string | number>().type.toBe<string>(); // fail
+  1241 |   expect<string | number>().type.toBe<number>(); // fail
+  1242 |   expect<string | number>().type.toBe<bigint>(); // fail
+       |                                       ~~~~~~
+  1243 |   expect<string | number>().type.toBe<boolean>(); // fail
+  1244 |   expect<string | number>().type.toBe<symbol>(); // fail
+  1245 |   expect<string | number>().type.toBe<object>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1242:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'boolean'.
+
+  1241 |   expect<string | number>().type.toBe<number>(); // fail
+  1242 |   expect<string | number>().type.toBe<bigint>(); // fail
+  1243 |   expect<string | number>().type.toBe<boolean>(); // fail
+       |                                       ~~~~~~~
+  1244 |   expect<string | number>().type.toBe<symbol>(); // fail
+  1245 |   expect<string | number>().type.toBe<object>(); // fail
+  1246 |   expect<string | number>().type.toBe<void>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1243:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'symbol'.
+
+  1242 |   expect<string | number>().type.toBe<bigint>(); // fail
+  1243 |   expect<string | number>().type.toBe<boolean>(); // fail
+  1244 |   expect<string | number>().type.toBe<symbol>(); // fail
+       |                                       ~~~~~~
+  1245 |   expect<string | number>().type.toBe<object>(); // fail
+  1246 |   expect<string | number>().type.toBe<void>(); // fail
+  1247 |   expect<string | number>().type.toBe<undefined>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1244:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'object'.
+
+  1243 |   expect<string | number>().type.toBe<boolean>(); // fail
+  1244 |   expect<string | number>().type.toBe<symbol>(); // fail
+  1245 |   expect<string | number>().type.toBe<object>(); // fail
+       |                                       ~~~~~~
+  1246 |   expect<string | number>().type.toBe<void>(); // fail
+  1247 |   expect<string | number>().type.toBe<undefined>(); // fail
+  1248 |   expect<string | number>().type.toBe<null>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1245:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'void'.
+
+  1244 |   expect<string | number>().type.toBe<symbol>(); // fail
+  1245 |   expect<string | number>().type.toBe<object>(); // fail
+  1246 |   expect<string | number>().type.toBe<void>(); // fail
+       |                                       ~~~~
+  1247 |   expect<string | number>().type.toBe<undefined>(); // fail
+  1248 |   expect<string | number>().type.toBe<null>(); // fail
+  1249 |   expect<string | number>().type.toBe<never>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1246:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'undefined'.
+
+  1245 |   expect<string | number>().type.toBe<object>(); // fail
+  1246 |   expect<string | number>().type.toBe<void>(); // fail
+  1247 |   expect<string | number>().type.toBe<undefined>(); // fail
+       |                                       ~~~~~~~~~
+  1248 |   expect<string | number>().type.toBe<null>(); // fail
+  1249 |   expect<string | number>().type.toBe<never>(); // fail
+  1250 |   expect<string | number>().type.toBe<'abc'>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1247:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'null'.
+
+  1246 |   expect<string | number>().type.toBe<void>(); // fail
+  1247 |   expect<string | number>().type.toBe<undefined>(); // fail
+  1248 |   expect<string | number>().type.toBe<null>(); // fail
+       |                                       ~~~~
+  1249 |   expect<string | number>().type.toBe<never>(); // fail
+  1250 |   expect<string | number>().type.toBe<'abc'>(); // fail
+  1251 |   expect<string | number>().type.toBe<'def'>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1248:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'never'.
+
+  1247 |   expect<string | number>().type.toBe<undefined>(); // fail
+  1248 |   expect<string | number>().type.toBe<null>(); // fail
+  1249 |   expect<string | number>().type.toBe<never>(); // fail
+       |                                       ~~~~~
+  1250 |   expect<string | number>().type.toBe<'abc'>(); // fail
+  1251 |   expect<string | number>().type.toBe<'def'>(); // fail
+  1252 |   expect<string | number>().type.toBe<123>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1249:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type '"abc"'.
+
+  1248 |   expect<string | number>().type.toBe<null>(); // fail
+  1249 |   expect<string | number>().type.toBe<never>(); // fail
+  1250 |   expect<string | number>().type.toBe<'abc'>(); // fail
+       |                                       ~~~~~
+  1251 |   expect<string | number>().type.toBe<'def'>(); // fail
+  1252 |   expect<string | number>().type.toBe<123>(); // fail
+  1253 |   expect<string | number>().type.toBe<456>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1250:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type '"def"'.
+
+  1249 |   expect<string | number>().type.toBe<never>(); // fail
+  1250 |   expect<string | number>().type.toBe<'abc'>(); // fail
+  1251 |   expect<string | number>().type.toBe<'def'>(); // fail
+       |                                       ~~~~~
+  1252 |   expect<string | number>().type.toBe<123>(); // fail
+  1253 |   expect<string | number>().type.toBe<456>(); // fail
+  1254 |   expect<string | number>().type.toBe<887n>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1251:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type '123'.
+
+  1250 |   expect<string | number>().type.toBe<'abc'>(); // fail
+  1251 |   expect<string | number>().type.toBe<'def'>(); // fail
+  1252 |   expect<string | number>().type.toBe<123>(); // fail
+       |                                       ~~~
+  1253 |   expect<string | number>().type.toBe<456>(); // fail
+  1254 |   expect<string | number>().type.toBe<887n>(); // fail
+  1255 |   expect<string | number>().type.toBe<998n>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1252:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type '456'.
+
+  1251 |   expect<string | number>().type.toBe<'def'>(); // fail
+  1252 |   expect<string | number>().type.toBe<123>(); // fail
+  1253 |   expect<string | number>().type.toBe<456>(); // fail
+       |                                       ~~~
+  1254 |   expect<string | number>().type.toBe<887n>(); // fail
+  1255 |   expect<string | number>().type.toBe<998n>(); // fail
+  1256 |   expect<string | number>().type.toBe<true>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1253:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type '887n'.
+
+  1252 |   expect<string | number>().type.toBe<123>(); // fail
+  1253 |   expect<string | number>().type.toBe<456>(); // fail
+  1254 |   expect<string | number>().type.toBe<887n>(); // fail
+       |                                       ~~~~
+  1255 |   expect<string | number>().type.toBe<998n>(); // fail
+  1256 |   expect<string | number>().type.toBe<true>(); // fail
+  1257 |   expect<string | number>().type.toBe<false>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1254:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type '998n'.
+
+  1253 |   expect<string | number>().type.toBe<456>(); // fail
+  1254 |   expect<string | number>().type.toBe<887n>(); // fail
+  1255 |   expect<string | number>().type.toBe<998n>(); // fail
+       |                                       ~~~~
+  1256 |   expect<string | number>().type.toBe<true>(); // fail
+  1257 |   expect<string | number>().type.toBe<false>(); // fail
+  1258 |   expect<string | number>().type.toBe<Array<string>>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1255:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'true'.
+
+  1254 |   expect<string | number>().type.toBe<887n>(); // fail
+  1255 |   expect<string | number>().type.toBe<998n>(); // fail
+  1256 |   expect<string | number>().type.toBe<true>(); // fail
+       |                                       ~~~~
+  1257 |   expect<string | number>().type.toBe<false>(); // fail
+  1258 |   expect<string | number>().type.toBe<Array<string>>(); // fail
+  1259 |   expect<string | number>().type.toBe<number[]>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1256:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'false'.
+
+  1255 |   expect<string | number>().type.toBe<998n>(); // fail
+  1256 |   expect<string | number>().type.toBe<true>(); // fail
+  1257 |   expect<string | number>().type.toBe<false>(); // fail
+       |                                       ~~~~~
+  1258 |   expect<string | number>().type.toBe<Array<string>>(); // fail
+  1259 |   expect<string | number>().type.toBe<number[]>(); // fail
+  1260 |   expect<string | number>().type.toBe<string | Array<string>>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1257:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'string[]'.
+
+  1256 |   expect<string | number>().type.toBe<true>(); // fail
+  1257 |   expect<string | number>().type.toBe<false>(); // fail
+  1258 |   expect<string | number>().type.toBe<Array<string>>(); // fail
+       |                                       ~~~~~~~~~~~~~
+  1259 |   expect<string | number>().type.toBe<number[]>(); // fail
+  1260 |   expect<string | number>().type.toBe<string | Array<string>>(); // fail
+  1261 | });
+
+         at ./__typetests__/structure.tst.ts:1258:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'number[]'.
+
+  1257 |   expect<string | number>().type.toBe<false>(); // fail
+  1258 |   expect<string | number>().type.toBe<Array<string>>(); // fail
+  1259 |   expect<string | number>().type.toBe<number[]>(); // fail
+       |                                       ~~~~~~~~
+  1260 |   expect<string | number>().type.toBe<string | Array<string>>(); // fail
+  1261 | });
+  1262 | 
+
+         at ./__typetests__/structure.tst.ts:1259:39 ❭ is string | number?
+
+Error: Type 'string | number' is not the same as type 'string | string[]'.
+
+  1258 |   expect<string | number>().type.toBe<Array<string>>(); // fail
+  1259 |   expect<string | number>().type.toBe<number[]>(); // fail
+  1260 |   expect<string | number>().type.toBe<string | Array<string>>(); // fail
+       |                                       ~~~~~~~~~~~~~~~~~~~~~~
+  1261 | });
+  1262 | 
+  1263 | test("is NOT string | number?", () => {
+
+         at ./__typetests__/structure.tst.ts:1260:39 ❭ is string | number?
+
+Error: Type 'string | number' is the same as type 'string | number'.
+
+  1286 |   expect<string | number>().type.not.toBe<string | Array<string>>();
+  1287 | 
+  1288 |   expect<string | number>().type.not.toBe<string | number>(); // fail
+       |                                           ~~~~~~~~~~~~~~~
+  1289 | });
+  1290 | 
+  1291 | test("is string | Array<string>?", () => {
+
+         at ./__typetests__/structure.tst.ts:1288:43 ❭ is NOT string | number?
+
+Error: Type 'string | string[]' is not the same as type 'any'.
+
+  1292 |   expect<string | Array<string>>().type.toBe<string | Array<string>>();
+  1293 | 
+  1294 |   expect<string | Array<string>>().type.toBe<any>(); // fail
+       |                                              ~~~
+  1295 |   expect<string | Array<string>>().type.toBe<unknown>(); // fail
+  1296 |   expect<string | Array<string>>().type.toBe<string>(); // fail
+  1297 |   expect<string | Array<string>>().type.toBe<number>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1294:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'unknown'.
+
+  1293 | 
+  1294 |   expect<string | Array<string>>().type.toBe<any>(); // fail
+  1295 |   expect<string | Array<string>>().type.toBe<unknown>(); // fail
+       |                                              ~~~~~~~
+  1296 |   expect<string | Array<string>>().type.toBe<string>(); // fail
+  1297 |   expect<string | Array<string>>().type.toBe<number>(); // fail
+  1298 |   expect<string | Array<string>>().type.toBe<bigint>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1295:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'string'.
+
+  1294 |   expect<string | Array<string>>().type.toBe<any>(); // fail
+  1295 |   expect<string | Array<string>>().type.toBe<unknown>(); // fail
+  1296 |   expect<string | Array<string>>().type.toBe<string>(); // fail
+       |                                              ~~~~~~
+  1297 |   expect<string | Array<string>>().type.toBe<number>(); // fail
+  1298 |   expect<string | Array<string>>().type.toBe<bigint>(); // fail
+  1299 |   expect<string | Array<string>>().type.toBe<boolean>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1296:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'number'.
+
+  1295 |   expect<string | Array<string>>().type.toBe<unknown>(); // fail
+  1296 |   expect<string | Array<string>>().type.toBe<string>(); // fail
+  1297 |   expect<string | Array<string>>().type.toBe<number>(); // fail
+       |                                              ~~~~~~
+  1298 |   expect<string | Array<string>>().type.toBe<bigint>(); // fail
+  1299 |   expect<string | Array<string>>().type.toBe<boolean>(); // fail
+  1300 |   expect<string | Array<string>>().type.toBe<symbol>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1297:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'bigint'.
+
+  1296 |   expect<string | Array<string>>().type.toBe<string>(); // fail
+  1297 |   expect<string | Array<string>>().type.toBe<number>(); // fail
+  1298 |   expect<string | Array<string>>().type.toBe<bigint>(); // fail
+       |                                              ~~~~~~
+  1299 |   expect<string | Array<string>>().type.toBe<boolean>(); // fail
+  1300 |   expect<string | Array<string>>().type.toBe<symbol>(); // fail
+  1301 |   expect<string | Array<string>>().type.toBe<object>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1298:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'boolean'.
+
+  1297 |   expect<string | Array<string>>().type.toBe<number>(); // fail
+  1298 |   expect<string | Array<string>>().type.toBe<bigint>(); // fail
+  1299 |   expect<string | Array<string>>().type.toBe<boolean>(); // fail
+       |                                              ~~~~~~~
+  1300 |   expect<string | Array<string>>().type.toBe<symbol>(); // fail
+  1301 |   expect<string | Array<string>>().type.toBe<object>(); // fail
+  1302 |   expect<string | Array<string>>().type.toBe<void>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1299:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'symbol'.
+
+  1298 |   expect<string | Array<string>>().type.toBe<bigint>(); // fail
+  1299 |   expect<string | Array<string>>().type.toBe<boolean>(); // fail
+  1300 |   expect<string | Array<string>>().type.toBe<symbol>(); // fail
+       |                                              ~~~~~~
+  1301 |   expect<string | Array<string>>().type.toBe<object>(); // fail
+  1302 |   expect<string | Array<string>>().type.toBe<void>(); // fail
+  1303 |   expect<string | Array<string>>().type.toBe<undefined>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1300:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'object'.
+
+  1299 |   expect<string | Array<string>>().type.toBe<boolean>(); // fail
+  1300 |   expect<string | Array<string>>().type.toBe<symbol>(); // fail
+  1301 |   expect<string | Array<string>>().type.toBe<object>(); // fail
+       |                                              ~~~~~~
+  1302 |   expect<string | Array<string>>().type.toBe<void>(); // fail
+  1303 |   expect<string | Array<string>>().type.toBe<undefined>(); // fail
+  1304 |   expect<string | Array<string>>().type.toBe<null>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1301:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'void'.
+
+  1300 |   expect<string | Array<string>>().type.toBe<symbol>(); // fail
+  1301 |   expect<string | Array<string>>().type.toBe<object>(); // fail
+  1302 |   expect<string | Array<string>>().type.toBe<void>(); // fail
+       |                                              ~~~~
+  1303 |   expect<string | Array<string>>().type.toBe<undefined>(); // fail
+  1304 |   expect<string | Array<string>>().type.toBe<null>(); // fail
+  1305 |   expect<string | Array<string>>().type.toBe<never>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1302:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'undefined'.
+
+  1301 |   expect<string | Array<string>>().type.toBe<object>(); // fail
+  1302 |   expect<string | Array<string>>().type.toBe<void>(); // fail
+  1303 |   expect<string | Array<string>>().type.toBe<undefined>(); // fail
+       |                                              ~~~~~~~~~
+  1304 |   expect<string | Array<string>>().type.toBe<null>(); // fail
+  1305 |   expect<string | Array<string>>().type.toBe<never>(); // fail
+  1306 |   expect<string | Array<string>>().type.toBe<'abc'>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1303:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'null'.
+
+  1302 |   expect<string | Array<string>>().type.toBe<void>(); // fail
+  1303 |   expect<string | Array<string>>().type.toBe<undefined>(); // fail
+  1304 |   expect<string | Array<string>>().type.toBe<null>(); // fail
+       |                                              ~~~~
+  1305 |   expect<string | Array<string>>().type.toBe<never>(); // fail
+  1306 |   expect<string | Array<string>>().type.toBe<'abc'>(); // fail
+  1307 |   expect<string | Array<string>>().type.toBe<'def'>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1304:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'never'.
+
+  1303 |   expect<string | Array<string>>().type.toBe<undefined>(); // fail
+  1304 |   expect<string | Array<string>>().type.toBe<null>(); // fail
+  1305 |   expect<string | Array<string>>().type.toBe<never>(); // fail
+       |                                              ~~~~~
+  1306 |   expect<string | Array<string>>().type.toBe<'abc'>(); // fail
+  1307 |   expect<string | Array<string>>().type.toBe<'def'>(); // fail
+  1308 |   expect<string | Array<string>>().type.toBe<123>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1305:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type '"abc"'.
+
+  1304 |   expect<string | Array<string>>().type.toBe<null>(); // fail
+  1305 |   expect<string | Array<string>>().type.toBe<never>(); // fail
+  1306 |   expect<string | Array<string>>().type.toBe<'abc'>(); // fail
+       |                                              ~~~~~
+  1307 |   expect<string | Array<string>>().type.toBe<'def'>(); // fail
+  1308 |   expect<string | Array<string>>().type.toBe<123>(); // fail
+  1309 |   expect<string | Array<string>>().type.toBe<456>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1306:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type '"def"'.
+
+  1305 |   expect<string | Array<string>>().type.toBe<never>(); // fail
+  1306 |   expect<string | Array<string>>().type.toBe<'abc'>(); // fail
+  1307 |   expect<string | Array<string>>().type.toBe<'def'>(); // fail
+       |                                              ~~~~~
+  1308 |   expect<string | Array<string>>().type.toBe<123>(); // fail
+  1309 |   expect<string | Array<string>>().type.toBe<456>(); // fail
+  1310 |   expect<string | Array<string>>().type.toBe<887n>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1307:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type '123'.
+
+  1306 |   expect<string | Array<string>>().type.toBe<'abc'>(); // fail
+  1307 |   expect<string | Array<string>>().type.toBe<'def'>(); // fail
+  1308 |   expect<string | Array<string>>().type.toBe<123>(); // fail
+       |                                              ~~~
+  1309 |   expect<string | Array<string>>().type.toBe<456>(); // fail
+  1310 |   expect<string | Array<string>>().type.toBe<887n>(); // fail
+  1311 |   expect<string | Array<string>>().type.toBe<998n>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1308:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type '456'.
+
+  1307 |   expect<string | Array<string>>().type.toBe<'def'>(); // fail
+  1308 |   expect<string | Array<string>>().type.toBe<123>(); // fail
+  1309 |   expect<string | Array<string>>().type.toBe<456>(); // fail
+       |                                              ~~~
+  1310 |   expect<string | Array<string>>().type.toBe<887n>(); // fail
+  1311 |   expect<string | Array<string>>().type.toBe<998n>(); // fail
+  1312 |   expect<string | Array<string>>().type.toBe<true>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1309:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type '887n'.
+
+  1308 |   expect<string | Array<string>>().type.toBe<123>(); // fail
+  1309 |   expect<string | Array<string>>().type.toBe<456>(); // fail
+  1310 |   expect<string | Array<string>>().type.toBe<887n>(); // fail
+       |                                              ~~~~
+  1311 |   expect<string | Array<string>>().type.toBe<998n>(); // fail
+  1312 |   expect<string | Array<string>>().type.toBe<true>(); // fail
+  1313 |   expect<string | Array<string>>().type.toBe<false>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1310:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type '998n'.
+
+  1309 |   expect<string | Array<string>>().type.toBe<456>(); // fail
+  1310 |   expect<string | Array<string>>().type.toBe<887n>(); // fail
+  1311 |   expect<string | Array<string>>().type.toBe<998n>(); // fail
+       |                                              ~~~~
+  1312 |   expect<string | Array<string>>().type.toBe<true>(); // fail
+  1313 |   expect<string | Array<string>>().type.toBe<false>(); // fail
+  1314 |   expect<string | Array<string>>().type.toBe<Array<string>>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1311:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'true'.
+
+  1310 |   expect<string | Array<string>>().type.toBe<887n>(); // fail
+  1311 |   expect<string | Array<string>>().type.toBe<998n>(); // fail
+  1312 |   expect<string | Array<string>>().type.toBe<true>(); // fail
+       |                                              ~~~~
+  1313 |   expect<string | Array<string>>().type.toBe<false>(); // fail
+  1314 |   expect<string | Array<string>>().type.toBe<Array<string>>(); // fail
+  1315 |   expect<string | Array<string>>().type.toBe<number[]>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1312:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'false'.
+
+  1311 |   expect<string | Array<string>>().type.toBe<998n>(); // fail
+  1312 |   expect<string | Array<string>>().type.toBe<true>(); // fail
+  1313 |   expect<string | Array<string>>().type.toBe<false>(); // fail
+       |                                              ~~~~~
+  1314 |   expect<string | Array<string>>().type.toBe<Array<string>>(); // fail
+  1315 |   expect<string | Array<string>>().type.toBe<number[]>(); // fail
+  1316 |   expect<string | Array<string>>().type.toBe<string | number>(); // fail
+
+         at ./__typetests__/structure.tst.ts:1313:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'string[]'.
+
+  1312 |   expect<string | Array<string>>().type.toBe<true>(); // fail
+  1313 |   expect<string | Array<string>>().type.toBe<false>(); // fail
+  1314 |   expect<string | Array<string>>().type.toBe<Array<string>>(); // fail
+       |                                              ~~~~~~~~~~~~~
+  1315 |   expect<string | Array<string>>().type.toBe<number[]>(); // fail
+  1316 |   expect<string | Array<string>>().type.toBe<string | number>(); // fail
+  1317 | });
+
+         at ./__typetests__/structure.tst.ts:1314:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'number[]'.
+
+  1313 |   expect<string | Array<string>>().type.toBe<false>(); // fail
+  1314 |   expect<string | Array<string>>().type.toBe<Array<string>>(); // fail
+  1315 |   expect<string | Array<string>>().type.toBe<number[]>(); // fail
+       |                                              ~~~~~~~~
+  1316 |   expect<string | Array<string>>().type.toBe<string | number>(); // fail
+  1317 | });
+  1318 | 
+
+         at ./__typetests__/structure.tst.ts:1315:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is not the same as type 'string | number'.
+
+  1314 |   expect<string | Array<string>>().type.toBe<Array<string>>(); // fail
+  1315 |   expect<string | Array<string>>().type.toBe<number[]>(); // fail
+  1316 |   expect<string | Array<string>>().type.toBe<string | number>(); // fail
+       |                                              ~~~~~~~~~~~~~~~
+  1317 | });
+  1318 | 
+  1319 | test("is NOT string | Array<string>?", () => {
+
+         at ./__typetests__/structure.tst.ts:1316:46 ❭ is string | Array<string>?
+
+Error: Type 'string | string[]' is the same as type 'string | string[]'.
+
+  1342 |   expect<string | Array<string>>().type.not.toBe<string | number>();
+  1343 | 
+  1344 |   expect<string | Array<string>>().type.not.toBe<string | Array<string>>(); // fail
+       |                                                  ~~~~~~~~~~~~~~~~~~~~~~
+  1345 | });
+  1346 | 
+
+         at ./__typetests__/structure.tst.ts:1344:50 ❭ is NOT string | Array<string>?
 

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -47,9 +47,13 @@ fail ./__typetests__/structure.tst.ts
   × is NOT Array<string>?
   × is number[]?
   × is NOT number[]?
+  × is string | number?
+  × is NOT string | number?
+  × is string | Array<string>?
+  × is NOT string | Array<string>?
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      44 failed, 44 total
-Assertions: 484 failed, 484 passed, 968 total
+Tests:      48 failed, 48 total
+Assertions: 576 failed, 576 passed, 1152 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBe-unions-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-unions-stderr.snap.txt
@@ -1,0 +1,47 @@
+Error: Type 'string | number' is not the same as type 'string | boolean'.
+
+  16 |   expect<string | Array<string>>().type.toBe<string | Array<string>>();
+  17 | 
+  18 |   expect<string | number>().type.toBe<string | boolean>(); // fail
+     |                                       ~~~~~~~~~~~~~~~~
+  19 |   expect<string | Array<string>>().type.toBe<string | Array<number>>(); // fail
+  20 | });
+  21 | 
+
+       at ./__typetests__/unions.tst.ts:18:39 ❭ is union the same?
+
+Error: Type 'string | string[]' is not the same as type 'string | number[]'.
+
+  17 | 
+  18 |   expect<string | number>().type.toBe<string | boolean>(); // fail
+  19 |   expect<string | Array<string>>().type.toBe<string | Array<number>>(); // fail
+     |                                              ~~~~~~~~~~~~~~~~~~~~~~
+  20 | });
+  21 | 
+  22 | test("is union NOT the same?", () => {
+
+       at ./__typetests__/unions.tst.ts:19:46 ❭ is union the same?
+
+Error: Type 'string | number' is the same as type 'string | number'.
+
+  24 |   expect<string | Array<string>>().type.not.toBe<string | Array<number>>();
+  25 | 
+  26 |   expect<string | number>().type.not.toBe<string | number>(); // fail
+     |                                           ~~~~~~~~~~~~~~~
+  27 |   expect<string | Array<string>>().type.not.toBe<string | Array<string>>(); // fail
+  28 | });
+  29 | 
+
+       at ./__typetests__/unions.tst.ts:26:43 ❭ is union NOT the same?
+
+Error: Type 'string | string[]' is the same as type 'string | string[]'.
+
+  25 | 
+  26 |   expect<string | number>().type.not.toBe<string | number>(); // fail
+  27 |   expect<string | Array<string>>().type.not.toBe<string | Array<string>>(); // fail
+     |                                                  ~~~~~~~~~~~~~~~~~~~~~~
+  28 | });
+  29 | 
+
+       at ./__typetests__/unions.tst.ts:27:50 ❭ is union NOT the same?
+

--- a/tests/__snapshots__/api-toBe-unions-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-unions-stdout.snap.txt
@@ -1,0 +1,14 @@
+···· TSTyche <<version>> at <<basePath>>/tests/__fixtures__/api-toBe
+
+uses TypeScript <<version>> with ./tsconfig.json
+
+fail ./__typetests__/unions.tst.ts
+  + edge cases
+  × is union the same?
+  × is union NOT the same?
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Tests:      2 failed, 1 passed, 3 total
+Assertions: 4 failed, 7 passed, 11 total
+Duration:   <<timestamp>>

--- a/tests/api-toBe.test.js
+++ b/tests/api-toBe.test.js
@@ -31,7 +31,7 @@ await test("toBe", async (t) => {
     assert.equal(exitCode, 1);
   });
 
-  await t.test("structure-based", async () => {
+  await t.test("structure", async () => {
     // TODO remove this check after dropping support for Node.js 20
     if (process.versions.node.startsWith("20")) {
       t.skip();
@@ -50,6 +50,39 @@ await test("toBe", async (t) => {
 
     await assert.matchSnapshot(normalizeOutput(stdout), {
       fileName: `${testFileName}-structure-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("enums", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["enums.tst.ts"], {
+      env: { ["TSTYCHE_NO_PATCH"]: "true" },
+    });
+
+    assert.equal(stderr, "");
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-enums-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("unions", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["unions.tst.ts"], {
+      env: { ["TSTYCHE_NO_PATCH"]: "true" },
+    });
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-unions-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-unions-stdout`,
       testFileUrl: import.meta.url,
     });
 


### PR DESCRIPTION
Part of #443

This PR adds logic to compare unions using the structure-based `.toBe()` matcher.