### PR TITLE
fix(structure): check predicate parameter position

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -357,6 +357,10 @@ export class Structure {
     const aTypePredicate = this.#typeChecker.getTypePredicateOfSignature(a);
     const bTypePredicate = this.#typeChecker.getTypePredicateOfSignature(b);
 
+    if (aTypePredicate?.parameterIndex !== bTypePredicate?.parameterIndex) {
+      return false;
+    }
+
     if (
       aTypePredicate?.kind !== bTypePredicate?.kind ||
       !this.#compareMaybeNullish(aTypePredicate?.type, bTypePredicate?.type)

--- a/tests/__fixtures__/api-toBe/__typetests__/predicates.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/predicates.tst.ts
@@ -78,3 +78,16 @@ test("'asserts this' type predicate", () => {
   expect(fso.isNetworked).type.not.toBe<() => asserts this is Directory & FileSystemObject>();
   expect(fso.isNetworked).type.not.toBe<() => void>();
 });
+
+test("parameter position", () => {
+  type A = (a: unknown, b: unknown) => a is number;
+  type X = (x: unknown, y: unknown) => y is number;
+
+  expect<A>().type.toBe<(a: unknown, b: unknown) => a is number>();
+  expect<A>().type.not.toBe<(a: unknown, b: unknown) => b is number>();
+  expect<A>().type.not.toBe<X>();
+
+  expect<X>().type.toBe<(x: unknown, y: unknown) => y is number>();
+  expect<X>().type.not.toBe<(x: unknown, y: unknown) => x is number>();
+  expect<X>().type.not.toBe<A>();
+});

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -21,6 +21,6 @@ pass ./__typetests__/unions.tst.ts
 
 Targets:    1 passed, 1 total
 Test files: 16 passed, 16 total
-Tests:      98 passed, 98 total
-Assertions: 673 passed, 673 total
+Tests:      99 passed, 99 total
+Assertions: 679 passed, 679 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
When checking structure of types, take into account predicate parameter position.