### PR TITLE
refactor: replace `TSTYCHE_TYPESCRIPT_MODULE` with `TSTYCHE_TYPESCRIPT_SPECIFIER`

### DIFF
--- a/source/environment/Environment.ts
+++ b/source/environment/Environment.ts
@@ -13,7 +13,7 @@ export class Environment {
       noInteractive: Environment.#resolveNoInteractive(),
       npmRegistry: Environment.#resolveNpmRegistry(),
       storePath: Environment.#resolveStorePath(),
-      typescriptModule: Environment.#resolveTypeScriptModule(),
+      typescriptSpecifier: Environment.#resolveTypeScriptSpecifier(),
     };
   }
 
@@ -89,21 +89,23 @@ export class Environment {
     return Path.resolve(os.homedir(), ".local", "share", "TSTyche");
   }
 
-  static #resolveTypeScriptModule() {
+  static #resolveTypeScriptSpecifier() {
     let specifier = "typescript";
 
-    if (process.env["TSTYCHE_TYPESCRIPT_MODULE"] != null) {
-      specifier = process.env["TSTYCHE_TYPESCRIPT_MODULE"];
+    if (process.env["TSTYCHE_TYPESCRIPT_SPECIFIER"] != null) {
+      specifier = process.env["TSTYCHE_TYPESCRIPT_SPECIFIER"];
     }
 
-    let resolvedModule: string | undefined;
+    let resolvedSpecifier: string | undefined;
 
     try {
-      resolvedModule = import.meta.resolve(specifier);
+      if (specifier) {
+        resolvedSpecifier = import.meta.resolve(`${specifier}/package.json`).replace(/package\.json$/, "");
+      }
     } catch {
       // module was not found
     }
 
-    return resolvedModule;
+    return resolvedSpecifier;
   }
 }

--- a/source/environment/Environment.ts
+++ b/source/environment/Environment.ts
@@ -90,22 +90,26 @@ export class Environment {
   }
 
   static #resolveTypeScriptSpecifier() {
-    let specifier = "typescript";
+    function resolve(specifier: string) {
+      return import.meta.resolve(`${specifier}/package.json`).replace(/package\.json$/, "");
+    }
 
     if (process.env["TSTYCHE_TYPESCRIPT_SPECIFIER"] != null) {
-      specifier = process.env["TSTYCHE_TYPESCRIPT_SPECIFIER"];
-    }
+      const specifier = process.env["TSTYCHE_TYPESCRIPT_SPECIFIER"];
 
-    let resolvedSpecifier: string | undefined;
+      if (specifier !== "") {
+        return resolve(specifier);
+      }
+
+      return;
+    }
 
     try {
-      if (specifier) {
-        resolvedSpecifier = import.meta.resolve(`${specifier}/package.json`).replace(/package\.json$/, "");
-      }
+      return resolve("typescript");
     } catch {
-      // module was not found
+      // 'typescript' is not installed
     }
 
-    return resolvedSpecifier;
+    return;
   }
 }

--- a/source/environment/types.ts
+++ b/source/environment/types.ts
@@ -6,5 +6,5 @@ export interface EnvironmentOptions {
   noInteractive: boolean;
   npmRegistry: string;
   storePath: string;
-  typescriptModule: string | undefined;
+  typescriptSpecifier: string | undefined;
 }

--- a/source/store/Store.ts
+++ b/source/store/Store.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import type ts from "typescript";
 import { Diagnostic } from "#diagnostic";
@@ -45,7 +46,7 @@ export class Store {
   }
 
   static async fetch(tag: string): Promise<void> {
-    if (tag === "*" && environmentOptions.typescriptModule != null) {
+    if (tag === "*" && environmentOptions.typescriptSpecifier != null) {
       return;
     }
 
@@ -53,20 +54,23 @@ export class Store {
   }
 
   static async load(tag: string): Promise<typeof ts | undefined> {
-    let resolvedModule: string | undefined;
+    let specifier: string | undefined;
 
-    if (tag === "*" && environmentOptions.typescriptModule != null) {
-      resolvedModule = environmentOptions.typescriptModule;
+    if (tag === "*" && environmentOptions.typescriptSpecifier != null) {
+      specifier = environmentOptions.typescriptSpecifier;
     } else {
       const packagePath = await Store.#ensure(tag);
 
       if (packagePath != null) {
-        resolvedModule = pathToFileURL(`${packagePath}/lib/typescript.js`).toString();
+        specifier = pathToFileURL(`${packagePath}/`).toString();
       }
     }
 
-    if (resolvedModule != null) {
-      return (await import(resolvedModule)).default;
+    if (specifier != null) {
+      const packageJsonText = await fs.readFile(new URL("package.json", specifier), { encoding: "utf8" });
+      const packageJson = JSON.parse(packageJsonText) as { main: string; version: string };
+
+      return (await import(new URL(packageJson.main, specifier).toString())).default;
     }
 
     return;

--- a/tests/config-target.test.js
+++ b/tests/config-target.test.js
@@ -149,7 +149,7 @@ await test("'--target' command line option", async (t) => {
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, ["--target", '"*"'], {
-      env: { ["TSTYCHE_TYPESCRIPT_MODULE"]: "" },
+      env: { ["TSTYCHE_TYPESCRIPT_SPECIFIER"]: "" },
     });
 
     assert.equal(stderr, "");
@@ -383,7 +383,7 @@ await test("'target' configuration file option", async (t) => {
     });
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
-      env: { ["TSTYCHE_TYPESCRIPT_MODULE"]: "" },
+      env: { ["TSTYCHE_TYPESCRIPT_SPECIFIER"]: "" },
     });
 
     assert.equal(stderr, "");

--- a/tests/config-typescriptSpecifier.test.js
+++ b/tests/config-typescriptSpecifier.test.js
@@ -13,7 +13,7 @@ test("is string?", () => {
 const testFileName = getTestFileName(import.meta.url);
 const fixtureUrl = getFixtureFileUrl(testFileName, { generated: true });
 
-await test("'TSTYCHE_TYPESCRIPT_MODULE' environment variable", async (t) => {
+await test("'TSTYCHE_TYPESCRIPT_SPECIFIER' environment variable", async (t) => {
   t.afterEach(async () => {
     await clearFixture(fixtureUrl);
   });
@@ -26,7 +26,7 @@ await test("'TSTYCHE_TYPESCRIPT_MODULE' environment variable", async (t) => {
     assert.equal(stderr, "");
 
     assert.matchObject(normalizeOutput(stdout), {
-      typescriptModule: /node_modules\/typescript\/lib\/typescript\.js$/,
+      typescriptSpecifier: /node_modules\/typescript\/$/,
     });
 
     assert.equal(exitCode, 0);
@@ -39,11 +39,11 @@ await test("'TSTYCHE_TYPESCRIPT_MODULE' environment variable", async (t) => {
 
     await spawnTyche(fixtureUrl, ["--fetch", "--target", "5.8.2"]);
 
-    const typescriptModule = new URL("./.store/typescript@5.8.2/lib/typescript.js", fixtureUrl).toString();
+    const typescriptSpecifier = new URL("./.store/typescript@5.8.2", fixtureUrl).toString();
 
     const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
       env: {
-        ["TSTYCHE_TYPESCRIPT_MODULE"]: typescriptModule,
+        ["TSTYCHE_TYPESCRIPT_SPECIFIER"]: typescriptSpecifier,
       },
     });
 

--- a/tests/feature-typescript-versions.test.js
+++ b/tests/feature-typescript-versions.test.js
@@ -34,10 +34,10 @@ await test("TypeScript versions", async (t) => {
     await t.test(`uses TypeScript ${version} as the target`, async () => {
       await spawnTyche(fixtureUrl, ["--fetch", "--target", version]);
 
-      const typescriptModule = new URL(`./typescript@${version}/lib/typescript.js`, storeUrl).toString();
+      const typescriptSpecifier = new URL(`./typescript@${version}`, storeUrl).toString();
 
       const { exitCode, stderr, stdout } = await spawnTyche(fixtureUrl, [], {
-        env: { ["TSTYCHE_TYPESCRIPT_MODULE"]: typescriptModule },
+        env: { ["TSTYCHE_TYPESCRIPT_SPECIFIER"]: typescriptSpecifier },
       });
 
       assert.equal(stderr, "");


### PR DESCRIPTION
Close #764

This PR replaces `TSTYCHE_TYPESCRIPT_MODULE` environment variable with `TSTYCHE_TYPESCRIPT_SPECIFIER`.

The value passed to `TSTYCHE_TYPESCRIPT_SPECIFIER` must be a module specifier like `typescript` (default), `@typescript/typescript6`, or a file URL that points to a directory containing a TypeScript package: `"file:///path/to/typescript"`.