### PR TITLE
fix(structure): handle reduced types

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -3,6 +3,7 @@ import { ComparisonResult } from "./ComparisonResult.enum.js";
 import {
   containsInstantiable,
   getIndexSignatures,
+  getReducedType,
   getSignatures,
   getTargetSymbol,
   getThisTypeOfSignature,
@@ -562,6 +563,8 @@ export class Structure {
   }
 
   #normalize(type: ts.Type): ts.Type {
+    type = getReducedType(type, this.#typeChecker);
+
     if (type.flags & this.#compiler.TypeFlags.Freshable && (type as ts.FreshableType).freshType === type) {
       return (type as ts.FreshableType).regularType;
     }

--- a/source/structure/helpers.ts
+++ b/source/structure/helpers.ts
@@ -19,6 +19,17 @@ export function getIndexSignatures(
   return typeChecker.getIndexInfosOfType(type);
 }
 
+export function getReducedType(type: ts.Type, typeChecker: ts.TypeChecker): ts.Type {
+  // ensures 'resolvedReducedType' is computed
+  typeChecker.typeToString(type);
+
+  if ("resolvedReducedType" in type) {
+    return type.resolvedReducedType as ts.Type;
+  }
+
+  return type;
+}
+
 export function getSignatures(
   type: ts.Type,
   kind: ts.SignatureKind,

--- a/tests/__fixtures__/api-toBe/__typetests__/intersections.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/intersections.tst.ts
@@ -173,3 +173,20 @@ test("string mapping", () => {
   expect<D>().type.not.toBe<E>();
   expect<E>().type.not.toBe<F>();
 });
+
+test("collapsing discriminant", () => {
+  interface TaggedError<Tag extends string> {
+    readonly _tag: Tag;
+  }
+
+  interface RateLimitError extends TaggedError<"RateLimitError"> {
+    readonly retryAfter: number;
+  }
+
+  interface QuotaExceededError extends TaggedError<"QuotaExceededError"> {
+    readonly limit: number;
+  }
+
+  expect<RateLimitError | (RateLimitError & QuotaExceededError)>().type.toBe<RateLimitError>();
+  expect<RateLimitError | (RateLimitError & QuotaExceededError)>().type.not.toBe<QuotaExceededError>();
+});

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -21,6 +21,6 @@ pass ./__typetests__/unions.tst.ts
 
 Targets:    1 passed, 1 total
 Test files: 16 passed, 16 total
-Tests:      101 passed, 101 total
-Assertions: 703 passed, 1 fixme, 704 total
+Tests:      102 passed, 102 total
+Assertions: 705 passed, 1 fixme, 706 total
 Duration:   <<timestamp>>


### PR DESCRIPTION
This PR adds handling of reduced types.

The implementation is dirty. I want to include this workaround for older TypeScript versions because TypeScript 7 has got `.getReducedType()` method added: https://github.com/microsoft/TypeScript/issues/63894