### PR TITLE
fix(structure): treat `NoInfer<T>` as identical to `T`

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -7,6 +7,7 @@ import {
   isConditionalType,
   isFreshLiteralType,
   isIntersectionType,
+  isNoInferType,
   isObjectType,
   isTupleTypeReference,
   isTypeParameter,
@@ -439,6 +440,10 @@ export class Structure {
   #normalize(type: ts.Type): ts.Type {
     if (isFreshLiteralType(type, this.#compiler)) {
       return type.regularType;
+    }
+
+    if (isNoInferType(type, this.#compiler)) {
+      return type.baseType;
     }
 
     if (isUnionType(type, this.#compiler) || isIntersectionType(type, this.#compiler)) {

--- a/source/structure/predicates.ts
+++ b/source/structure/predicates.ts
@@ -16,6 +16,14 @@ export function isIntersectionType(type: ts.Type, compiler: typeof ts): type is 
   return !!(type.flags & compiler.TypeFlags.Intersection);
 }
 
+export function isNoInferType(type: ts.Type, compiler: typeof ts): type is ts.SubstitutionType {
+  // A 'NoInfer<T>' type is represented as a substitution type with a 'TypeFlags.Unknown' constraint.
+  return !!(
+    type.flags & compiler.TypeFlags.Substitution &&
+    (type as ts.SubstitutionType).constraint.flags & compiler.TypeFlags.Unknown
+  );
+}
+
 export function isObjectType(type: ts.Type, compiler: typeof ts): type is ts.ObjectType {
   return !!(type.flags & compiler.TypeFlags.Object);
 }

--- a/tests/__fixtures__/api-toBe/__typetests__/references.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/references.tst.ts
@@ -21,6 +21,12 @@ test("edge cases", () => {
   expect<{ a: toArrayString }>().type.toBe<{ a: toArray<string> }>();
 });
 
+test("NoInfer", () => {
+  expect<{ a: string }>().type.toBe<NoInfer<{ a: string }>>();
+  expect<Array<{ a: string }>>().type.toBe<NoInfer<Array<{ a: string }>>>();
+  expect<<T>(value: T) => T>().type.toBe<<T>(value: NoInfer<T>) => T>();
+});
+
 test("Array", () => {
   type A = Array<string>;
   type B = Array<{ b: number }>;

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -19,6 +19,6 @@ pass ./__typetests__/unions.tst.ts
 
 Targets:    1 passed, 1 total
 Test files: 14 passed, 14 total
-Tests:      85 passed, 85 total
-Assertions: 558 passed, 558 total
+Tests:      86 passed, 86 total
+Assertions: 561 passed, 561 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
When comparing type structure, treat `NoInfer<T>` is identical to `T`.