### PR TITLE
refactor: pass `ts.Program` as argument to internal classes

### DIFF
--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -14,12 +14,12 @@ import { ToBeCallableWith } from "./ToBeCallableWith.js";
 import { ToBeConstructableWith } from "./ToBeConstructableWith.js";
 import { ToHaveProperty } from "./ToHaveProperty.js";
 import { ToRaiseError } from "./ToRaiseError.js";
-import type { MatchResult, TypeChecker } from "./types.js";
+import type { MatchResult } from "./types.js";
 
 export class ExpectService {
   #compiler: typeof ts;
+  #program: ts.Program;
   #reject: Reject;
-  #typeChecker: TypeChecker;
 
   private toAcceptProps: ToAcceptProps;
   private toBe: ToBe;
@@ -31,12 +31,12 @@ export class ExpectService {
   private toHaveProperty: ToHaveProperty;
   private toRaiseError: ToRaiseError;
 
-  constructor(compiler: typeof ts, typeChecker: TypeChecker, reject: Reject) {
+  constructor(compiler: typeof ts, program: ts.Program, reject: Reject) {
     this.#compiler = compiler;
+    this.#program = program;
     this.#reject = reject;
-    this.#typeChecker = typeChecker;
 
-    this.toAcceptProps = new ToAcceptProps(compiler, typeChecker);
+    this.toAcceptProps = new ToAcceptProps(compiler, program);
     this.toBe = new ToBe();
     this.toBeApplicable = new ToBeApplicable(compiler);
     this.toBeAssignableFrom = new ToBeAssignableFrom();
@@ -65,7 +65,7 @@ export class ExpectService {
       return;
     }
 
-    const matchWorker = new MatchWorker(this.#compiler, this.#typeChecker, assertionNode);
+    const matchWorker = new MatchWorker(this.#compiler, this.#program, assertionNode);
 
     if (
       !(matcherNameText === "toRaiseError" && assertionNode.isNot === false) &&

--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -2,7 +2,8 @@ import type ts from "typescript";
 import type { ExpectNode } from "#collect";
 import { DiagnosticOrigin } from "#diagnostic";
 import { Relation } from "./Relation.enum.js";
-import type { TypeChecker } from "./types.js";
+
+type TypeChecker = ts.TypeChecker & { isTypeIdenticalTo(source: ts.Type, target: ts.Type): boolean };
 
 export class MatchWorker {
   assertionNode: ExpectNode;
@@ -10,9 +11,9 @@ export class MatchWorker {
   #signatureCache = new Map<ts.Node, Array<ts.Signature>>();
   typeChecker: TypeChecker;
 
-  constructor(compiler: typeof ts, typeChecker: TypeChecker, assertionNode: ExpectNode) {
+  constructor(compiler: typeof ts, program: ts.Program, assertionNode: ExpectNode) {
     this.#compiler = compiler;
-    this.typeChecker = typeChecker;
+    this.typeChecker = program.getTypeChecker() as TypeChecker;
     this.assertionNode = assertionNode;
   }
 

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -4,15 +4,15 @@ import { nodeBelongsToArgumentList } from "#layers";
 import { ExpectDiagnosticText } from "./ExpectDiagnosticText.js";
 import type { MatchWorker } from "./MatchWorker.js";
 import { isUnionType } from "./predicates.js";
-import type { ArgumentNode, MatchResult, TypeChecker } from "./types.js";
+import type { ArgumentNode, MatchResult } from "./types.js";
 
 export class ToAcceptProps {
   #compiler: typeof ts;
-  #typeChecker: TypeChecker;
+  #typeChecker: ts.TypeChecker;
 
-  constructor(compiler: typeof ts, typeChecker: TypeChecker) {
+  constructor(compiler: typeof ts, program: ts.Program) {
     this.#compiler = compiler;
-    this.#typeChecker = typeChecker;
+    this.#typeChecker = program.getTypeChecker();
   }
 
   #explain(matchWorker: MatchWorker, sourceNode: ArgumentNode, targetNode: ArgumentNode) {

--- a/source/expect/index.ts
+++ b/source/expect/index.ts
@@ -1,2 +1,2 @@
 export { ExpectService } from "./ExpectService.js";
-export type { MatchResult, TypeChecker } from "./types.js";
+export type { MatchResult } from "./types.js";

--- a/source/expect/types.ts
+++ b/source/expect/types.ts
@@ -7,7 +7,3 @@ export interface MatchResult {
   explain: () => Array<Diagnostic>;
   isMatch: boolean;
 }
-
-export interface TypeChecker extends ts.TypeChecker {
-  isTypeIdenticalTo: (source: ts.Type, target: ts.Type) => boolean;
-}

--- a/source/reject/Reject.ts
+++ b/source/reject/Reject.ts
@@ -10,9 +10,9 @@ export class Reject {
   #rejectedArgumentTypes = new Set<"any" | "never">();
   #typeChecker: ts.TypeChecker;
 
-  constructor(compiler: typeof ts, typeChecker: ts.TypeChecker, resolvedConfig: ResolvedConfig) {
+  constructor(compiler: typeof ts, program: ts.Program, resolvedConfig: ResolvedConfig) {
     this.#compiler = compiler;
-    this.#typeChecker = typeChecker;
+    this.#typeChecker = program.getTypeChecker();
 
     if (resolvedConfig?.rejectAnyType) {
       this.#rejectedArgumentTypes.add("any");

--- a/source/runner/FileRunner.ts
+++ b/source/runner/FileRunner.ts
@@ -5,7 +5,6 @@ import { CollectService, type TestTree } from "#collect";
 import { Directive, type ResolvedConfig } from "#config";
 import { Diagnostic, type DiagnosticsHandler } from "#diagnostic";
 import { EventEmitter } from "#events";
-import type { TypeChecker } from "#expect";
 import type { FileLocation } from "#file";
 import { ProjectService } from "#project";
 import { FileResult } from "#result";
@@ -56,7 +55,7 @@ export class FileRunner {
     file: FileLocation,
     fileResult: FileResult,
     runModeFlags: RunModeFlags,
-  ): Promise<{ runModeFlags: RunModeFlags; testTree: TestTree; typeChecker: TypeChecker } | undefined> {
+  ): Promise<{ runModeFlags: RunModeFlags; testTree: TestTree; program: ts.Program } | undefined> {
     // wrapping around the language service allows querying on per file basis
     // reference: https://github.com/microsoft/TypeScript/wiki/Using-the-Language-Service-API#design-goals
     const languageService = this.#projectService.getLanguageService(file.path);
@@ -71,10 +70,9 @@ export class FileRunner {
 
     const semanticDiagnostics = languageService?.getSemanticDiagnostics(file.path);
     const program = languageService?.getProgram();
-    const typeChecker = program?.getTypeChecker() as TypeChecker;
     const sourceFile = program?.getSourceFile(file.path);
 
-    if (!sourceFile) {
+    if (!sourceFile || !program) {
       return;
     }
 
@@ -110,7 +108,7 @@ export class FileRunner {
 
     this.#suppressedService.match(testTree);
 
-    return { runModeFlags, testTree, typeChecker };
+    return { runModeFlags, testTree, program };
   }
 
   async #run(file: FileLocation, fileResult: FileResult, cancellationToken: CancellationToken) {
@@ -136,17 +134,11 @@ export class FileRunner {
       this.#onDiagnostics(diagnostics, fileResult);
     };
 
-    const testTreeWalker = new TestTreeWalker(
-      this.#compiler,
-      facts.typeChecker,
-      this.#resolvedConfig,
-      onFileDiagnostics,
-      {
-        cancellationToken,
-        hasOnly: facts.testTree.hasOnly,
-        position: file.position,
-      },
-    );
+    const testTreeWalker = new TestTreeWalker(this.#compiler, facts.program, this.#resolvedConfig, onFileDiagnostics, {
+      cancellationToken,
+      hasOnly: facts.testTree.hasOnly,
+      position: file.position,
+    });
 
     await testTreeWalker.visit(facts.testTree.children, facts.runModeFlags, /* parentResult */ undefined);
   }

--- a/source/runner/TestTreeWalker.ts
+++ b/source/runner/TestTreeWalker.ts
@@ -3,7 +3,7 @@ import { type ExpectNode, type TestTreeNode, TestTreeNodeBrand, TestTreeNodeFlag
 import { Directive, type ResolvedConfig } from "#config";
 import { Diagnostic, type DiagnosticsHandler } from "#diagnostic";
 import { EventEmitter } from "#events";
-import { ExpectService, type TypeChecker } from "#expect";
+import { ExpectService } from "#expect";
 import { Reject } from "#reject";
 import { DescribeResult, ExpectResult, TestResult } from "#result";
 import type { CancellationToken } from "#token";
@@ -30,7 +30,7 @@ export class TestTreeWalker {
 
   constructor(
     compiler: typeof ts,
-    typeChecker: TypeChecker,
+    program: ts.Program,
     resolvedConfig: ResolvedConfig,
     onFileDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
     options: TestTreeWalkerOptions,
@@ -43,9 +43,9 @@ export class TestTreeWalker {
     this.#hasOnly = options.hasOnly || resolvedConfig.only != null || options.position != null;
     this.#position = options.position;
 
-    const reject = new Reject(compiler, typeChecker, resolvedConfig);
+    const reject = new Reject(compiler, program, resolvedConfig);
 
-    this.#expectService = new ExpectService(compiler, typeChecker, reject);
+    this.#expectService = new ExpectService(compiler, program, reject);
     this.#whenService = new WhenService(reject, onFileDiagnostics);
   }
 


### PR DESCRIPTION
Split from #636

Let’s pass `ts.Program` as argument to internal classes instead of `ts.TypeChecker`. One can get the `TypeChecker` from the `Program` as well as other useful APIs.