### PR TITLE
refactor!: remove `TSTYCHE_TIMEOUT` environment variable

### DIFF
--- a/source/environment/Environment.ts
+++ b/source/environment/Environment.ts
@@ -30,11 +30,6 @@ export class Environment {
       return Number.parseFloat(process.env["TSTYCHE_FETCH_TIMEOUT"]);
     }
 
-    // TODO remove in TSTyche 8
-    if (process.env["TSTYCHE_TIMEOUT"] != null) {
-      return Number.parseFloat(process.env["TSTYCHE_TIMEOUT"]);
-    }
-
     return 30;
   }
 

--- a/tests/config-fetchTimeout.test.js
+++ b/tests/config-fetchTimeout.test.js
@@ -47,30 +47,3 @@ await test("'TSTYCHE_FETCH_TIMEOUT' environment variable", async (t) => {
     assert.equal(exitCode, 1);
   });
 });
-
-await test("'TSTYCHE_TIMEOUT' environment variable", async (t) => {
-  t.afterEach(async () => {
-    await clearFixture(fixtureUrl);
-  });
-
-  await t.test("when timeout is specified", async () => {
-    await writeFixture(fixtureUrl);
-
-    const { exitCode, stderr } = await spawnTyche(fixtureUrl, ["--target", "5.8"], {
-      env: {
-        ["TSTYCHE_TIMEOUT"]: "0.001",
-      },
-    });
-
-    const expected = [
-      "Error: Failed to fetch metadata of the 'typescript' package from 'https://registry.npmjs.org'.",
-      "",
-      "The request timeout of 0.001s was exceeded.",
-      "",
-      "",
-    ].join("\n");
-
-    assert.equal(stderr, expected);
-    assert.equal(exitCode, 1);
-  });
-});


### PR DESCRIPTION
Close #765

This PR removes `TSTYCHE_TIMEOUT` environment variable in favour of ` TSTYCHE_FETCH_TIMEOUT`.
