### PR TITLE
fix: use TypeScript v6 when v7 is installed

### DIFF
--- a/source/environment/Environment.ts
+++ b/source/environment/Environment.ts
@@ -95,18 +95,22 @@ export class Environment {
   }
 
   static #resolveTypeScriptModule() {
-    let specifier = "typescript";
-
     if (process.env["TSTYCHE_TYPESCRIPT_MODULE"] != null) {
-      specifier = process.env["TSTYCHE_TYPESCRIPT_MODULE"];
+      const specifier = process.env["TSTYCHE_TYPESCRIPT_MODULE"];
+
+      if (specifier !== "") {
+        return import.meta.resolve(specifier);
+      }
+
+      return;
     }
 
     let resolvedModule: string | undefined;
 
     try {
-      resolvedModule = import.meta.resolve(specifier);
+      resolvedModule = import.meta.resolve("typescript");
     } catch {
-      // module was not found
+      // 'typescript' is not installed
     }
 
     return resolvedModule?.endsWith("lib/typescript.js") ? resolvedModule : undefined;

--- a/source/environment/Environment.ts
+++ b/source/environment/Environment.ts
@@ -109,6 +109,6 @@ export class Environment {
       // module was not found
     }
 
-    return resolvedModule;
+    return resolvedModule?.endsWith("lib/typescript.js") ? resolvedModule : undefined;
   }
 }


### PR DESCRIPTION
This change makes sure TSTyche will fall back to TypeScript v6 when v7 is the installed version.