### PR TITLE
feat: add fetch environment variables

### DIFF
--- a/source/environment/Environment.ts
+++ b/source/environment/Environment.ts
@@ -6,14 +6,36 @@ import type { EnvironmentOptions } from "./types.js";
 export class Environment {
   static resolve(): EnvironmentOptions {
     return {
+      fetchRetries: Environment.#resolveFetchRetries(),
+      fetchTimeout: Environment.#resolveFetchTimeout(),
       isCi: Environment.#resolveIsCi(),
       noColor: Environment.#resolveNoColor(),
       noInteractive: Environment.#resolveNoInteractive(),
       npmRegistry: Environment.#resolveNpmRegistry(),
       storePath: Environment.#resolveStorePath(),
-      timeout: Environment.#resolveTimeout(),
       typescriptModule: Environment.#resolveTypeScriptModule(),
     };
+  }
+
+  static #resolveFetchRetries() {
+    if (process.env["TSTYCHE_FETCH_RETRIES"] != null) {
+      return Number(process.env["TSTYCHE_FETCH_RETRIES"]);
+    }
+
+    return 2;
+  }
+
+  static #resolveFetchTimeout() {
+    if (process.env["TSTYCHE_FETCH_TIMEOUT"] != null) {
+      return Number.parseFloat(process.env["TSTYCHE_FETCH_TIMEOUT"]);
+    }
+
+    // TODO remove in TSTyche 8
+    if (process.env["TSTYCHE_TIMEOUT"] != null) {
+      return Number.parseFloat(process.env["TSTYCHE_TIMEOUT"]);
+    }
+
+    return 30;
   }
 
   static #resolveIsCi() {
@@ -70,14 +92,6 @@ export class Environment {
     }
 
     return Path.resolve(os.homedir(), ".local", "share", "TSTyche");
-  }
-
-  static #resolveTimeout() {
-    if (process.env["TSTYCHE_TIMEOUT"] != null) {
-      return Number.parseFloat(process.env["TSTYCHE_TIMEOUT"]);
-    }
-
-    return 30;
   }
 
   static #resolveTypeScriptModule() {

--- a/source/environment/types.ts
+++ b/source/environment/types.ts
@@ -1,9 +1,10 @@
 export interface EnvironmentOptions {
+  fetchRetries: number;
+  fetchTimeout: number;
   isCi: boolean;
   noColor: boolean;
   noInteractive: boolean;
   npmRegistry: string;
   storePath: string;
-  timeout: number;
   typescriptModule: string | undefined;
 }

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -55,7 +55,7 @@ export class Fetcher {
         if (error instanceof Error && error.name === "TimeoutError") {
           this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout)));
         } else {
-          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure()));
+          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure(this.#retries)));
         }
       }
 

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -42,20 +42,16 @@ export class Fetcher {
           return;
         }
 
-        if (suppressErrors) {
-          continue;
+        if (!suppressErrors) {
+          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
         }
-
-        this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
       } catch (error) {
-        if (suppressErrors) {
-          continue;
-        }
-
-        if (error instanceof Error && error.name === "TimeoutError") {
-          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout)));
-        } else {
-          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure(this.#retries)));
+        if (!suppressErrors) {
+          if (error instanceof Error && error.name === "TimeoutError") {
+            this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout)));
+          } else {
+            this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure(this.#retries)));
+          }
         }
       }
 

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -18,10 +18,9 @@ export class Fetcher {
     diagnostic: () => Diagnostic,
     options?: { suppressErrors?: boolean | undefined },
   ): Promise<Response | undefined> {
-    let attempt = 0;
     let delay = 3000;
 
-    while (attempt <= this.#retries) {
+    for (let attempt = 0; attempt <= this.#retries; attempt++) {
       const isLastAttempt = attempt === this.#retries;
       const suppressErrors = options?.suppressErrors ?? !isLastAttempt;
 
@@ -64,8 +63,6 @@ export class Fetcher {
         await sleep(delay);
         delay *= 2;
       }
-
-      attempt++;
     }
 
     return;

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -32,22 +32,31 @@ export class Fetcher {
           return response;
         }
 
-        // only retry 5xx, 429 (rate limit) or connection error
+        // do not retry 4xx, except 429 (rate limit)
         if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-          !options?.suppressErrors &&
-            this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
+          if (options?.suppressErrors) {
+            return;
+          }
+
+          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
 
           return;
         }
 
-        !suppressErrors &&
-          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
+        if (suppressErrors) {
+          continue;
+        }
+
+        this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
       } catch (error) {
+        if (suppressErrors) {
+          continue;
+        }
+
         if (error instanceof Error && error.name === "TimeoutError") {
-          !suppressErrors &&
-            this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout)));
+          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout)));
         } else {
-          !suppressErrors && this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure()));
+          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure()));
         }
       }
 

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -4,12 +4,12 @@ import { StoreDiagnosticText } from "./StoreDiagnosticText.js";
 
 export class Fetcher {
   #onDiagnostics: DiagnosticsHandler;
+  #retries: number;
   #timeout: number;
-  #retries = 2;
-  #attempt = 0;
 
-  constructor(onDiagnostics: DiagnosticsHandler, timeout: number) {
+  constructor(onDiagnostics: DiagnosticsHandler, retries: number, timeout: number) {
     this.#onDiagnostics = onDiagnostics;
+    this.#retries = retries;
     this.#timeout = timeout;
   }
 
@@ -18,9 +18,13 @@ export class Fetcher {
     diagnostic: () => Diagnostic,
     options?: { suppressErrors?: boolean | undefined },
   ): Promise<Response | undefined> {
-    let delay = 2000;
+    let attempt = 0;
+    let delay = 3000;
 
-    for (this.#attempt = 0; this.#attempt <= this.#retries; this.#attempt++) {
+    while (attempt <= this.#retries) {
+      const isLastAttempt = attempt === this.#retries;
+      const suppressErrors = options?.suppressErrors ?? !isLastAttempt;
+
       try {
         const response = await fetch(request, { signal: AbortSignal.timeout(this.#timeout) });
 
@@ -28,35 +32,33 @@ export class Fetcher {
           return response;
         }
 
-        this.#emitDiagnostic(
-          diagnostic,
-          StoreDiagnosticText.requestFailedWithStatusCode(response.status),
-          options?.suppressErrors,
-        );
+        // only retry 5xx, 429 (rate limit) or connection error
+        if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+          !options?.suppressErrors &&
+            this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
+
+          return;
+        }
+
+        !suppressErrors &&
+          this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestFailed(response.status)));
       } catch (error) {
         if (error instanceof Error && error.name === "TimeoutError") {
-          this.#emitDiagnostic(
-            diagnostic,
-            StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout),
-            options?.suppressErrors,
-          );
+          !suppressErrors &&
+            this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.requestTimeoutWasExceeded(this.#timeout)));
         } else {
-          this.#emitDiagnostic(diagnostic, StoreDiagnosticText.maybeNetworkConnectionIssue(), options?.suppressErrors);
+          !suppressErrors && this.#onDiagnostics(diagnostic().extendWith(StoreDiagnosticText.networkFailure()));
         }
       }
 
-      if (this.#attempt < this.#retries) {
+      if (!isLastAttempt) {
         await sleep(delay);
         delay *= 2;
       }
+
+      attempt++;
     }
 
     return;
-  }
-
-  #emitDiagnostic(diagnostic: () => Diagnostic, text: string, suppressErrors?: boolean): void {
-    if (this.#attempt === this.#retries && !suppressErrors) {
-      this.#onDiagnostics(diagnostic().extendWith(text));
-    }
   }
 }

--- a/source/store/Fetcher.ts
+++ b/source/store/Fetcher.ts
@@ -22,7 +22,7 @@ export class Fetcher {
 
     for (let attempt = 0; attempt <= this.#retries; attempt++) {
       const isLastAttempt = attempt === this.#retries;
-      const suppressErrors = options?.suppressErrors ?? !isLastAttempt;
+      const suppressErrors = options?.suppressErrors || !isLastAttempt;
 
       try {
         const response = await fetch(request, { signal: AbortSignal.timeout(this.#timeout) });

--- a/source/store/Store.ts
+++ b/source/store/Store.ts
@@ -18,13 +18,14 @@ export class Store {
   static #manifestService: ManifestService;
   static #packageService: PackageService;
   static #npmRegistry = environmentOptions.npmRegistry;
+  static #fetchRetries = environmentOptions.fetchRetries;
+  static #fetchTimeout = environmentOptions.fetchTimeout * 1000;
   static #storePath = environmentOptions.storePath;
   static #supportedTags: Array<string> | undefined;
-  static #timeout = environmentOptions.timeout * 1000;
 
   static {
-    Store.#fetcher = new Fetcher(Store.#onDiagnostics, Store.#timeout);
-    Store.#lockService = new LockService(Store.#onDiagnostics, Store.#timeout);
+    Store.#fetcher = new Fetcher(Store.#onDiagnostics, Store.#fetchRetries, Store.#fetchTimeout);
+    Store.#lockService = new LockService(Store.#onDiagnostics, Store.#fetchTimeout);
     Store.#packageService = new PackageService(Store.#storePath, Store.#fetcher, Store.#lockService);
     Store.#manifestService = new ManifestService(Store.#storePath, Store.#npmRegistry, Store.#fetcher);
   }

--- a/source/store/StoreDiagnosticText.ts
+++ b/source/store/StoreDiagnosticText.ts
@@ -15,12 +15,12 @@ export class StoreDiagnosticText {
     return `Failed to update metadata of the 'typescript' package from '${registry}'.`;
   }
 
-  static networkFailure(): string {
-    return "Might be there is an issue with the registry or the network connection.";
-  }
-
   static maybeOutdatedResolution(tag: string): string {
     return `The resolution of the '${tag}' tag may be outdated.`;
+  }
+
+  static networkFailure(retries: number): string {
+    return `The network connection failed after ${retries + 1} attempts.`;
   }
 
   static requestFailed(code: number): string {

--- a/source/store/StoreDiagnosticText.ts
+++ b/source/store/StoreDiagnosticText.ts
@@ -15,7 +15,7 @@ export class StoreDiagnosticText {
     return `Failed to update metadata of the 'typescript' package from '${registry}'.`;
   }
 
-  static maybeNetworkConnectionIssue(): string {
+  static networkFailure(): string {
     return "Might be there is an issue with the registry or the network connection.";
   }
 
@@ -23,7 +23,7 @@ export class StoreDiagnosticText {
     return `The resolution of the '${tag}' tag may be outdated.`;
   }
 
-  static requestFailedWithStatusCode(code: number): string {
+  static requestFailed(code: number): string {
     return `The request failed with status code ${code}.`;
   }
 

--- a/tests/config-fetchRetries.test.js
+++ b/tests/config-fetchRetries.test.js
@@ -29,18 +29,22 @@ await test("'TSTYCHE_FETCH_RETRIES' environment variable", async (t) => {
   await t.test("when retry count is specified", async () => {
     await writeFixture(fixtureUrl);
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"], {
+    const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
       env: {
-        ["TSTYCHE_FETCH_RETRIES"]: "5",
+        ["TSTYCHE_FETCH_RETRIES"]: "1",
+        ["TSTYCHE_NPM_REGISTRY"]: "https://nothing.tstyche.org",
       },
     });
 
-    assert.equal(stderr, "");
+    const expected = [
+      "Error: Failed to fetch metadata of the 'typescript' package from 'https://nothing.tstyche.org'.",
+      "",
+      "The network connection failed after 2 attempts.",
+      "",
+      "",
+    ].join("\n");
 
-    assert.matchObject(normalizeOutput(stdout), {
-      fetchRetries: 5,
-    });
-
-    assert.equal(exitCode, 0);
+    assert.equal(stderr, expected);
+    assert.equal(exitCode, 1);
   });
 });

--- a/tests/config-fetchRetries.test.js
+++ b/tests/config-fetchRetries.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'TSTYCHE_FETCH_RETRIES' environment variable", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("has default value", async () => {
+    await writeFixture(fixtureUrl);
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"]);
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      fetchRetries: 2,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when retry count is specified", async () => {
+    await writeFixture(fixtureUrl);
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"], {
+      env: {
+        ["TSTYCHE_FETCH_RETRIES"]: "5",
+      },
+    });
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      fetchRetries: 5,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+});

--- a/tests/config-fetchTimeout.test.js
+++ b/tests/config-fetchTimeout.test.js
@@ -47,3 +47,30 @@ await test("'TSTYCHE_FETCH_TIMEOUT' environment variable", async (t) => {
     assert.equal(exitCode, 1);
   });
 });
+
+await test("'TSTYCHE_TIMEOUT' environment variable", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("when timeout is specified", async () => {
+    await writeFixture(fixtureUrl);
+
+    const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
+      env: {
+        ["TSTYCHE_TIMEOUT"]: "0.001",
+      },
+    });
+
+    const expected = [
+      "Error: Failed to fetch metadata of the 'typescript' package from 'https://registry.npmjs.org'.",
+      "",
+      "The request timeout of 0.001s was exceeded.",
+      "",
+      "",
+    ].join("\n");
+
+    assert.equal(stderr, expected);
+    assert.equal(exitCode, 1);
+  });
+});

--- a/tests/config-fetchTimeout.test.js
+++ b/tests/config-fetchTimeout.test.js
@@ -29,18 +29,21 @@ await test("'TSTYCHE_FETCH_TIMEOUT' environment variable", async (t) => {
   await t.test("when timeout is specified", async () => {
     await writeFixture(fixtureUrl);
 
-    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"], {
+    const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
       env: {
-        ["TSTYCHE_FETCH_TIMEOUT"]: "60",
+        ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
       },
     });
 
-    assert.equal(stderr, "");
+    const expected = [
+      "Error: Failed to fetch metadata of the 'typescript' package from 'https://registry.npmjs.org'.",
+      "",
+      "The request timeout of 0.001s was exceeded.",
+      "",
+      "",
+    ].join("\n");
 
-    assert.matchObject(normalizeOutput(stdout), {
-      fetchTimeout: 60,
-    });
-
-    assert.equal(exitCode, 0);
+    assert.equal(stderr, expected);
+    assert.equal(exitCode, 1);
   });
 });

--- a/tests/config-fetchTimeout.test.js
+++ b/tests/config-fetchTimeout.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import * as assert from "./__utilities__/assert.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
+import { normalizeOutput } from "./__utilities__/output.js";
+import { spawnTyche } from "./__utilities__/tstyche.js";
+
+const testFileName = getTestFileName(import.meta.url);
+const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+await test("'TSTYCHE_FETCH_TIMEOUT' environment variable", async (t) => {
+  t.afterEach(async () => {
+    await clearFixture(fixtureUrl);
+  });
+
+  await t.test("has default value", async () => {
+    await writeFixture(fixtureUrl);
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"]);
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      fetchTimeout: 30,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+
+  await t.test("when timeout is specified", async () => {
+    await writeFixture(fixtureUrl);
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--showConfig"], {
+      env: {
+        ["TSTYCHE_FETCH_TIMEOUT"]: "60",
+      },
+    });
+
+    assert.equal(stderr, "");
+
+    assert.matchObject(normalizeOutput(stdout), {
+      fetchTimeout: 60,
+    });
+
+    assert.equal(exitCode, 0);
+  });
+});

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -47,7 +47,7 @@ await test("store", async (t) => {
 
     const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
       env: {
-        ["TSTYCHE_TIMEOUT"]: "0.001",
+        ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
       },
     });
 
@@ -95,7 +95,7 @@ await test("store", async (t) => {
 
     const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.6"], {
       env: {
-        ["TSTYCHE_TIMEOUT"]: "0.001",
+        ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
       },
     });
 
@@ -119,7 +119,7 @@ await test("store", async (t) => {
 
     const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.4"], {
       env: {
-        ["TSTYCHE_TIMEOUT"]: "1.5",
+        ["TSTYCHE_FETCH_TIMEOUT"]: "1.5",
       },
     });
 
@@ -197,7 +197,7 @@ await test("store", async (t) => {
 
         const { stderr } = await spawnTyche(fixtureUrl, ["--showConfig", "--target", target], {
           env: {
-            ["TSTYCHE_TIMEOUT"]: "0.001",
+            ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
           },
         });
 
@@ -251,7 +251,7 @@ await test("store", async (t) => {
 
         const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--showConfig", "--target", target], {
           env: {
-            ["TSTYCHE_TIMEOUT"]: "0.001",
+            ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
           },
         });
 
@@ -344,7 +344,7 @@ await test("store", async (t) => {
 
       const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
         env: {
-          ["TSTYCHE_TIMEOUT"]: "0.001",
+          ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
         },
       });
 

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -18,9 +18,7 @@ await test("store", async (t) => {
   });
 
   await t.test("when fetch request of metadata fails with 404", async () => {
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-    });
+    await writeFixture(fixtureUrl);
 
     const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
       env: {
@@ -41,9 +39,7 @@ await test("store", async (t) => {
   });
 
   await t.test("when fetch request of metadata times out", async () => {
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-    });
+    await writeFixture(fixtureUrl);
 
     const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
       env: {
@@ -64,9 +60,7 @@ await test("store", async (t) => {
   });
 
   await t.test("when fetch request of metadata fails", async () => {
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-    });
+    await writeFixture(fixtureUrl);
 
     const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
       env: {
@@ -77,7 +71,7 @@ await test("store", async (t) => {
     const expected = [
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://nothing.tstyche.org'.",
       "",
-      "Might be there is an issue with the registry or the network connection.",
+      "The network connection failed after 3 attempts.",
       "",
       "",
     ].join("\n");

--- a/tests/validation-store.test.js
+++ b/tests/validation-store.test.js
@@ -86,7 +86,7 @@ await test("store", async (t) => {
     assert.equal(exitCode, 1);
   });
 
-  await t.test("when installing 'typescript' times out", async () => {
+  await t.test("when fetch request of 'typescript' package times out", async () => {
     await writeFixture(fixtureUrl, {
       ["__typetests__/dummy.test.ts"]: isStringTestText,
     });

--- a/tests/validation-update.test.js
+++ b/tests/validation-update.test.js
@@ -94,10 +94,6 @@ await test("'--update' command line option", async (t) => {
       ["__typetests__/dummy.test.ts"]: isStringTestText,
     });
 
-    await writeFixture(fixtureUrl, {
-      ["__typetests__/dummy.test.ts"]: isStringTestText,
-    });
-
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--update"], {
       env: {
         ["TSTYCHE_NPM_REGISTRY"]: "https://nothing.tstyche.org",
@@ -107,7 +103,7 @@ await test("'--update' command line option", async (t) => {
     const expected = [
       "Error: Failed to fetch metadata of the 'typescript' package from 'https://nothing.tstyche.org'.",
       "",
-      "Might be there is an issue with the registry or the network connection.",
+      "The network connection failed after 3 attempts.",
       "",
       "",
     ].join("\n");

--- a/tests/validation-update.test.js
+++ b/tests/validation-update.test.js
@@ -64,7 +64,7 @@ await test("'--update' command line option", async (t) => {
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--update"], {
       env: {
-        ["TSTYCHE_TIMEOUT"]: "0.001",
+        ["TSTYCHE_FETCH_TIMEOUT"]: "0.001",
       },
     });
 


### PR DESCRIPTION
This PR add the following environment variables:

- `TSTYCHE_FETCH_RETRIES`, The number of times to retry a failed HTTP request.
- `TSTYCHE_FETCH_TIMEOUT` (renamed from `TSTYCHE_TIMEOUT`), The maximum number of seconds to wait before an HTTP request times out.

