### PR TITLE
fix: validate jsx setup for `.toAcceptProps` matcher

### DIFF
--- a/source/expect/Ensure.ts
+++ b/source/expect/Ensure.ts
@@ -37,6 +37,26 @@ export class Ensure {
     return true;
   }
 
+  jsxSetup(program: ts.Program, node: ts.Node, onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>): boolean {
+    const diagnosticText: Array<string> = [];
+
+    if (!program.getCompilerOptions().jsx) {
+      diagnosticText.push("The matcher requires the 'jsx' compiler option to be configured.");
+    }
+
+    if (node.getSourceFile().languageVariant !== this.#compiler.LanguageVariant.JSX) {
+      diagnosticText.push("The matcher requires a '.tsx' file extension.");
+    }
+
+    if (diagnosticText.length > 0) {
+      this.#emitDiagnostic(diagnosticText, node, onDiagnostics);
+
+      return false;
+    }
+
+    return true;
+  }
+
   typeArgument<T extends ts.Node>(
     node: T | undefined,
     enclosingNode: ts.Node,
@@ -51,9 +71,17 @@ export class Ensure {
     return true;
   }
 
-  #emitDiagnostic(text: string, enclosingNode: ts.Node, onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>): void {
+  #emitDiagnostic(
+    text: string | Array<string>,
+    enclosingNode: ts.Node,
+    onDiagnostics: DiagnosticsHandler<Array<Diagnostic>>,
+  ): void {
+    if (!Array.isArray(text)) {
+      text = [text];
+    }
+
     const origin = DiagnosticOrigin.fromNode(enclosingNode);
 
-    onDiagnostics([Diagnostic.error(text, origin)]);
+    onDiagnostics(text.map((text) => Diagnostic.error(text, origin)));
   }
 }

--- a/source/expect/Ensure.ts
+++ b/source/expect/Ensure.ts
@@ -45,7 +45,7 @@ export class Ensure {
     }
 
     if (node.getSourceFile().languageVariant !== this.#compiler.LanguageVariant.JSX) {
-      diagnosticText.push("The matcher requires a '.tsx' file extension.");
+      diagnosticText.push("The matcher requires a '.tsx' or '.jsx' file extension.");
     }
 
     if (diagnosticText.length > 0) {

--- a/source/expect/ExpectService.ts
+++ b/source/expect/ExpectService.ts
@@ -60,11 +60,16 @@ export class ExpectService {
   ): MatchResult | undefined {
     const matcherNameText = assertionNode.matcherNameNode.name.text;
 
-    if (!this.#ensure.argumentOrTypeArgument(assertionNode.source[0], assertionNode.node.expression, onDiagnostics)) {
+    if (
+      matcherNameText === "toAcceptProps" &&
+      !this.#ensure.jsxSetup(this.#program, assertionNode.matcherNameNode.name, onDiagnostics)
+    ) {
       return;
     }
 
-    const matchWorker = new MatchWorker(this.#compiler, this.#program, assertionNode);
+    if (!this.#ensure.argumentOrTypeArgument(assertionNode.source[0], assertionNode.node.expression, onDiagnostics)) {
+      return;
+    }
 
     if (
       !(matcherNameText === "toBeInstantiableWith" || (matcherNameText === "toRaiseError" && !assertionNode.isNot)) &&
@@ -72,6 +77,8 @@ export class ExpectService {
     ) {
       return;
     }
+
+    const matchWorker = new MatchWorker(this.#compiler, this.#program, assertionNode);
 
     switch (matcherNameText) {
       case "toAcceptProps":

--- a/tests/__snapshots__/validation-toAcceptProps-requires-jsx-option-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-requires-jsx-option-stderr.snap.txt
@@ -1,0 +1,10 @@
+Error: The matcher requires the 'jsx' compiler option to be configured.
+
+  5 | }
+  6 | 
+  7 | expect(Component).type.toAcceptProps({});
+    |                        ~~~~~~~~~~~~~
+  8 | 
+
+      at ./__typetests__/toAcceptProps.tst.tsx:7:24
+

--- a/tests/__snapshots__/validation-toAcceptProps-requires-jsx-option-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-requires-jsx-option-stdout.snap.txt
@@ -1,0 +1,10 @@
+···· TSTyche <<version>> at <<basePath>>/tests/__fixtures__/.generated/validation-toAcceptProps
+
+uses TypeScript <<version>> with ./__typetests__/tsconfig.json
+
+fail ./__typetests__/toAcceptProps.tst.tsx
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Assertions: 1 failed, 1 total
+Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-toAcceptProps-requires-tsx-extension-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-requires-tsx-extension-stderr.snap.txt
@@ -1,0 +1,10 @@
+Error: The matcher requires a '.tsx' or '.jsx' file extension.
+
+  5 | }
+  6 | 
+  7 | expect(Component).type.toAcceptProps({});
+    |                        ~~~~~~~~~~~~~
+  8 | 
+
+      at ./__typetests__/toAcceptProps.tst.ts:7:24
+

--- a/tests/__snapshots__/validation-toAcceptProps-requires-tsx-extension-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-requires-tsx-extension-stdout.snap.txt
@@ -1,0 +1,10 @@
+···· TSTyche <<version>> at <<basePath>>/tests/__fixtures__/.generated/validation-toAcceptProps
+
+uses TypeScript <<version>> with ./__typetests__/tsconfig.json
+
+fail ./__typetests__/toAcceptProps.tst.ts
+
+Targets:    1 failed, 1 total
+Test files: 1 failed, 1 total
+Assertions: 1 failed, 1 total
+Duration:   <<timestamp>>

--- a/tests/validation-toAcceptProps.test.js
+++ b/tests/validation-toAcceptProps.test.js
@@ -1,13 +1,13 @@
 import test from "node:test";
 import * as assert from "./__utilities__/assert.js";
-import { getFixtureFileUrl, getTestFileName } from "./__utilities__/fixture.js";
+import { clearFixture, getFixtureFileUrl, getTestFileName, writeFixture } from "./__utilities__/fixture.js";
 import { normalizeOutput } from "./__utilities__/output.js";
 import { spawnTyche } from "./__utilities__/tstyche.js";
 
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName);
 
-await test("toAcceptProps", async () => {
+await test("toAcceptProps", async (t) => {
   const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
 
   await assert.matchSnapshot(stderr, {
@@ -21,4 +21,89 @@ await test("toAcceptProps", async () => {
   });
 
   assert.equal(exitCode, 1);
+
+  await t.test("requires the 'jsx' compiler option", async (t) => {
+    const toAcceptPropsText = `import { expect } from "tstyche";
+
+export default function Component() {
+  return "Test";
+}
+
+expect(Component).type.toAcceptProps({});
+`;
+
+    const tsconfig = {
+      extends: "../../../tsconfig.json",
+      include: ["**/*"],
+    };
+
+    const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+    t.after(async () => {
+      await clearFixture(fixtureUrl);
+    });
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/toAcceptProps.tst.tsx"]: toAcceptPropsText,
+      ["__typetests__/tsconfig.json"]: JSON.stringify(tsconfig),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-requires-jsx-option-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-requires-jsx-option-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
+
+  await t.test("requires the 'tsx' file extension", async (t) => {
+    const toAcceptPropsText = `import { expect } from "tstyche";
+
+export default function Component() {
+  return "Test";
+}
+
+expect(Component).type.toAcceptProps({});
+`;
+
+    const tsconfig = {
+      extends: "../../../tsconfig.json",
+      compilerOptions: {
+        jsx: "react-jsx",
+      },
+      include: ["**/*"],
+    };
+
+    const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
+
+    t.after(async () => {
+      await clearFixture(fixtureUrl);
+    });
+
+    await writeFixture(fixtureUrl, {
+      ["__typetests__/toAcceptProps.tst.ts"]: toAcceptPropsText,
+      ["__typetests__/tsconfig.json"]: JSON.stringify(tsconfig),
+    });
+
+    const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl);
+
+    await assert.matchSnapshot(stderr, {
+      fileName: `${testFileName}-requires-tsx-extension-stderr`,
+      testFileUrl: import.meta.url,
+    });
+
+    await assert.matchSnapshot(normalizeOutput(stdout), {
+      fileName: `${testFileName}-requires-tsx-extension-stdout`,
+      testFileUrl: import.meta.url,
+    });
+
+    assert.equal(exitCode, 1);
+  });
 });


### PR DESCRIPTION
The `.toAcceptProps` matcher can only be used in `.tsx` files and the [`jsx`](https://www.typescriptlang.org/tsconfig/#jsx) compiler option must be configured.

This PR adds validation logic that emits clear error messages.