### PR TITLE
fix(structure): compare `const` type parameters

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 import { ComparisonResult } from "./ComparisonResult.enum.js";
+import { getTargetSymbol, getTypeParameterModifiers, isSymbolFromDefaultLibrary } from "./getters.js";
 import { ensureArray, length } from "./helpers.js";
 import { getParameterCount, getParameterFacts } from "./parameters.js";
 import {
@@ -16,7 +17,6 @@ import {
   isUnionType,
 } from "./predicates.js";
 import { getPropertyType, isOptionalProperty, isReadonlyProperty } from "./properties.js";
-import { getTargetSymbol, isSymbolFromDefaultLibrary } from "./symbols.js";
 
 export class Structure {
   #compiler: typeof ts;
@@ -392,6 +392,10 @@ export class Structure {
   }
 
   compareTypeParameter(a: ts.TypeParameter, b: ts.TypeParameter): boolean {
+    if (getTypeParameterModifiers(a, this.#compiler) !== getTypeParameterModifiers(b, this.#compiler)) {
+      return false;
+    }
+
     if (
       !this.#compareMaybeNullish(
         this.#typeChecker.getBaseConstraintOfType(a),

--- a/source/structure/getters.ts
+++ b/source/structure/getters.ts
@@ -1,5 +1,19 @@
 import type ts from "typescript";
 
+export function getTypeParameterModifiers(typeParameter: ts.TypeParameter, compiler: typeof ts): ts.ModifierFlags {
+  if (!typeParameter.symbol.declarations) {
+    return compiler.ModifierFlags.None;
+  }
+
+  return (
+    typeParameter.symbol.declarations.reduce(
+      (modifiers, declaration) => modifiers | compiler.getEffectiveModifierFlags(declaration),
+      compiler.ModifierFlags.None,
+    ) &
+    (compiler.ModifierFlags.In | compiler.ModifierFlags.Out | compiler.ModifierFlags.Const)
+  );
+}
+
 export function getTargetSymbol(symbol: ts.Symbol, compiler: typeof ts) {
   return isCheckFlagSet(symbol, compiler.CheckFlags.Instantiated, compiler)
     ? (symbol as ts.TransientSymbol).links.target

--- a/source/structure/properties.ts
+++ b/source/structure/properties.ts
@@ -1,6 +1,6 @@
 import type ts from "typescript";
+import { isCheckFlagSet } from "./getters.js";
 import { isUnionType } from "./predicates.js";
-import { isCheckFlagSet } from "./symbols.js";
 
 export function getPropertyType(
   symbol: ts.Symbol,

--- a/source/ts-internals.d.ts
+++ b/source/ts-internals.d.ts
@@ -28,4 +28,6 @@ declare module "typescript" {
   }
 
   function getDeclarationModifierFlagsFromSymbol(symbol: Symbol): ModifierFlags;
+
+  function getEffectiveModifierFlags(node: Node): ModifierFlags;
 }

--- a/tests/__fixtures__/api-toBe/__typetests__/call-signatures.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/call-signatures.tst.ts
@@ -146,6 +146,30 @@ test("generic type parameters", () => {
   expect(withDefault).type.not.toBe<<T = string>(value: T) => string>();
 });
 
+test("'const' type parameters", () => {
+  function getNames<T extends { names: ReadonlyArray<string> }>(arg: T): T["names"] {
+    return arg.names;
+  }
+
+  function getNamesExactly<const T extends { names: ReadonlyArray<string> }>(arg: T): T["names"] {
+    return arg.names;
+  }
+
+  expect(getNames({ names: ["Alice", "Bob", "Eve"] })).type.toBe<Array<string>>();
+  expect(getNames({ names: ["Alice", "Bob", "Eve"] })).type.not.toBe<readonly ["Alice", "Bob", "Eve"]>();
+
+  expect(getNamesExactly({ names: ["Alice", "Bob", "Eve"] })).type.toBe<readonly ["Alice", "Bob", "Eve"]>();
+  expect(getNamesExactly({ names: ["Alice", "Bob", "Eve"] })).type.not.toBe<Array<string>>();
+
+  expect(getNames).type.toBe<<T extends { names: ReadonlyArray<string> }>(arg: T) => T["names"]>();
+  expect(getNames).type.not.toBe<<const T extends { names: ReadonlyArray<string> }>(arg: T) => T["names"]>();
+
+  expect(getNamesExactly).type.toBe<<const T extends { names: ReadonlyArray<string> }>(arg: T) => T["names"]>();
+  expect(getNamesExactly).type.not.toBe<<T extends { names: ReadonlyArray<string> }>(arg: T) => T["names"]>();
+
+  expect(getNames).type.not.toBe(getNamesExactly);
+});
+
 test("overloads", () => {
   type Sample = {
     (x: string): string;

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -19,6 +19,6 @@ pass ./__typetests__/unions.tst.ts
 
 Targets:    1 passed, 1 total
 Test files: 14 passed, 14 total
-Tests:      86 passed, 86 total
-Assertions: 566 passed, 566 total
+Tests:      87 passed, 87 total
+Assertions: 575 passed, 575 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
When checking type structure, compare `const` type parameters as well.