### PR TITLE
refactor: rename the `--root` command line option

### DIFF
--- a/source/cli/Cli.ts
+++ b/source/cli/Cli.ts
@@ -89,7 +89,7 @@ export class Cli {
 
       const { configFileOptions, configFilePath } = await Config.parseConfigFile(
         commandLineOptions.config,
-        commandLineOptions.rootPath,
+        commandLineOptions.root,
       );
 
       const resolvedConfig = Config.resolve({

--- a/source/config/Config.ts
+++ b/source/config/Config.ts
@@ -33,10 +33,11 @@ export class Config {
   }
 
   static async parseConfigFile(
-    filePath?: string,
+    configPath?: string,
+    // TODO set default 'rootPath = "."' here and use 'rootPath' to resolve 'configFilePath', but not vice versa
     rootPath?: string,
   ): Promise<{ configFileOptions: ConfigFileOptions; configFilePath: string }> {
-    const configFilePath = Config.resolveConfigFilePath(filePath, rootPath);
+    const configFilePath = Config.resolveConfigFilePath(configPath, rootPath);
 
     const configFileOptions: ConfigFileOptions = {
       rootPath: rootPath ?? Path.dirname(configFilePath),
@@ -80,13 +81,16 @@ export class Config {
     if ("config" in resolvedConfig) {
       delete resolvedConfig.config;
     }
+    if ("root" in resolvedConfig) {
+      delete resolvedConfig.root;
+    }
 
     return resolvedConfig;
   }
 
-  static resolveConfigFilePath(filePath?: string, rootPath = "."): string {
-    if (filePath != null) {
-      return Path.resolve(filePath);
+  static resolveConfigFilePath(configPath?: string, rootPath = "."): string {
+    if (configPath != null) {
+      return Path.resolve(configPath);
     }
 
     return Path.resolve(rootPath, "./tstyche.config.json");

--- a/source/config/Options.ts
+++ b/source/config/Options.ts
@@ -157,7 +157,14 @@ export class Options {
     {
       brand: OptionBrand.String,
       description: "The path to a directory containing files of a test project.",
-      group: OptionGroup.CommandLine | OptionGroup.ConfigFile,
+      group: OptionGroup.CommandLine,
+      name: "root",
+    },
+
+    {
+      brand: OptionBrand.String,
+      description: "The path to a directory containing files of a test project.",
+      group: OptionGroup.ConfigFile,
       name: "rootPath",
     },
 
@@ -251,6 +258,7 @@ export class Options {
 
     switch (canonicalOptionName) {
       case "config":
+      case "root":
       case "rootPath":
       case "tsconfig":
         if (canonicalOptionName === "tsconfig" && Options.#isLookupStrategy(optionValue)) {
@@ -295,6 +303,7 @@ export class Options {
 
     switch (canonicalOptionName) {
       case "config":
+      case "root":
       case "rootPath":
       case "tsconfig":
         if (canonicalOptionName === "tsconfig" && Options.#isLookupStrategy(optionValue)) {

--- a/source/config/types.ts
+++ b/source/config/types.ts
@@ -13,7 +13,7 @@ export interface CommandLineOptions {
   prune?: boolean;
   quiet?: boolean;
   reporters?: Array<string>;
-  rootPath?: string;
+  root?: string;
   showConfig?: boolean;
   skip?: string;
   target?: Array<string>;

--- a/tests/__fixtures__/integration-tag/__tests__/fail.test.js
+++ b/tests/__fixtures__/integration-tag/__tests__/fail.test.js
@@ -5,5 +5,5 @@ import { getFixtureUrl } from "./getFixtureUrl.js";
 const fixtureUrl = getFixtureUrl(import.meta);
 
 await assert.rejects(async () => {
-  await tstyche`isNumber --quiet --rootPath ${fixtureUrl}`;
+  await tstyche`isNumber --quiet --root ${fixtureUrl}`;
 }, "Error: TSTyche test run failed. Check the output above for details.");

--- a/tests/__fixtures__/integration-tag/__tests__/pass.test.js
+++ b/tests/__fixtures__/integration-tag/__tests__/pass.test.js
@@ -3,4 +3,4 @@ import { getFixtureUrl } from "./getFixtureUrl.js";
 
 const fixtureUrl = getFixtureUrl(import.meta);
 
-await tstyche`isString --quiet --rootPath ${fixtureUrl}`;
+await tstyche`isString --quiet --root ${fixtureUrl}`;

--- a/tests/__snapshots__/config-help-stdout.snap.txt
+++ b/tests/__snapshots__/config-help-stdout.snap.txt
@@ -42,7 +42,7 @@ Command Line Options
   --reporters  list of strings
   The list of reporters to use.
 
-  --rootPath  string
+  --root  string
   The path to a directory containing files of a test project.
 
   --showConfig

--- a/tests/config-root.test.js
+++ b/tests/config-root.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'--root' command line option", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("sets root path of a test project", async () => {
+    await writeFixture(fixtureUrl, {
+      ["temp/empty"]: undefined,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--root", "./temp", "--showConfig"]);
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-root/temp",
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when absolute path is specified", async () => {
+    await writeFixture(fixtureUrl, {
+      ["temp/empty"]: undefined,
+    });
+
+    const rootUrl = fileURLToPath(new URL("./temp", fixtureUrl));
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--root", rootUrl, "--showConfig"]);
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-root/temp",
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when URL string is specified", async () => {
+    await writeFixture(fixtureUrl, {
+      ["temp/empty"]: undefined,
+    });
+
+    const rootUrl = new URL("./temp", fixtureUrl).toString();
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--root", rootUrl, "--showConfig"]);
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-root/temp",
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("overrides configuration file option", async () => {
+    const config = {
+      rootPath: "../",
+    };
+
+    await writeFixture(fixtureUrl, {
+      ["config/tstyche.json"]: JSON.stringify(config, null, 2),
+      ["temp/empty"]: undefined,
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--root", "./temp", "--showConfig"]);
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-root/temp",
+    });
+
+    assert.equal(exitCode, 0);
+  });
+});

--- a/tests/config-rootPath.test.js
+++ b/tests/config-rootPath.test.js
@@ -1,5 +1,4 @@
 import test from "node:test";
-import { fileURLToPath } from "node:url";
 import * as assert from "./__utilities__/assert.js";
 import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { normalizeOutput } from "./__utilities__/output.js";
@@ -7,85 +6,6 @@ import { spawnTyche } from "./__utilities__/tstyche.js";
 
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
-
-await test("'--rootPath' command line option", async (t) => {
-  t.afterEach(async () => {
-    await clearFixture(fixtureUrl);
-  });
-
-  await t.test("sets root path of a test project", async () => {
-    await writeFixture(fixtureUrl, {
-      ["temp/empty"]: undefined,
-    });
-
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--rootPath", "./temp", "--showConfig"]);
-
-    assert.equal(stderr, "");
-
-    assert.matchObject(normalizeOutput(stdout), {
-      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-rootPath/temp",
-    });
-
-    assert.equal(exitCode, 0);
-  });
-
-  await t.test("when absolute path is specified", async () => {
-    await writeFixture(fixtureUrl, {
-      ["temp/empty"]: undefined,
-    });
-
-    const rootPath = fileURLToPath(new URL("./temp", fixtureUrl));
-
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--rootPath", rootPath, "--showConfig"]);
-
-    assert.equal(stderr, "");
-
-    assert.matchObject(normalizeOutput(stdout), {
-      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-rootPath/temp",
-    });
-
-    assert.equal(exitCode, 0);
-  });
-
-  await t.test("when URL string is specified", async () => {
-    await writeFixture(fixtureUrl, {
-      ["temp/empty"]: undefined,
-    });
-
-    const rootUrl = new URL("./temp", fixtureUrl).toString();
-
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--rootPath", rootUrl, "--showConfig"]);
-
-    assert.equal(stderr, "");
-
-    assert.matchObject(normalizeOutput(stdout), {
-      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-rootPath/temp",
-    });
-
-    assert.equal(exitCode, 0);
-  });
-
-  await t.test("overrides configuration file option", async () => {
-    const config = {
-      rootPath: "../",
-    };
-
-    await writeFixture(fixtureUrl, {
-      ["config/tstyche.json"]: JSON.stringify(config, null, 2),
-      ["temp/empty"]: undefined,
-    });
-
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--rootPath", "./temp", "--showConfig"]);
-
-    assert.equal(stderr, "");
-
-    assert.matchObject(normalizeOutput(stdout), {
-      rootPath: "<<basePath>>/tests/__fixtures__/.generated/config-rootPath/temp",
-    });
-
-    assert.equal(exitCode, 0);
-  });
-});
 
 await test("'rootPath' configuration file option", async (t) => {
   t.afterEach(async () => {

--- a/tests/validation-root.test.js
+++ b/tests/validation-root.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'--root' command line option", async (t) => {
+  await writeFixture(fixtureUrl);
+
+  t.after(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when option value is missing", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--root"]);
+
+    const expected = [
+      "Error: Option '--root' expects a value.",
+      "",
+      "Value for the '--root' option must be a string.",
+      "",
+      "",
+    ].join("\n");
+
+    assert.equal(stderr, expected);
+    assert.equal(stdout, "");
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("when specified path does not exist", async () => {
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--root", "../nope"]);
+
+    const expected = [
+      "Error: The specified path '<<basePath>>/tests/__fixtures__/.generated/nope' does not exist.",
+      "",
+      "",
+    ].join("\n");
+
+    assert.equal(normalizeOutput(stderr), expected);
+    assert.equal(stdout, "");
+    assert.equal(exitCode, 1);
+  });
+});

--- a/tests/validation-rootPath.test.js
+++ b/tests/validation-rootPath.test.js
@@ -7,44 +7,6 @@ import { spawnTyche } from "./__utilities__/tstyche.js";
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
-await test("'--rootPath' command line option", async (t) => {
-  await writeFixture(fixtureUrl);
-
-  t.after(async () => {
-    await clearFixture(fixtureUrl);
-  });
-
-  await t.test("when option value is missing", async () => {
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--rootPath"]);
-
-    const expected = [
-      "Error: Option '--rootPath' expects a value.",
-      "",
-      "Value for the '--rootPath' option must be a string.",
-      "",
-      "",
-    ].join("\n");
-
-    assert.equal(stderr, expected);
-    assert.equal(stdout, "");
-    assert.equal(exitCode, 1);
-  });
-
-  await t.test("when specified path does not exist", async () => {
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--rootPath", "../nope"]);
-
-    const expected = [
-      "Error: The specified path '<<basePath>>/tests/__fixtures__/.generated/nope' does not exist.",
-      "",
-      "",
-    ].join("\n");
-
-    assert.equal(normalizeOutput(stderr), expected);
-    assert.equal(stdout, "");
-    assert.equal(exitCode, 1);
-  });
-});
-
 await test("'rootPath' configuration file option", async (t) => {
   t.afterEach(async () => {
     await clearFixture(fixtureUrl);

--- a/typetests/CommandLineOptions.tst.ts
+++ b/typetests/CommandLineOptions.tst.ts
@@ -14,6 +14,7 @@ describe("CommandLineOptions", () => {
       prune: true,
       quiet: true,
       reporters: ["./tstyche-reporter.js"],
+      root: "./example",
       showConfig: true,
       skip: "internal",
       target: ["5.0" as const, "5.4" as const, "latest" as const],
@@ -85,6 +86,12 @@ describe("CommandLineOptions", () => {
   test("'reporters' option", () => {
     expect<Pick<CommandLineOptions, "reporters">>().type.toBe<{
       reporters?: Array<string>;
+    }>();
+  });
+
+  test("'root' option", () => {
+    expect<Pick<CommandLineOptions, "root">>().type.toBe<{
+      root?: string;
     }>();
   });
 


### PR DESCRIPTION
Renaming the `--root` command line option.