### PR TITLE
fix: handle broken symlinks during the lookup of test files

### DIFF
--- a/source/select/Select.ts
+++ b/source/select/Select.ts
@@ -30,14 +30,18 @@ export class Select {
       for (const entry of entries) {
         let entryMeta: FileSystemEntryMeta = entry;
 
-        if (entry.isSymbolicLink()) {
-          entryMeta = await fs.stat([targetPath, entry.name].join("/"));
-        }
+        try {
+          if (entry.isSymbolicLink()) {
+            entryMeta = await fs.stat([targetPath, entry.name].join("/"));
+          }
 
-        if (entryMeta.isDirectory()) {
-          directories.push(entry.name);
-        } else if (entryMeta.isFile()) {
-          files.push(entry.name);
+          if (entryMeta.isDirectory()) {
+            directories.push(entry.name);
+          } else if (entryMeta.isFile()) {
+            files.push(entry.name);
+          }
+        } catch {
+          // continue regardless of error
         }
       }
     } catch {


### PR DESCRIPTION
This PR adds a missing `try..catch` block to handle errors during the lookup of test files, allowing the process to continue smoothly when encountering broken symlinks.