### PR TITLE
fix: improve validation of arguments passed to the `.toAcceptProps()` matcher

### DIFF
--- a/source/expect/MatchWorker.ts
+++ b/source/expect/MatchWorker.ts
@@ -4,7 +4,6 @@ import type { ExpectNode } from "#collect";
 export class MatchWorker {
   assertionNode: ExpectNode;
   #compiler: typeof ts;
-  #signatureCache = new Map<ts.Node, Array<ts.Signature>>();
   typeChecker: ts.TypeChecker;
 
   constructor(compiler: typeof ts, program: ts.Program, assertionNode: ExpectNode) {
@@ -35,22 +34,6 @@ export class MatchWorker {
         : ({ flags: this.#compiler.TypeFlags.NonPrimitive } as ts.Type); // TODO remove this workaround after dropping support for TypeScript 5.8
 
     return this.typeChecker.isTypeAssignableTo(type, nonPrimitiveType);
-  }
-
-  getSignatures(node: ts.Node): Array<ts.Signature> {
-    let signatures = this.#signatureCache.get(node);
-
-    if (!signatures) {
-      const type = this.getType(node);
-
-      signatures = type.getCallSignatures() as Array<ts.Signature>;
-
-      if (signatures.length === 0) {
-        signatures = type.getConstructSignatures() as Array<ts.Signature>;
-      }
-    }
-
-    return signatures;
   }
 
   getTypeText(node: ts.Node): string {

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -9,6 +9,10 @@ export class ToAcceptProps extends AbilityMatcherBase {
   explainText = ExpectDiagnosticText.acceptsProps;
   explainNotText = ExpectDiagnosticText.doesNotAcceptProps;
 
+  #isValidIdentifier(target: string) {
+    return target[0] === target[0]!.toUpperCase() && /^[A-Z_$]/.test(target[0]);
+  }
+
   match(
     matchWorker: MatchWorker,
     sourceNode: ArgumentNode,
@@ -26,6 +30,11 @@ export class ToAcceptProps extends AbilityMatcherBase {
         ? ExpectDiagnosticText.argumentMustBe(expectedText)
         : ExpectDiagnosticText.typeArgumentMustBe(expectedText);
 
+      const origin = DiagnosticOrigin.fromNode(sourceNode);
+
+      diagnostics.push(Diagnostic.error(text, origin));
+    } else if (nodeBelongsToArgumentList(this.compiler, sourceNode) && !this.#isValidIdentifier(sourceNode.getText())) {
+      const text = "Component names must begin with an uppercase letter.";
       const origin = DiagnosticOrigin.fromNode(sourceNode);
 
       diagnostics.push(Diagnostic.error(text, origin));

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -10,7 +10,7 @@ export class ToAcceptProps extends AbilityMatcherBase {
   explainNotText = ExpectDiagnosticText.doesNotAcceptProps;
 
   #isValidIdentifier(target: string) {
-    return /^[A-Z_$]/.test(target[0]);
+    return /^[A-Z_$]/.test(target[0]!);
   }
 
   match(

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -9,10 +9,6 @@ export class ToAcceptProps extends AbilityMatcherBase {
   explainText = ExpectDiagnosticText.acceptsProps;
   explainNotText = ExpectDiagnosticText.doesNotAcceptProps;
 
-  #isValidIdentifier(target: string) {
-    return /^[A-Z_$]/.test(target[0]!);
-  }
-
   match(
     matchWorker: MatchWorker,
     sourceNode: ArgumentNode,
@@ -21,11 +17,18 @@ export class ToAcceptProps extends AbilityMatcherBase {
   ): MatchResult | undefined {
     const diagnostics: Array<Diagnostic> = [];
 
-    const signatures = matchWorker.getSignatures(sourceNode);
+    const sourceType = matchWorker.getType(sourceNode);
 
-    if (signatures.length === 0) {
-      const expectedText = "of a function or class type";
-
+    if (
+      !(
+        this.compiler.isIdentifier(sourceNode) ||
+        this.compiler.isPropertyAccessExpression(sourceNode) ||
+        this.compiler.isTypeReferenceNode(sourceNode) ||
+        this.compiler.isExpressionWithTypeArguments(sourceNode)
+      ) ||
+      !(sourceType.getCallSignatures().length > 0 || sourceType.getConstructSignatures().length > 0)
+    ) {
+      const expectedText = "an identifier of a JSX component";
       const text = nodeBelongsToArgumentList(this.compiler, sourceNode)
         ? ExpectDiagnosticText.argumentMustBe(expectedText)
         : ExpectDiagnosticText.typeArgumentMustBe(expectedText);
@@ -33,8 +36,12 @@ export class ToAcceptProps extends AbilityMatcherBase {
       const origin = DiagnosticOrigin.fromNode(sourceNode);
 
       diagnostics.push(Diagnostic.error(text, origin));
-    } else if (nodeBelongsToArgumentList(this.compiler, sourceNode) && !this.#isValidIdentifier(sourceNode.getText())) {
-      const text = "Component names must begin with an uppercase letter.";
+    } else if (!/^[A-Z_$]/.test(sourceNode.getText()[0]!)) {
+      const expectedText = "an identifier that begins with an uppercase letter";
+      const text = nodeBelongsToArgumentList(this.compiler, sourceNode)
+        ? ExpectDiagnosticText.argumentMustBe(expectedText)
+        : ExpectDiagnosticText.typeArgumentMustBe(expectedText);
+
       const origin = DiagnosticOrigin.fromNode(sourceNode);
 
       diagnostics.push(Diagnostic.error(text, origin));

--- a/source/expect/ToAcceptProps.ts
+++ b/source/expect/ToAcceptProps.ts
@@ -10,7 +10,7 @@ export class ToAcceptProps extends AbilityMatcherBase {
   explainNotText = ExpectDiagnosticText.doesNotAcceptProps;
 
   #isValidIdentifier(target: string) {
-    return target[0] === target[0]!.toUpperCase() && /^[A-Z_$]/.test(target[0]);
+    return /^[A-Z_$]/.test(target[0]);
   }
 
   match(

--- a/source/layers/AbilityLayer.ts
+++ b/source/layers/AbilityLayer.ts
@@ -57,6 +57,13 @@ export class AbilityLayer {
         if (
           !sourceNode ||
           !targetNode ||
+          !(
+            this.#compiler.isIdentifier(sourceNode) ||
+            this.#compiler.isPropertyAccessExpression(sourceNode) ||
+            this.#compiler.isTypeReferenceNode(sourceNode) ||
+            this.#compiler.isExpressionWithTypeArguments(sourceNode)
+          ) ||
+          !/^[A-Z_$]/.test(sourceNode.getText()[0]!) ||
           !this.#compiler.isObjectLiteralExpression(targetNode) ||
           !targetNode.properties.every(
             (property) =>

--- a/tests/__fixtures__/validation-toAcceptProps/__typetests__/toAcceptProps.tst.tsx
+++ b/tests/__fixtures__/validation-toAcceptProps/__typetests__/toAcceptProps.tst.tsx
@@ -1,54 +1,86 @@
 import { describe, expect, test } from "tstyche";
 
-const $dummy = () => "test";
-const Dummy = () => "test";
-const _dummy = () => "test";
-const dummy = () => "test";
+const Component = () => "test";
+
+namespace Namespace {
+  export const Component = () => "test";
+}
 
 describe("argument for 'source'", () => {
+  const $component = () => "test";
+  const _component = () => "test";
+  const component = () => "test";
+
+  function GenericComponent<T>({ a, b }: { a: T; b: T }) {
+    return "test";
+  }
+
   test("must be provided", () => {
     expect().type.toAcceptProps({ test: false });
   });
 
-  test("must be of a function or class type", () => {
+  test("must be an identifier of a JSX component", () => {
     expect({ a: "sample" }).type.toAcceptProps({ test: false });
+    expect(() => {}).type.toAcceptProps({ test: false });
   });
 
-  test("must begin with an uppercase letter", () => {
-    expect(dummy).type.toAcceptProps({});
+  test("must an identifier that begins with an uppercase letter", () => {
+    expect(component).type.toAcceptProps({});
   });
 
-  test("allowed names", () => {
-    expect(Dummy).type.toAcceptProps({});
-    expect($dummy).type.toAcceptProps({});
-    expect(_dummy).type.toAcceptProps({});
+  test("allowed expressions", () => {
+    expect(Component).type.toAcceptProps({});
+    expect(Namespace.Component).type.toAcceptProps({});
+    expect(GenericComponent).type.not.toAcceptProps({});
+    expect(GenericComponent<string>).type.not.toAcceptProps({});
+    expect($component).type.toAcceptProps({});
+    expect(_component).type.toAcceptProps({});
   });
 });
 
 describe("type argument for 'source'", () => {
-  test("must be of a function or class type", () => {
+  type Component = () => React.JSX.Element;
+  // biome-ignore lint/style/useNamingConvention: test
+  type $component = () => React.JSX.Element;
+  // biome-ignore lint/style/useNamingConvention: test
+  type _component = () => React.JSX.Element;
+  // biome-ignore lint/style/useNamingConvention: test
+  type component = () => React.JSX.Element;
+
+  test("must be an identifier of a JSX component", () => {
     expect<{ a: string }>().type.not.toAcceptProps({});
+    expect<() => string>().type.not.toAcceptProps({});
+  });
+
+  test("must an identifier that begins with an uppercase letter", () => {
+    expect<component>().type.toAcceptProps({});
+  });
+
+  test("allowed types", () => {
+    expect<Component>().type.toAcceptProps({});
+    expect<$component>().type.toAcceptProps({});
+    expect<_component>().type.toAcceptProps({});
   });
 });
 
 describe("argument for 'target'", () => {
   test("must be provided", () => {
     // @ts-expect-error!
-    expect(Dummy).type.toAcceptProps();
+    expect(Component).type.toAcceptProps();
   });
 
   test("must be an object literal", () => {
     // @ts-expect-error!
-    expect(Dummy).type.toAcceptProps("nope");
+    expect(Component).type.toAcceptProps("nope");
   });
 
   test("must only contain key-value pairs", () => {
     const b = "no";
     const c = { c: true };
-    expect(Dummy).type.toAcceptProps({ a: "yes", b, ...c });
+    expect(Component).type.toAcceptProps({ a: "yes", b, ...c });
   });
 
   test("property keys must be static identifiers or string literals", () => {
-    expect(Dummy).type.toAcceptProps({ ["a"]: "nope" });
+    expect(Component).type.toAcceptProps({ ["a"]: "nope" });
   });
 });

--- a/tests/__fixtures__/validation-toAcceptProps/__typetests__/toAcceptProps.tst.tsx
+++ b/tests/__fixtures__/validation-toAcceptProps/__typetests__/toAcceptProps.tst.tsx
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "tstyche";
 
+const $dummy = () => "test";
+const Dummy = () => "test";
+const _dummy = () => "test";
+const dummy = () => "test";
+
 describe("argument for 'source'", () => {
   test("must be provided", () => {
     expect().type.toAcceptProps({ test: false });
@@ -7,6 +12,16 @@ describe("argument for 'source'", () => {
 
   test("must be of a function or class type", () => {
     expect({ a: "sample" }).type.toAcceptProps({ test: false });
+  });
+
+  test("must begin with an uppercase letter", () => {
+    expect(dummy).type.toAcceptProps({});
+  });
+
+  test("allowed names", () => {
+    expect(Dummy).type.toAcceptProps({});
+    expect($dummy).type.toAcceptProps({});
+    expect(_dummy).type.toAcceptProps({});
   });
 });
 
@@ -19,21 +34,21 @@ describe("type argument for 'source'", () => {
 describe("argument for 'target'", () => {
   test("must be provided", () => {
     // @ts-expect-error!
-    expect(() => <>{"test"}</>).type.toAcceptProps();
+    expect(Dummy).type.toAcceptProps();
   });
 
   test("must be an object literal", () => {
     // @ts-expect-error!
-    expect(() => <>{"test"}</>).type.toAcceptProps("nope");
+    expect(Dummy).type.toAcceptProps("nope");
   });
 
   test("must only contain key-value pairs", () => {
     const b = "no";
     const c = { c: true };
-    expect(() => <>{"test"}</>).type.toAcceptProps({ a: "yes", b, ...c });
+    expect(Dummy).type.toAcceptProps({ a: "yes", b, ...c });
   });
 
   test("property keys must be static identifiers or string literals", () => {
-    expect(() => <>{"test"}</>).type.toAcceptProps({ ["a"]: "nope" });
+    expect(Dummy).type.toAcceptProps({ ["a"]: "nope" });
   });
 });

--- a/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
@@ -1,96 +1,132 @@
 Error: An argument or type argument must be provided.
 
-   8 | describe("argument for 'source'", () => {
-   9 |   test("must be provided", () => {
-  10 |     expect().type.toAcceptProps({ test: false });
+  17 | 
+  18 |   test("must be provided", () => {
+  19 |     expect().type.toAcceptProps({ test: false });
      |     ~~~~~~
-  11 |   });
-  12 | 
-  13 |   test("must be of a function or class type", () => {
+  20 |   });
+  21 | 
+  22 |   test("must be an identifier of a JSX component", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:10:5
+       at ./__typetests__/toAcceptProps.tst.tsx:19:5
 
-Error: The argument must be of a function or class type.
+Error: The argument must be an identifier of a JSX component.
 
-  12 | 
-  13 |   test("must be of a function or class type", () => {
-  14 |     expect({ a: "sample" }).type.toAcceptProps({ test: false });
+  21 | 
+  22 |   test("must be an identifier of a JSX component", () => {
+  23 |     expect({ a: "sample" }).type.toAcceptProps({ test: false });
      |            ~~~~~~~~~~~~~~~
-  15 |   });
-  16 | 
-  17 |   test("must begin with an uppercase letter", () => {
+  24 |     expect(() => {}).type.toAcceptProps({ test: false });
+  25 |   });
+  26 | 
 
-       at ./__typetests__/toAcceptProps.tst.tsx:14:12
+       at ./__typetests__/toAcceptProps.tst.tsx:23:12
 
-Error: Component names must begin with an uppercase letter.
+Error: The argument must be an identifier of a JSX component.
 
-  16 | 
-  17 |   test("must begin with an uppercase letter", () => {
-  18 |     expect(dummy).type.toAcceptProps({});
-     |            ~~~~~
-  19 |   });
-  20 | 
-  21 |   test("allowed names", () => {
+  22 |   test("must be an identifier of a JSX component", () => {
+  23 |     expect({ a: "sample" }).type.toAcceptProps({ test: false });
+  24 |     expect(() => {}).type.toAcceptProps({ test: false });
+     |            ~~~~~~~~
+  25 |   });
+  26 | 
+  27 |   test("must an identifier that begins with an uppercase letter", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:18:12
+       at ./__typetests__/toAcceptProps.tst.tsx:24:12
 
-Error: The type argument must be of a function or class type.
+Error: The argument must be an identifier that begins with an uppercase letter.
 
-  28 | describe("type argument for 'source'", () => {
-  29 |   test("must be of a function or class type", () => {
-  30 |     expect<{ a: string }>().type.not.toAcceptProps({});
+  26 | 
+  27 |   test("must an identifier that begins with an uppercase letter", () => {
+  28 |     expect(component).type.toAcceptProps({});
+     |            ~~~~~~~~~
+  29 |   });
+  30 | 
+  31 |   test("allowed expressions", () => {
+
+       at ./__typetests__/toAcceptProps.tst.tsx:28:12
+
+Error: The type argument must be an identifier of a JSX component.
+
+  49 | 
+  50 |   test("must be an identifier of a JSX component", () => {
+  51 |     expect<{ a: string }>().type.not.toAcceptProps({});
      |            ~~~~~~~~~~~~~
-  31 |   });
-  32 | });
-  33 | 
+  52 |     expect<() => string>().type.not.toAcceptProps({});
+  53 |   });
+  54 | 
 
-       at ./__typetests__/toAcceptProps.tst.tsx:30:12
+       at ./__typetests__/toAcceptProps.tst.tsx:51:12
+
+Error: The type argument must be an identifier of a JSX component.
+
+  50 |   test("must be an identifier of a JSX component", () => {
+  51 |     expect<{ a: string }>().type.not.toAcceptProps({});
+  52 |     expect<() => string>().type.not.toAcceptProps({});
+     |            ~~~~~~~~~~~~
+  53 |   });
+  54 | 
+  55 |   test("must an identifier that begins with an uppercase letter", () => {
+
+       at ./__typetests__/toAcceptProps.tst.tsx:52:12
+
+Error: The type argument must be an identifier that begins with an uppercase letter.
+
+  54 | 
+  55 |   test("must an identifier that begins with an uppercase letter", () => {
+  56 |     expect<component>().type.toAcceptProps({});
+     |            ~~~~~~~~~
+  57 |   });
+  58 | 
+  59 |   test("allowed types", () => {
+
+       at ./__typetests__/toAcceptProps.tst.tsx:56:12
 
 Error: An argument or type argument must be provided.
 
-  35 |   test("must be provided", () => {
-  36 |     // @ts-expect-error!
-  37 |     expect(Dummy).type.toAcceptProps();
-     |                        ~~~~~~~~~~~~~
-  38 |   });
-  39 | 
-  40 |   test("must be an object literal", () => {
+  67 |   test("must be provided", () => {
+  68 |     // @ts-expect-error!
+  69 |     expect(Component).type.toAcceptProps();
+     |                            ~~~~~~~~~~~~~
+  70 |   });
+  71 | 
+  72 |   test("must be an object literal", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:37:24
+       at ./__typetests__/toAcceptProps.tst.tsx:69:28
 
 Error: The argument must be an object literal with key-value pairs.
 
-  40 |   test("must be an object literal", () => {
-  41 |     // @ts-expect-error!
-  42 |     expect(Dummy).type.toAcceptProps("nope");
-     |                                      ~~~~~~
-  43 |   });
-  44 | 
-  45 |   test("must only contain key-value pairs", () => {
+  72 |   test("must be an object literal", () => {
+  73 |     // @ts-expect-error!
+  74 |     expect(Component).type.toAcceptProps("nope");
+     |                                          ~~~~~~
+  75 |   });
+  76 | 
+  77 |   test("must only contain key-value pairs", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:42:38
+       at ./__typetests__/toAcceptProps.tst.tsx:74:42
 
 Error: Each property must be a key-value pair or a spread element.
 
-  46 |     const b = "no";
-  47 |     const c = { c: true };
-  48 |     expect(Dummy).type.toAcceptProps({ a: "yes", b, ...c });
-     |                                                  ~
-  49 |   });
-  50 | 
-  51 |   test("property keys must be static identifiers or string literals", () => {
+  78 |     const b = "no";
+  79 |     const c = { c: true };
+  80 |     expect(Component).type.toAcceptProps({ a: "yes", b, ...c });
+     |                                                      ~
+  81 |   });
+  82 | 
+  83 |   test("property keys must be static identifiers or string literals", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:48:50
+       at ./__typetests__/toAcceptProps.tst.tsx:80:54
 
 Error: Property keys must be static identifiers or string literals.
 
-  50 | 
-  51 |   test("property keys must be static identifiers or string literals", () => {
-  52 |     expect(Dummy).type.toAcceptProps({ ["a"]: "nope" });
-     |                                        ~~~~~
-  53 |   });
-  54 | });
-  55 | 
+  82 | 
+  83 |   test("property keys must be static identifiers or string literals", () => {
+  84 |     expect(Component).type.toAcceptProps({ ["a"]: "nope" });
+     |                                            ~~~~~
+  85 |   });
+  86 | });
+  87 | 
 
-       at ./__typetests__/toAcceptProps.tst.tsx:52:40
+       at ./__typetests__/toAcceptProps.tst.tsx:84:44
 

--- a/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stderr.snap.txt
@@ -1,84 +1,96 @@
 Error: An argument or type argument must be provided.
 
-  3 | describe("argument for 'source'", () => {
-  4 |   test("must be provided", () => {
-  5 |     expect().type.toAcceptProps({ test: false });
-    |     ~~~~~~
-  6 |   });
-  7 | 
-  8 |   test("must be of a function or class type", () => {
+   8 | describe("argument for 'source'", () => {
+   9 |   test("must be provided", () => {
+  10 |     expect().type.toAcceptProps({ test: false });
+     |     ~~~~~~
+  11 |   });
+  12 | 
+  13 |   test("must be of a function or class type", () => {
 
-      at ./__typetests__/toAcceptProps.tst.tsx:5:5
+       at ./__typetests__/toAcceptProps.tst.tsx:10:5
 
 Error: The argument must be of a function or class type.
 
-   7 | 
-   8 |   test("must be of a function or class type", () => {
-   9 |     expect({ a: "sample" }).type.toAcceptProps({ test: false });
-     |            ~~~~~~~~~~~~~~~
-  10 |   });
-  11 | });
   12 | 
+  13 |   test("must be of a function or class type", () => {
+  14 |     expect({ a: "sample" }).type.toAcceptProps({ test: false });
+     |            ~~~~~~~~~~~~~~~
+  15 |   });
+  16 | 
+  17 |   test("must begin with an uppercase letter", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:9:12
+       at ./__typetests__/toAcceptProps.tst.tsx:14:12
+
+Error: Component names must begin with an uppercase letter.
+
+  16 | 
+  17 |   test("must begin with an uppercase letter", () => {
+  18 |     expect(dummy).type.toAcceptProps({});
+     |            ~~~~~
+  19 |   });
+  20 | 
+  21 |   test("allowed names", () => {
+
+       at ./__typetests__/toAcceptProps.tst.tsx:18:12
 
 Error: The type argument must be of a function or class type.
 
-  13 | describe("type argument for 'source'", () => {
-  14 |   test("must be of a function or class type", () => {
-  15 |     expect<{ a: string }>().type.not.toAcceptProps({});
+  28 | describe("type argument for 'source'", () => {
+  29 |   test("must be of a function or class type", () => {
+  30 |     expect<{ a: string }>().type.not.toAcceptProps({});
      |            ~~~~~~~~~~~~~
-  16 |   });
-  17 | });
-  18 | 
+  31 |   });
+  32 | });
+  33 | 
 
-       at ./__typetests__/toAcceptProps.tst.tsx:15:12
+       at ./__typetests__/toAcceptProps.tst.tsx:30:12
 
 Error: An argument or type argument must be provided.
 
-  20 |   test("must be provided", () => {
-  21 |     // @ts-expect-error!
-  22 |     expect(() => <>{"test"}</>).type.toAcceptProps();
-     |                                      ~~~~~~~~~~~~~
-  23 |   });
-  24 | 
-  25 |   test("must be an object literal", () => {
+  35 |   test("must be provided", () => {
+  36 |     // @ts-expect-error!
+  37 |     expect(Dummy).type.toAcceptProps();
+     |                        ~~~~~~~~~~~~~
+  38 |   });
+  39 | 
+  40 |   test("must be an object literal", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:22:38
+       at ./__typetests__/toAcceptProps.tst.tsx:37:24
 
 Error: The argument must be an object literal with key-value pairs.
 
-  25 |   test("must be an object literal", () => {
-  26 |     // @ts-expect-error!
-  27 |     expect(() => <>{"test"}</>).type.toAcceptProps("nope");
-     |                                                    ~~~~~~
-  28 |   });
-  29 | 
-  30 |   test("must only contain key-value pairs", () => {
+  40 |   test("must be an object literal", () => {
+  41 |     // @ts-expect-error!
+  42 |     expect(Dummy).type.toAcceptProps("nope");
+     |                                      ~~~~~~
+  43 |   });
+  44 | 
+  45 |   test("must only contain key-value pairs", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:27:52
+       at ./__typetests__/toAcceptProps.tst.tsx:42:38
 
 Error: Each property must be a key-value pair or a spread element.
 
-  31 |     const b = "no";
-  32 |     const c = { c: true };
-  33 |     expect(() => <>{"test"}</>).type.toAcceptProps({ a: "yes", b, ...c });
-     |                                                                ~
-  34 |   });
-  35 | 
-  36 |   test("property keys must be static identifiers or string literals", () => {
+  46 |     const b = "no";
+  47 |     const c = { c: true };
+  48 |     expect(Dummy).type.toAcceptProps({ a: "yes", b, ...c });
+     |                                                  ~
+  49 |   });
+  50 | 
+  51 |   test("property keys must be static identifiers or string literals", () => {
 
-       at ./__typetests__/toAcceptProps.tst.tsx:33:64
+       at ./__typetests__/toAcceptProps.tst.tsx:48:50
 
 Error: Property keys must be static identifiers or string literals.
 
-  35 | 
-  36 |   test("property keys must be static identifiers or string literals", () => {
-  37 |     expect(() => <>{"test"}</>).type.toAcceptProps({ ["a"]: "nope" });
-     |                                                      ~~~~~
-  38 |   });
-  39 | });
-  40 | 
+  50 | 
+  51 |   test("property keys must be static identifiers or string literals", () => {
+  52 |     expect(Dummy).type.toAcceptProps({ ["a"]: "nope" });
+     |                                        ~~~~~
+  53 |   });
+  54 | });
+  55 | 
 
-       at ./__typetests__/toAcceptProps.tst.tsx:37:54
+       at ./__typetests__/toAcceptProps.tst.tsx:52:40
 

--- a/tests/__snapshots__/validation-toAcceptProps-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stdout.snap.txt
@@ -6,6 +6,8 @@ fail ./__typetests__/toAcceptProps.tst.tsx
   argument for 'source'
     × must be provided
     × must be of a function or class type
+    × must begin with an uppercase letter
+    + allowed names
   type argument for 'source'
     × must be of a function or class type
   argument for 'target'
@@ -16,7 +18,7 @@ fail ./__typetests__/toAcceptProps.tst.tsx
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      7 failed, 7 total
-Assertions: 7 failed, 7 total
+Tests:      8 failed, 1 passed, 9 total
+Assertions: 8 failed, 3 passed, 11 total
 Suppressed: 2 ignored, 2 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/validation-toAcceptProps-stdout.snap.txt
+++ b/tests/__snapshots__/validation-toAcceptProps-stdout.snap.txt
@@ -5,11 +5,13 @@ uses TypeScript <<version>> with ./tsconfig.json
 fail ./__typetests__/toAcceptProps.tst.tsx
   argument for 'source'
     × must be provided
-    × must be of a function or class type
-    × must begin with an uppercase letter
-    + allowed names
+    × must be an identifier of a JSX component
+    × must an identifier that begins with an uppercase letter
+    + allowed expressions
   type argument for 'source'
-    × must be of a function or class type
+    × must be an identifier of a JSX component
+    × must an identifier that begins with an uppercase letter
+    + allowed types
   argument for 'target'
     × must be provided
     × must be an object literal
@@ -18,7 +20,7 @@ fail ./__typetests__/toAcceptProps.tst.tsx
 
 Targets:    1 failed, 1 total
 Test files: 1 failed, 1 total
-Tests:      8 failed, 1 passed, 9 total
-Assertions: 8 failed, 3 passed, 11 total
+Tests:      9 failed, 2 passed, 11 total
+Assertions: 11 failed, 9 passed, 20 total
 Suppressed: 2 ignored, 2 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
This PR improves validation of arguments passed to the `.toAcceptProps()` matcher.

The argument must be a JSX component identifier that begins with a capital letter and has call or construct signatures. 