### PR TITLE
fix: prevent infinite recursion when comparing self-referential generic types

### DIFF
--- a/source/structure/Structure.ts
+++ b/source/structure/Structure.ts
@@ -19,6 +19,7 @@ export class Structure {
 
   #deduplicateCache = new WeakMap<ts.Type, Array<ts.Type>>();
   #memoizeCache = new Map<string, ComparisonResult>();
+  #recursionStack: Array<{ aId: number; bId: number; aIdentity: ts.Symbol; bIdentity: ts.Symbol }> = [];
 
   constructor(compiler: typeof ts, program: ts.Program) {
     this.#compiler = compiler;
@@ -545,6 +546,35 @@ export class Structure {
     return result;
   }
 
+  #getRecursionIdentity(type: ts.Type): ts.Symbol | undefined {
+    return type.aliasSymbol ?? type.symbol;
+  }
+
+  #isInfiniteRecursion(a: ts.Type, b: ts.Type): boolean {
+    const aIdentity = this.#getRecursionIdentity(a);
+    const bIdentity = this.#getRecursionIdentity(b);
+
+    if (!aIdentity || !bIdentity) {
+      return false;
+    }
+
+    let matches = 0;
+
+    for (const frame of this.#recursionStack) {
+      // increasing ids on both sides of a matching identity signal a fresh instantiation, not a true revisit
+      if (frame.aIdentity === aIdentity && frame.bIdentity === bIdentity && a.id > frame.aId && b.id > frame.bId) {
+        matches++;
+
+        // require 2 repeats to avoid false positives
+        if (matches >= 2) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
   #memoize(a: ts.Type, b: ts.Type, compare: () => boolean): boolean {
     const key = [a.id, b.id].sort((a, b) => a - b).join(":");
     const result = this.#memoizeCache.get(key);
@@ -553,9 +583,25 @@ export class Structure {
       return result !== ComparisonResult.Different;
     }
 
+    if (this.#isInfiniteRecursion(a, b)) {
+      this.#memoizeCache.set(key, ComparisonResult.Identical);
+      return true;
+    }
+
     this.#memoizeCache.set(key, ComparisonResult.Pending);
 
+    const aIdentity = this.#getRecursionIdentity(a);
+    const bIdentity = this.#getRecursionIdentity(b);
+
+    if (aIdentity != null && bIdentity != null) {
+      this.#recursionStack.push({ aId: a.id, bId: b.id, aIdentity, bIdentity });
+    }
+
     const isSame = compare();
+
+    if (aIdentity != null && bIdentity != null) {
+      this.#recursionStack.pop();
+    }
 
     this.#memoizeCache.set(key, isSame ? ComparisonResult.Identical : ComparisonResult.Different);
 

--- a/tests/__fixtures__/api-toBe/__typetests__/infinite-recursion.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/infinite-recursion.tst.ts
@@ -8,3 +8,11 @@ export declare class Collection<Value> {
 }
 
 expect<ReadonlyCollection<{}>>().type.not.toBe<ReadonlyCollection<{ x: string }>>();
+expect<ReadonlyCollection<{}>>().type.toBe<ReadonlyCollection<{ x: string }>>(); // fail
+
+type Box<T> = {
+  value: T;
+};
+
+expect<Box<Box<Box<string>>>>().type.not.toBe<Box<Box<Box<number>>>>();
+expect<Box<Box<Box<string>>>>().type.toBe<Box<Box<Box<number>>>>(); // fail

--- a/tests/__fixtures__/api-toBe/__typetests__/infinite-recursion.tst.ts
+++ b/tests/__fixtures__/api-toBe/__typetests__/infinite-recursion.tst.ts
@@ -1,0 +1,10 @@
+import { expect } from "tstyche";
+
+export type ReadonlyCollection<Value> = Omit<Collection<Value>, "tap">;
+
+export declare class Collection<Value> {
+  tap(fn: (collection: this) => void): this;
+  union<OtherValue>(other: ReadonlyCollection<OtherValue>): Collection<OtherValue | Value>;
+}
+
+expect<ReadonlyCollection<{}>>().type.not.toBe<ReadonlyCollection<{ x: string }>>();

--- a/tests/__snapshots__/api-toBe-structure-stderr.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stderr.snap.txt
@@ -1,0 +1,22 @@
+Error: Type 'ReadonlyCollection<{}>' is not the same as type 'ReadonlyCollection<{ x: string; }>'.
+
+   9 | 
+  10 | expect<ReadonlyCollection<{}>>().type.not.toBe<ReadonlyCollection<{ x: string }>>();
+  11 | expect<ReadonlyCollection<{}>>().type.toBe<ReadonlyCollection<{ x: string }>>(); // fail
+     |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  12 | 
+  13 | type Box<T> = {
+  14 |   value: T;
+
+       at ./__typetests__/infinite-recursion.tst.ts:11:44
+
+Error: Type 'Box<Box<Box<string>>>' is not the same as type 'Box<Box<Box<number>>>'.
+
+  16 | 
+  17 | expect<Box<Box<Box<string>>>>().type.not.toBe<Box<Box<Box<number>>>>();
+  18 | expect<Box<Box<Box<string>>>>().type.toBe<Box<Box<Box<number>>>>(); // fail
+     |                                           ~~~~~~~~~~~~~~~~~~~~~
+  19 | 
+
+       at ./__typetests__/infinite-recursion.tst.ts:18:43
+

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -6,7 +6,8 @@ pass ./__typetests__/call-signatures.tst.ts
 pass ./__typetests__/classes.tst.ts
 pass ./__typetests__/conditional.tst.ts
 pass ./__typetests__/enums.tst.ts
-pass ./__typetests__/infinite-recursion.tst.ts
+fail ./__typetests__/infinite-recursion.tst.ts
+
 pass ./__typetests__/interfaces.tst.ts
 pass ./__typetests__/intersections.tst.ts
 pass ./__typetests__/mapped.tst.ts
@@ -20,8 +21,8 @@ pass ./__typetests__/template-literals.tst.ts
 pass ./__typetests__/tuples.tst.ts
 pass ./__typetests__/unions.tst.ts
 
-Targets:    1 passed, 1 total
-Test files: 17 passed, 17 total
+Targets:    1 failed, 1 total
+Test files: 1 failed, 16 passed, 17 total
 Tests:      102 passed, 102 total
-Assertions: 706 passed, 1 fixme, 707 total
+Assertions: 2 failed, 707 passed, 1 fixme, 710 total
 Duration:   <<timestamp>>

--- a/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
+++ b/tests/__snapshots__/api-toBe-structure-stdout.snap.txt
@@ -6,6 +6,7 @@ pass ./__typetests__/call-signatures.tst.ts
 pass ./__typetests__/classes.tst.ts
 pass ./__typetests__/conditional.tst.ts
 pass ./__typetests__/enums.tst.ts
+pass ./__typetests__/infinite-recursion.tst.ts
 pass ./__typetests__/interfaces.tst.ts
 pass ./__typetests__/intersections.tst.ts
 pass ./__typetests__/mapped.tst.ts
@@ -20,7 +21,7 @@ pass ./__typetests__/tuples.tst.ts
 pass ./__typetests__/unions.tst.ts
 
 Targets:    1 passed, 1 total
-Test files: 16 passed, 16 total
+Test files: 17 passed, 17 total
 Tests:      102 passed, 102 total
-Assertions: 705 passed, 1 fixme, 706 total
+Assertions: 706 passed, 1 fixme, 707 total
 Duration:   <<timestamp>>

--- a/tests/api-toBe.test.js
+++ b/tests/api-toBe.test.js
@@ -67,14 +67,17 @@ await test("toBe", async (t) => {
       "./tsconfig-exact.json",
     ]);
 
-    assert.equal(stderr, "");
+    await assert.matchSnapshot(normalizeOutput(stderr), {
+      fileName: `${testFileName}-structure-stderr`,
+      testFileUrl: import.meta.url,
+    });
 
     await assert.matchSnapshot(normalizeOutput(stdout), {
       fileName: `${testFileName}-structure-stdout`,
       testFileUrl: import.meta.url,
     });
 
-    assert.equal(exitCode, 0);
+    assert.equal(exitCode, 1);
   });
 
   await t.test("exact optional property types", async () => {

--- a/tests/api-toBe.test.js
+++ b/tests/api-toBe.test.js
@@ -49,6 +49,7 @@ await test("toBe", async (t) => {
       "classes",
       "conditional",
       "enums",
+      "infinite-recursion",
       "interfaces",
       "intersections",
       "mapped",


### PR DESCRIPTION
This PR adds a recursion guard that tracks in-progress comparisons on a stack. The change prevents structural type comparison from recursing indefinitely on types like generic methods whose parameters/return types reference the enclosing generic type again (e.g. `union<T>(other: Self<T>): Self<T | V>`).