### PR TITLE
fix(structure): compare indexed access types

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -6,6 +6,7 @@ import {
   isClass,
   isConditionalType,
   isFreshLiteralType,
+  isIndexedAccessType,
   isIntersectionType,
   isNoInferType,
   isObjectType,
@@ -114,6 +115,14 @@ export class Structure {
       return false;
     }
 
+    if (isIndexedAccessType(a, this.#compiler) || isIndexedAccessType(b, this.#compiler)) {
+      if (isIndexedAccessType(a, this.#compiler) && isIndexedAccessType(b, this.#compiler)) {
+        return this.compareIndexedAccessType(a, b);
+      }
+
+      return false;
+    }
+
     if (isObjectType(a, this.#compiler) || isObjectType(b, this.#compiler)) {
       if (isObjectType(a, this.#compiler) && isObjectType(b, this.#compiler)) {
         return this.compareObjects(a, b);
@@ -138,6 +147,18 @@ export class Structure {
         this.#typeChecker.getTypeAtLocation(b.root.node.falseType),
       )
     );
+  }
+
+  compareIndexedAccessType(a: ts.IndexedAccessType, b: ts.IndexedAccessType): boolean {
+    if (!this.compare(a.objectType, b.objectType)) {
+      return false;
+    }
+
+    if (!this.compare(a.indexType, b.indexType)) {
+      return false;
+    }
+
+    return true;
   }
 
   compareIndexSignatures(a: ts.Type, b: ts.Type): boolean {
@@ -375,7 +396,12 @@ export class Structure {
       !this.#compareMaybeNullish(
         this.#typeChecker.getBaseConstraintOfType(a),
         this.#typeChecker.getBaseConstraintOfType(b),
-      ) ||
+      )
+    ) {
+      return false;
+    }
+
+    if (
       !this.#compareMaybeNullish(
         this.#typeChecker.getDefaultFromTypeParameter(a),
         this.#typeChecker.getDefaultFromTypeParameter(b),

--- a/source/structure/predicates.ts
+++ b/source/structure/predicates.ts
@@ -12,6 +12,10 @@ export function isFreshLiteralType(type: ts.Type, compiler: typeof ts): type is 
   return !!(type.flags & compiler.TypeFlags.Freshable) && (type as ts.LiteralType).freshType === type;
 }
 
+export function isIndexedAccessType(type: ts.Type, compiler: typeof ts): type is ts.IndexedAccessType {
+  return !!(type.flags & compiler.TypeFlags.IndexedAccess);
+}
+
 export function isIntersectionType(type: ts.Type, compiler: typeof ts): type is ts.IntersectionType {
   return !!(type.flags & compiler.TypeFlags.Intersection);
 }

--- a/tests/__fixtures__/api-toBe/__typetests__/call-signatures.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/call-signatures.tst.ts
@@ -241,15 +241,24 @@ test("async function", () => {
 });
 
 test("return type", () => {
-  expect<() => void>().type.toBe<() => void>();
-  expect<() => void>().type.not.toBe<() => never>();
+  type A = () => void;
+  type B = <T>() => T;
+  type C = (a: number) => (b: string) => boolean;
+  type D = <T extends [number, number]>(a: T) => T[number];
 
-  expect<<T>() => T>().type.toBe<<T>() => T>();
-  expect<<T>() => T>().type.not.toBe<() => unknown>();
+  expect<A>().type.toBe<() => void>();
+  expect<A>().type.not.toBe<() => never>();
 
-  expect<(a: number) => (b: string) => boolean>().type.toBe<(a: number) => (b: string) => boolean>();
-  expect<(a: number) => (b: string) => boolean>().type.not.toBe<(a: number) => (b: string) => void>();
-  expect<(a: number) => (b: string) => boolean>().type.not.toBe<(a: number) => () => boolean>();
+  expect<B>().type.toBe<<T>() => T>();
+  expect<B>().type.not.toBe<() => unknown>();
+
+  expect<C>().type.toBe<(a: number) => (b: string) => boolean>();
+  expect<C>().type.not.toBe<(a: number) => (b: string) => void>();
+  expect<C>().type.not.toBe<(a: number) => () => boolean>();
+
+  expect<D>().type.toBe<<T extends [number, number]>(a: T) => T[number]>();
+  expect<D>().type.not.toBe<<T extends [number, number]>(a: T) => T>();
+  expect<D>().type.not.toBe<<T extends [number, number]>(a: T) => number>();
 });
 
 test("property function signature", () => {

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -20,5 +20,5 @@ pass ./__typetests__/unions.tst.ts
 Targets:    1 passed, 1 total
 Test files: 14 passed, 14 total
 Tests:      86 passed, 86 total
-Assertions: 561 passed, 561 total
+Assertions: 564 passed, 564 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
When checking type structure, compare indexed access types as well.