### PR TITLE
fix(structure): compare `target` type of type references

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -7,7 +7,6 @@ import {
   getThisTypeOfSignature,
   getTypeParameterModifiers,
   getTypeParametersOfSignature,
-  isSymbolFromDefaultLibrary,
 } from "./helpers.js";
 import { getParameterCount, getParameterFacts } from "./parameters.js";
 import { getPropertyType, isOptionalProperty, isReadonlyProperty } from "./properties.js";
@@ -16,14 +15,12 @@ import { SeenService } from "./SeenService.js";
 export class Structure {
   #compiler: typeof ts;
   #compilerOptions: ts.CompilerOptions;
-  #program: ts.Program;
   #seen = new SeenService();
   #typeChecker: ts.TypeChecker;
 
   constructor(compiler: typeof ts, program: ts.Program) {
     this.#compiler = compiler;
     this.#compilerOptions = program.getCompilerOptions();
-    this.#program = program;
     this.#typeChecker = program.getTypeChecker();
   }
 
@@ -166,17 +163,15 @@ export class Structure {
 
   compareObjects(a: ts.ObjectType, b: ts.ObjectType): boolean {
     if (a.objectFlags & b.objectFlags & this.#compiler.ObjectFlags.Reference) {
-      const isSame = this.compareTypeReferences(a as ts.TypeReference, b as ts.TypeReference);
-
-      if (isSame != null) {
-        return isSame;
+      if (!((a.objectFlags | b.objectFlags) & this.#compiler.ObjectFlags.ClassOrInterface)) {
+        return this.compareTypeReferences(a as ts.TypeReference, b as ts.TypeReference);
       }
     }
 
     return this.compareStructuredTypes(a, b);
   }
 
-  compareTypeReferences(a: ts.TypeReference, b: ts.TypeReference): boolean | undefined {
+  compareTypeReferences(a: ts.TypeReference, b: ts.TypeReference): boolean {
     if ((a.target.objectFlags | b.target.objectFlags) & this.#compiler.ObjectFlags.Tuple) {
       if (a.target.objectFlags & b.target.objectFlags & this.#compiler.ObjectFlags.Tuple) {
         return this.compareTuples(a as ts.TupleTypeReference, b as ts.TupleTypeReference);
@@ -185,16 +180,8 @@ export class Structure {
       return false;
     }
 
-    if ((a.objectFlags | b.objectFlags) & this.#compiler.ObjectFlags.Class) {
+    if (!this.compare(a.target, b.target)) {
       return this.compareStructuredTypes(a, b);
-    }
-
-    if (a.symbol !== b.symbol) {
-      if (isSymbolFromDefaultLibrary(a.symbol, this.#program) || isSymbolFromDefaultLibrary(b.symbol, this.#program)) {
-        return false;
-      }
-
-      return;
     }
 
     const aTypeArguments = this.#typeChecker.getTypeArguments(a);
@@ -204,10 +191,14 @@ export class Structure {
       return false;
     }
 
-    return aTypeArguments.every((type, i) =>
+    for (let i = 0; i < aTypeArguments.length; i++) {
       // biome-ignore lint/style/noNonNullAssertion: length was checked above
-      this.compare(type, bTypeArguments[i]!),
-    );
+      if (!this.compare(aTypeArguments[i]!, bTypeArguments[i]!)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   compareTuples(a: ts.TupleTypeReference, b: ts.TupleTypeReference): boolean {

--- a/source/structure/helpers.ts
+++ b/source/structure/helpers.ts
@@ -63,7 +63,3 @@ export function getTargetSymbol(symbol: ts.Symbol, compiler: typeof ts): ts.Symb
 export function isCheckFlagSet(symbol: ts.Symbol, flag: ts.CheckFlags, compiler: typeof ts): boolean {
   return !!(symbol.flags & compiler.SymbolFlags.Transient && (symbol as ts.TransientSymbol).links.checkFlags & flag);
 }
-
-export function isSymbolFromDefaultLibrary(symbol: ts.Symbol, program: ts.Program): boolean {
-  return !!symbol.declarations?.every((declaration) => program.isSourceFileDefaultLibrary(declaration.getSourceFile()));
-}

--- a/tests/__fixtures__/api-toBe/__typetests__/interfaces.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/interfaces.tst.ts
@@ -25,21 +25,24 @@ test("edge cases", () => {
 });
 
 test("recursive types", () => {
-  interface A<T> {
-    value: T;
-    left: B<T> | null;
-    right: B<T> | null;
+  interface Alpha<K, V> {
+    // biome-ignore lint/style/useNamingConvention: test
+    merge<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Alpha<K | KC, Exclude<V, VC> | VC>;
+    merge<C>(...collections: Array<{ [key: string]: C }>): Alpha<K | string, Exclude<V, C> | C>;
   }
 
-  type B<T> = {
-    value: T;
-    left: A<T> | null;
-    right: A<T> | null;
-  };
+  interface Bravo<K, V> {
+    // biome-ignore lint/style/useNamingConvention: test
+    merge<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Bravo<K | KC, Exclude<V, VC> | VC>;
+    merge<C>(...collections: Array<{ [key: string]: C }>): Bravo<K | string, Exclude<V, C> | C>;
+  }
 
-  expect<A<number>>().type.toBe<B<number>>();
-  expect<B<number>>().type.toBe<A<number>>();
+  expect<Alpha<string, string>>().type.toBe<Bravo<string, string>>();
+  expect<Bravo<string, string>>().type.toBe<Alpha<string, string>>();
 
-  expect<A<null>>().type.toBe<B<null>>();
-  expect<B<null>>().type.toBe<A<null>>();
+  expect<Alpha<string, number>>().type.toBe<Bravo<string, number>>();
+  expect<Bravo<string, number>>().type.toBe<Alpha<string, number>>();
+
+  expect<Alpha<string, string>>().type.not.toBe<Bravo<string, number>>();
+  expect<Bravo<string, string>>().type.not.toBe<Alpha<string, number>>();
 });

--- a/tests/__fixtures__/api-toBe/__typetests__/smoke.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/smoke.tst.ts
@@ -48,8 +48,10 @@ const samples = [
   // arrays
 
   "Array<string>",
+  "Array<Array<string>>",
   "number[]",
   "ReadonlyArray<string>",
+  "ReadonlyArray<ReadonlyArray<string>>",
   "Array<{ a: string }>",
   "{ a: number }[]",
   "ReadonlyArray<{ a: string }>",

--- a/tests/__snapshots__/api-toBe-smoke-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-smoke-stdout.snap.txt
@@ -67,10 +67,14 @@ pass ./__typetests__/smoke.tst.ts
   + is NOT { readonly a?: string }?
   + is Array<string>?
   + is NOT Array<string>?
+  + is Array<Array<string>>?
+  + is NOT Array<Array<string>>?
   + is number[]?
   + is NOT number[]?
   + is ReadonlyArray<string>?
   + is NOT ReadonlyArray<string>?
+  + is ReadonlyArray<ReadonlyArray<string>>?
+  + is NOT ReadonlyArray<ReadonlyArray<string>>?
   + is Array<{ a: string }>?
   + is NOT Array<{ a: string }>?
   + is { a: number }[]?
@@ -118,6 +122,6 @@ pass ./__typetests__/smoke.tst.ts
 
 Targets:    1 passed, 1 total
 Test files: 1 passed, 1 total
-Tests:      112 passed, 112 total
-Assertions: 3136 passed, 3136 total
+Tests:      116 passed, 116 total
+Assertions: 3364 passed, 3364 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -22,5 +22,5 @@ pass ./__typetests__/unions.tst.ts
 Targets:    1 passed, 1 total
 Test files: 16 passed, 16 total
 Tests:      98 passed, 98 total
-Assertions: 652 passed, 652 total
+Assertions: 654 passed, 654 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
When checking type structure, compare `target` type of type references instead of `symbol`. Because results of type comparisons are cached.