### PR TITLE
fix(structure): compare `NoInfer` as substitution type

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -514,14 +514,6 @@ export class Structure {
       return (type as ts.FreshableType).regularType;
     }
 
-    if (
-      // A 'NoInfer<T>' type is represented as a substitution type with a 'TypeFlags.Unknown' constraint
-      type.flags & this.#compiler.TypeFlags.Substitution &&
-      (type as ts.SubstitutionType).constraint.flags & this.#compiler.TypeFlags.Unknown
-    ) {
-      return (type as ts.SubstitutionType).baseType;
-    }
-
     if (type.flags & this.#compiler.TypeFlags.UnionOrIntersection) {
       // biome-ignore lint/style/noNonNullAssertion: intersections or unions have at least two members
       const candidateType = this.#normalize((type as ts.UnionOrIntersectionType).types[0]!);

--- a/tests/__fixtures__/api-toBe/__typetests__/references.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/references.tst.ts
@@ -21,12 +21,6 @@ test("edge cases", () => {
   expect<{ a: toArrayString }>().type.toBe<{ a: toArray<string> }>();
 });
 
-test("NoInfer", () => {
-  expect<{ a: string }>().type.toBe<NoInfer<{ a: string }>>();
-  expect<Array<{ a: string }>>().type.toBe<NoInfer<Array<{ a: string }>>>();
-  expect<<T>(value: T) => T>().type.toBe<<T>(value: NoInfer<T>) => T>();
-});
-
 test("Array", () => {
   type A = Array<string>;
   type B = Array<{ b: number }>;

--- a/tests/__fixtures__/api-toBe/__typetests__/substitution.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/substitution.tst.ts
@@ -1,21 +1,61 @@
-import { expect } from "tstyche";
+import { expect, test } from "tstyche";
 
-interface UserProfile {
-  age: number | undefined;
-  name: string | undefined;
-}
+test("signatures", () => {
+  interface UserProfile {
+    age: number | undefined;
+    name: string | undefined;
+  }
 
-type S<T extends string> = T;
-type N<T extends number> = T;
+  type S<T extends string> = T;
+  type N<T extends number> = T;
 
-type A = <T>() => T extends UserProfile ? (T["name"] extends string ? S<T["name"]> : never) : never;
-type B = <T>() => T extends UserProfile ? (T["age"] extends number ? N<T["age"]> : never) : never;
+  type A = <T>() => T extends UserProfile ? (T["name"] extends string ? S<T["name"]> : never) : never;
+  type B = <T>() => T extends UserProfile ? (T["age"] extends number ? N<T["age"]> : never) : never;
 
-expect<A>().type.toBe<<T>() => T extends UserProfile ? (T["name"] extends string ? S<T["name"]> : never) : never>();
-expect<A>().type.not.toBe<<T>() => T extends UserProfile ? (T["name"] extends string ? string : never) : never>();
+  expect<A>().type.toBe<<T>() => T extends UserProfile ? (T["name"] extends string ? S<T["name"]> : never) : never>();
+  expect<A>().type.not.toBe<<T>() => T extends UserProfile ? (T["name"] extends string ? string : never) : never>();
 
-expect<B>().type.toBe<<T>() => T extends UserProfile ? (T["age"] extends number ? N<T["age"]> : never) : never>();
-expect<B>().type.not.toBe<<T>() => T extends UserProfile ? (T["age"] extends number ? number : never) : never>();
+  expect<B>().type.toBe<<T>() => T extends UserProfile ? (T["age"] extends number ? N<T["age"]> : never) : never>();
+  expect<B>().type.not.toBe<<T>() => T extends UserProfile ? (T["age"] extends number ? number : never) : never>();
 
-expect<A>().type.not.toBe<B>();
-expect<B>().type.not.toBe<A>();
+  expect<A>().type.not.toBe<B>();
+  expect<B>().type.not.toBe<A>();
+});
+
+test("NoInfer", () => {
+  type A = <T>(value: NoInfer<T>) => T;
+  type B = <T>(value: T) => T;
+
+  const a = <T>(value: NoInfer<T>) => value;
+  const b = <T>(value: T) => value;
+
+  expect<A>().type.toBe<<T>(value: NoInfer<T>) => T>();
+  expect<A>().type.not.toBe<<T>(value: T) => T>();
+  expect(a).type.toBe<<T>(value: NoInfer<T>) => T>();
+  expect(a).type.not.toBe<<T>(value: T) => T>();
+
+  expect<B>().type.toBe<<T>(value: T) => T>();
+  expect<B>().type.not.toBe<<T>(value: NoInfer<T>) => T>();
+  expect(b).type.toBe<<T>(value: T) => T>();
+  expect(b).type.not.toBe<<T>(value: NoInfer<T>) => T>();
+
+  expect(a("abc")).type.toBe<unknown>();
+  expect(b("abc")).type.toBe<"abc">();
+
+  expect<A>().type.not.toBe<B>();
+  expect<B>().type.not.toBe<A>();
+});
+
+test("nested 'NoInfer'", () => {
+  type A = <S extends string>(config: { initial: NoInfer<S>; states: Array<S> }) => S;
+  type B = <S extends string>(config: { initial: S; states: Array<S> }) => S;
+
+  expect<A>().type.toBe<<S extends string>(config: { initial: NoInfer<S>; states: Array<S> }) => S>();
+  expect<A>().type.not.toBe<<S extends string>(config: { initial: S; states: Array<S> }) => S>();
+
+  expect<B>().type.toBe<<S extends string>(config: { initial: S; states: Array<S> }) => S>();
+  expect<B>().type.not.toBe<<S extends string>(config: { initial: NoInfer<S>; states: Array<S> }) => S>();
+
+  expect<A>().type.not.toBe<B>();
+  expect<B>().type.not.toBe<A>();
+});

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -20,6 +20,6 @@ pass ./__typetests__/unions.tst.ts
 
 Targets:    1 passed, 1 total
 Test files: 15 passed, 15 total
-Tests:      88 passed, 88 total
-Assertions: 589 passed, 589 total
+Tests:      90 passed, 90 total
+Assertions: 604 passed, 604 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
When comparing type structure, compare `NoInfer` as substitution type.