### PR TITLE
fix: always sort test files by name in watch mode

### DIFF
--- a/source/watch/WatchService.ts
+++ b/source/watch/WatchService.ts
@@ -119,7 +119,7 @@ export class WatchService {
       const testFiles = await debounce.schedule();
 
       if (testFiles.length > 0) {
-        yield testFiles;
+        yield testFiles.sort((a, b) => a.path.localeCompare(b.path));
       }
     }
   }

--- a/tests/__snapshots__/feature-watch-multiple-test-files-are-added-stdout.snap.txt
+++ b/tests/__snapshots__/feature-watch-multiple-test-files-are-added-stdout.snap.txt
@@ -12,6 +12,10 @@ runs ./b-feature/__typetests__/isNumber.test.ts
 <moveCursorUpBy1Row>
 <eraseLineEnd>
 pass ./b-feature/__typetests__/isNumber.test.ts
+runs ./b-feature/__typetests__/isString.test.ts
+<moveCursorUpBy1Row>
+<eraseLineEnd>
+pass ./b-feature/__typetests__/isString.test.ts
 
 Press a to run all tests.
 Press x to exit.

--- a/tests/__snapshots__/feature-watch-multiple-test-files-are-changed-stdout.snap.txt
+++ b/tests/__snapshots__/feature-watch-multiple-test-files-are-changed-stdout.snap.txt
@@ -8,6 +8,10 @@ fail ./a-feature/__typetests__/isNumber.test.ts
 
 uses TypeScript <<version>> with ./b-feature/__typetests__/tsconfig.json
 
+runs ./b-feature/__typetests__/isNumber.test.ts
+<moveCursorUpBy1Row>
+<eraseLineEnd>
+pass ./b-feature/__typetests__/isNumber.test.ts
 runs ./b-feature/__typetests__/isString.test.ts
 <moveCursorUpBy1Row>
 <eraseLineEnd>

--- a/tests/__snapshots__/feature-watch-single-test-file-is-renamed-stdout.snap.txt
+++ b/tests/__snapshots__/feature-watch-single-test-file-is-renamed-stdout.snap.txt
@@ -15,6 +15,10 @@ runs ./a-feature/__typetests__/isString.test.ts
 <moveCursorUpBy1Row>
 <eraseLineEnd>
 pass ./a-feature/__typetests__/isString.test.ts
+runs ./a-feature/__typetests__/new-isNumber.test.ts
+<moveCursorUpBy1Row>
+<eraseLineEnd>
+pass ./a-feature/__typetests__/new-isNumber.test.ts
 
 uses TypeScript <<version>> with ./b-feature/__typetests__/tsconfig.json
 
@@ -22,13 +26,6 @@ runs ./b-feature/__typetests__/isString.test.ts
 <moveCursorUpBy1Row>
 <eraseLineEnd>
 pass ./b-feature/__typetests__/isString.test.ts
-
-uses TypeScript <<version>> with ./a-feature/__typetests__/tsconfig.json
-
-runs ./a-feature/__typetests__/new-isNumber.test.ts
-<moveCursorUpBy1Row>
-<eraseLineEnd>
-pass ./a-feature/__typetests__/new-isNumber.test.ts
 
 Press a to run all tests.
 Press x to exit.

--- a/tests/feature-watch.test.js
+++ b/tests/feature-watch.test.js
@@ -281,6 +281,7 @@ await test("watch", async (t) => {
       process.resetOutput();
 
       fs.writeFileSync(new URL("a-feature/__typetests__/isString.test.ts", fixtureUrl), isStringTestWithErrorText);
+      fs.writeFileSync(new URL("b-feature/__typetests__/isString.test.ts", fixtureUrl), isStringTestText);
       fs.writeFileSync(new URL("b-feature/__typetests__/isNumber.test.ts", fixtureUrl), isNumberTestText);
 
       const filesAdded = await process.waitForIdle();
@@ -341,6 +342,7 @@ await test("watch", async (t) => {
 
       fs.writeFileSync(new URL("a-feature/__typetests__/isNumber.test.ts", fixtureUrl), isNumberTestWithErrorText);
       fs.writeFileSync(new URL("b-feature/__typetests__/isString.test.ts", fixtureUrl), isStringTestWithErrorText);
+      fs.writeFileSync(new URL("b-feature/__typetests__/isNumber.test.ts", fixtureUrl), isStringTestText);
 
       const filesChanged = await process.waitForIdle();
 


### PR DESCRIPTION
This change makes sure test files are always sorted by name in watch mode.